### PR TITLE
fix: split WINDMILL_SERVER_* and WINDMILL_SERVICE_* env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,10 @@
-# Windmill (optional — service starts without it)
-WINDMILL_SERVICE_URL=https://windmill.mcpfactory.org
-WINDMILL_WORKSPACE=prod
+# Windmill server connection (optional — service starts without it)
+WINDMILL_SERVER_URL=https://windmill-production-433f.up.railway.app
+WINDMILL_SERVER_API_KEY=xxx
+WINDMILL_SERVER_WORKSPACE=prod
 
-# Database
+# This service
 WINDMILL_SERVICE_DATABASE_URL=postgresql://...
-
-# API key (used for both incoming auth + Windmill token)
 WINDMILL_SERVICE_API_KEY=xxx
-
-# Port
+WINDMILL_SERVICE_URL=https://windmill.mcpfactory.org
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ npm run dev
 
 | Variable | Description |
 |----------|-------------|
-| `WINDMILL_BASE_URL` | Windmill instance URL |
-| `WINDMILL_API_TOKEN` | Windmill Bearer token |
-| `WINDMILL_WORKSPACE` | Windmill workspace (default: `prod`) |
+| `WINDMILL_SERVER_URL` | Windmill instance URL |
+| `WINDMILL_SERVER_API_KEY` | Windmill Bearer token |
+| `WINDMILL_SERVER_WORKSPACE` | Windmill workspace (default: `prod`) |
 | `WINDMILL_SERVICE_DATABASE_URL` | Neon Postgres connection string |
-| `WINDMILL_SERVICE_API_KEY` | API key for service-to-service auth |
+| `WINDMILL_SERVICE_API_KEY` | API key for incoming service-to-service auth |
+| `WINDMILL_SERVICE_URL` | Public URL of this service |
 | `PORT` | HTTP port (default: `3000`) |
 
 ## API Endpoints

--- a/scripts/setup-windmill.ts
+++ b/scripts/setup-windmill.ts
@@ -6,12 +6,12 @@ import { NODE_TYPE_REGISTRY } from "../src/lib/node-type-registry.js";
 const NODES_DIR = join(import.meta.dirname ?? ".", "nodes");
 
 async function main() {
-  const baseUrl = process.env.WINDMILL_SERVICE_URL;
-  const token = process.env.WINDMILL_SERVICE_API_KEY;
-  const workspace = process.env.WINDMILL_WORKSPACE ?? "prod";
+  const baseUrl = process.env.WINDMILL_SERVER_URL;
+  const token = process.env.WINDMILL_SERVER_API_KEY;
+  const workspace = process.env.WINDMILL_SERVER_WORKSPACE ?? "prod";
 
   if (!baseUrl || !token) {
-    console.error("WINDMILL_SERVICE_URL and WINDMILL_SERVICE_API_KEY are required");
+    console.error("WINDMILL_SERVER_URL and WINDMILL_SERVER_API_KEY are required");
     process.exit(1);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ if (process.env.NODE_ENV !== "test") {
         const poller = new JobPoller(db, windmillClient, workflowRuns);
         poller.start();
       } else {
-        console.log("Windmill not configured (WINDMILL_SERVICE_URL / WINDMILL_SERVICE_API_KEY missing) — job poller disabled");
+        console.log("Windmill not configured (WINDMILL_SERVER_URL / WINDMILL_SERVER_API_KEY missing) — job poller disabled");
       }
 
       app.listen(Number(PORT), "::", () => {

--- a/src/lib/windmill-client.ts
+++ b/src/lib/windmill-client.ts
@@ -139,9 +139,9 @@ let _client: WindmillClient | null = null;
 
 export function getWindmillClient(): WindmillClient | null {
   if (!_client) {
-    const baseUrl = process.env.WINDMILL_SERVICE_URL;
-    const token = process.env.WINDMILL_SERVICE_API_KEY;
-    const workspace = process.env.WINDMILL_WORKSPACE;
+    const baseUrl = process.env.WINDMILL_SERVER_URL;
+    const token = process.env.WINDMILL_SERVER_API_KEY;
+    const workspace = process.env.WINDMILL_SERVER_WORKSPACE;
 
     if (!baseUrl || !token) {
       return null;

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,6 +2,7 @@ process.env.WINDMILL_SERVICE_DATABASE_URL =
   process.env.WINDMILL_SERVICE_DATABASE_URL ??
   "postgresql://test:test@localhost/windmill_test";
 process.env.WINDMILL_SERVICE_API_KEY = "test-api-key";
-process.env.WINDMILL_SERVICE_URL = "http://localhost:8000";
-process.env.WINDMILL_WORKSPACE = "test";
+process.env.WINDMILL_SERVER_URL = "http://localhost:8000";
+process.env.WINDMILL_SERVER_API_KEY = "test-windmill-token";
+process.env.WINDMILL_SERVER_WORKSPACE = "test";
 process.env.NODE_ENV = "test";


### PR DESCRIPTION
## Summary
- Separates Windmill instance connection vars (`WINDMILL_SERVER_URL`, `WINDMILL_SERVER_API_KEY`, `WINDMILL_SERVER_WORKSPACE`) from this service's own config (`WINDMILL_SERVICE_API_KEY`, `WINDMILL_SERVICE_DATABASE_URL`, `WINDMILL_SERVICE_URL`)
- Previously `WINDMILL_SERVICE_API_KEY` and `WINDMILL_SERVICE_URL` were doing double duty (both connecting to Windmill AND authenticating incoming requests)
- Updates all references across source, tests, scripts, README, and .env.example

## Test plan
- [x] All 58 tests pass
- [x] Build + OpenAPI generation succeeds
- [ ] Update Railway env vars on windmill-service to use new names

🤖 Generated with [Claude Code](https://claude.com/claude-code)