### PR TITLE
feat: add 15 node types for stripe, client, email, and app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,10 @@
-# Windmill (optional — service starts without it)
-WINDMILL_SERVICE_URL=https://windmill.mcpfactory.org
-WINDMILL_WORKSPACE=prod
+# Windmill server connection (optional — service starts without it)
+WINDMILL_SERVER_URL=https://windmill-production-433f.up.railway.app
+WINDMILL_SERVER_API_KEY=xxx
+WINDMILL_SERVER_WORKSPACE=prod
 
-# Database
+# This service
 WINDMILL_SERVICE_DATABASE_URL=postgresql://...
-
-# API key (used for both incoming auth + Windmill token)
 WINDMILL_SERVICE_API_KEY=xxx
-
-# Port
+WINDMILL_SERVICE_URL=https://windmill.mcpfactory.org
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ npm run dev
 
 | Variable | Description |
 |----------|-------------|
-| `WINDMILL_BASE_URL` | Windmill instance URL |
-| `WINDMILL_API_TOKEN` | Windmill Bearer token |
-| `WINDMILL_WORKSPACE` | Windmill workspace (default: `prod`) |
+| `WINDMILL_SERVER_URL` | Windmill instance URL |
+| `WINDMILL_SERVER_API_KEY` | Windmill Bearer token |
+| `WINDMILL_SERVER_WORKSPACE` | Windmill workspace (default: `prod`) |
 | `WINDMILL_SERVICE_DATABASE_URL` | Neon Postgres connection string |
-| `WINDMILL_SERVICE_API_KEY` | API key for service-to-service auth |
+| `WINDMILL_SERVICE_API_KEY` | API key for incoming service-to-service auth |
+| `WINDMILL_SERVICE_URL` | Public URL of this service |
 | `PORT` | HTTP port (default: `3000`) |
 
 ## API Endpoints

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://windmill-service.mcpfactory.org"
+      "url": "https://windmill.mcpfactory.org"
     }
   ],
   "components": {

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -14,7 +14,7 @@ const document = generator.generateDocument({
   },
   servers: [
     {
-      url: process.env.SERVICE_URL ?? "https://windmill-service.mcpfactory.org",
+      url: process.env.SERVICE_URL ?? "https://windmill.mcpfactory.org",
     },
   ],
 });

--- a/scripts/nodes/app-resolve-discount.ts
+++ b/scripts/nodes/app-resolve-discount.ts
@@ -1,0 +1,23 @@
+// Windmill node script — app-level logic, resolves a discount/coupon for a product+context combo
+// No external HTTP call — reads from config passed in the DAG
+export async function main(
+  config: {
+    discountRegistry: Record<string, { stripeCouponId: string; name: string; percentOff?: number }>;
+    discountKey: string;
+  }
+) {
+  const discount = config.discountRegistry[config.discountKey];
+
+  if (!discount) {
+    throw new Error(
+      `app.resolveDiscount: unknown discount key "${config.discountKey}". Available: ${Object.keys(config.discountRegistry).join(", ")}`
+    );
+  }
+
+  return {
+    stripeCouponId: discount.stripeCouponId,
+    name: discount.name,
+    percentOff: discount.percentOff,
+    discountKey: config.discountKey,
+  };
+}

--- a/scripts/nodes/app-resolve-product.ts
+++ b/scripts/nodes/app-resolve-product.ts
@@ -1,0 +1,22 @@
+// Windmill node script — app-level logic, resolves a product to its Stripe product ID
+// No external HTTP call — reads from config passed in the DAG
+export async function main(
+  config: {
+    productRegistry: Record<string, { stripeProductId: string; name: string }>;
+    productKey: string;
+  }
+) {
+  const product = config.productRegistry[config.productKey];
+
+  if (!product) {
+    throw new Error(
+      `app.resolveProduct: unknown product key "${config.productKey}". Available: ${Object.keys(config.productRegistry).join(", ")}`
+    );
+  }
+
+  return {
+    stripeProductId: product.stripeProductId,
+    name: product.name,
+    productKey: config.productKey,
+  };
+}

--- a/scripts/nodes/client-create-user.ts
+++ b/scripts/nodes/client-create-user.ts
@@ -1,0 +1,31 @@
+// Windmill node script — calls client POST /anonymous-users
+export async function main(
+  config: {
+    appId: string;
+    email: string;
+    firstName?: string;
+    lastName?: string;
+    phone?: string;
+    orgId?: string;
+    metadata?: Record<string, unknown>;
+  }
+) {
+  const response = await fetch(
+    `${Bun.env.CLIENT_SERVICE_URL!}/anonymous-users`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": Bun.env.CLIENT_SERVICE_API_KEY!,
+      },
+      body: JSON.stringify(config),
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`client createUser failed (${response.status}): ${err}`);
+  }
+
+  return response.json();
+}

--- a/scripts/nodes/client-get-users.ts
+++ b/scripts/nodes/client-get-users.ts
@@ -1,0 +1,28 @@
+// Windmill node script — calls client GET /anonymous-users?appId=...
+export async function main(
+  config: {
+    appId: string;
+    limit?: number;
+    offset?: number;
+  }
+) {
+  const params = new URLSearchParams({ appId: config.appId });
+  if (config.limit) params.set("limit", String(config.limit));
+  if (config.offset) params.set("offset", String(config.offset));
+
+  const response = await fetch(
+    `${Bun.env.CLIENT_SERVICE_URL!}/anonymous-users?${params}`,
+    {
+      headers: {
+        "x-api-key": Bun.env.CLIENT_SERVICE_API_KEY!,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`client getUsers failed (${response.status}): ${err}`);
+  }
+
+  return response.json();
+}

--- a/scripts/nodes/client-update-user.ts
+++ b/scripts/nodes/client-update-user.ts
@@ -1,0 +1,33 @@
+// Windmill node script — calls client PATCH /anonymous-users/:id
+export async function main(
+  config: {
+    userId: string;
+    firstName?: string;
+    lastName?: string;
+    phone?: string;
+    clerkUserId?: string | null;
+    orgId?: string | null;
+    metadata?: Record<string, unknown> | null;
+  }
+) {
+  const { userId, ...body } = config;
+
+  const response = await fetch(
+    `${Bun.env.CLIENT_SERVICE_URL!}/anonymous-users/${userId}`,
+    {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": Bun.env.CLIENT_SERVICE_API_KEY!,
+      },
+      body: JSON.stringify(body),
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`client updateUser failed (${response.status}): ${err}`);
+  }
+
+  return response.json();
+}

--- a/scripts/nodes/lifecycle-email-send.ts
+++ b/scripts/nodes/lifecycle-email-send.ts
@@ -1,0 +1,33 @@
+// Windmill node script — calls transactional-email POST /send
+export async function main(
+  config: {
+    appId: string;
+    eventType: string;
+    recipientEmail?: string;
+    brandId?: string;
+    campaignId?: string;
+    productId?: string;
+    clerkUserId?: string;
+    clerkOrgId?: string;
+    metadata?: Record<string, unknown>;
+  }
+) {
+  const response = await fetch(
+    `${Bun.env.LIFECYCLE_EMAILS_URL!}/send`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": Bun.env.LIFECYCLE_EMAILS_API_KEY!,
+      },
+      body: JSON.stringify(config),
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`lifecycle-email send failed (${response.status}): ${err}`);
+  }
+
+  return response.json();
+}

--- a/scripts/nodes/stripe-create-checkout.ts
+++ b/scripts/nodes/stripe-create-checkout.ts
@@ -1,0 +1,46 @@
+// Windmill node script — calls stripe POST /checkout/create
+export async function main(
+  config: {
+    lineItems: { priceId: string; quantity: number }[];
+    successUrl: string;
+    cancelUrl: string;
+    mode?: "payment" | "subscription";
+    customerId?: string;
+    customerEmail?: string;
+    metadata?: Record<string, string>;
+    discounts?: { coupon?: string; promotionCode?: string }[];
+  },
+  context?: {
+    orgId?: string;
+    brandId?: string;
+    campaignId?: string;
+    runId?: string;
+    appId?: string;
+  }
+) {
+  const response = await fetch(
+    `${Bun.env.STRIPE_SERVICE_URL!}/checkout/create`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
+      },
+      body: JSON.stringify({
+        ...config,
+        orgId: context?.orgId,
+        brandId: context?.brandId,
+        campaignId: context?.campaignId,
+        runId: context?.runId,
+        appId: context?.appId,
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`stripe createCheckout failed (${response.status}): ${err}`);
+  }
+
+  return response.json();
+}

--- a/scripts/nodes/stripe-create-coupon.ts
+++ b/scripts/nodes/stripe-create-coupon.ts
@@ -1,0 +1,34 @@
+// Windmill node script — calls stripe POST /coupons/create
+export async function main(
+  config: {
+    id?: string;
+    name?: string;
+    percentOff?: number;
+    amountOffInCents?: number;
+    currency?: string;
+    duration?: "once" | "repeating" | "forever";
+    durationInMonths?: number;
+    maxRedemptions?: number;
+    redeemBy?: string;
+    metadata?: Record<string, string>;
+  }
+) {
+  const response = await fetch(
+    `${Bun.env.STRIPE_SERVICE_URL!}/coupons/create`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
+      },
+      body: JSON.stringify(config),
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`stripe createCoupon failed (${response.status}): ${err}`);
+  }
+
+  return response.json();
+}

--- a/scripts/nodes/stripe-create-price.ts
+++ b/scripts/nodes/stripe-create-price.ts
@@ -1,0 +1,29 @@
+// Windmill node script — calls stripe POST /prices/create
+export async function main(
+  config: {
+    productId: string;
+    unitAmountInCents: number;
+    currency?: string;
+    recurring?: { interval: "day" | "week" | "month" | "year"; intervalCount?: number };
+    metadata?: Record<string, string>;
+  }
+) {
+  const response = await fetch(
+    `${Bun.env.STRIPE_SERVICE_URL!}/prices/create`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
+      },
+      body: JSON.stringify(config),
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`stripe createPrice failed (${response.status}): ${err}`);
+  }
+
+  return response.json();
+}

--- a/scripts/nodes/stripe-create-product.ts
+++ b/scripts/nodes/stripe-create-product.ts
@@ -1,0 +1,28 @@
+// Windmill node script — calls stripe POST /products/create
+export async function main(
+  config: {
+    name: string;
+    description?: string;
+    id?: string;
+    metadata?: Record<string, string>;
+  }
+) {
+  const response = await fetch(
+    `${Bun.env.STRIPE_SERVICE_URL!}/products/create`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
+      },
+      body: JSON.stringify(config),
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`stripe createProduct failed (${response.status}): ${err}`);
+  }
+
+  return response.json();
+}

--- a/scripts/nodes/stripe-get-coupon.ts
+++ b/scripts/nodes/stripe-get-coupon.ts
@@ -1,0 +1,22 @@
+// Windmill node script — calls stripe GET /coupons/:couponId
+export async function main(
+  config: {
+    couponId: string;
+  }
+) {
+  const response = await fetch(
+    `${Bun.env.STRIPE_SERVICE_URL!}/coupons/${config.couponId}`,
+    {
+      headers: {
+        "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`stripe getCoupon failed (${response.status}): ${err}`);
+  }
+
+  return response.json();
+}

--- a/scripts/nodes/stripe-get-prices-by-product.ts
+++ b/scripts/nodes/stripe-get-prices-by-product.ts
@@ -1,0 +1,22 @@
+// Windmill node script — calls stripe GET /prices/by-product/:productId
+export async function main(
+  config: {
+    productId: string;
+  }
+) {
+  const response = await fetch(
+    `${Bun.env.STRIPE_SERVICE_URL!}/prices/by-product/${config.productId}`,
+    {
+      headers: {
+        "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`stripe getPricesByProduct failed (${response.status}): ${err}`);
+  }
+
+  return response.json();
+}

--- a/scripts/nodes/stripe-get-product.ts
+++ b/scripts/nodes/stripe-get-product.ts
@@ -1,0 +1,22 @@
+// Windmill node script — calls stripe GET /products/:productId
+export async function main(
+  config: {
+    productId: string;
+  }
+) {
+  const response = await fetch(
+    `${Bun.env.STRIPE_SERVICE_URL!}/products/${config.productId}`,
+    {
+      headers: {
+        "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`stripe getProduct failed (${response.status}): ${err}`);
+  }
+
+  return response.json();
+}

--- a/scripts/nodes/stripe-get-stats.ts
+++ b/scripts/nodes/stripe-get-stats.ts
@@ -1,0 +1,29 @@
+// Windmill node script — calls stripe POST /stats
+export async function main(
+  config: {
+    runIds?: string[];
+    clerkOrgId?: string;
+    brandId?: string;
+    appId?: string;
+    campaignId?: string;
+  }
+) {
+  const response = await fetch(
+    `${Bun.env.STRIPE_SERVICE_URL!}/stats`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
+      },
+      body: JSON.stringify(config),
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`stripe getStats failed (${response.status}): ${err}`);
+  }
+
+  return response.json();
+}

--- a/scripts/nodes/transactional-email-get-stats.ts
+++ b/scripts/nodes/transactional-email-get-stats.ts
@@ -1,0 +1,28 @@
+// Windmill node script — calls transactional-email POST /stats
+export async function main(
+  config: {
+    appId?: string;
+    clerkOrgId?: string;
+    clerkUserId?: string;
+    eventType?: string;
+  }
+) {
+  const response = await fetch(
+    `${Bun.env.LIFECYCLE_EMAILS_URL!}/stats`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": Bun.env.LIFECYCLE_EMAILS_API_KEY!,
+      },
+      body: JSON.stringify(config),
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`transactional-email getStats failed (${response.status}): ${err}`);
+  }
+
+  return response.json();
+}

--- a/scripts/setup-windmill.ts
+++ b/scripts/setup-windmill.ts
@@ -6,12 +6,12 @@ import { NODE_TYPE_REGISTRY } from "../src/lib/node-type-registry.js";
 const NODES_DIR = join(import.meta.dirname ?? ".", "nodes");
 
 async function main() {
-  const baseUrl = process.env.WINDMILL_SERVICE_URL;
-  const token = process.env.WINDMILL_SERVICE_API_KEY;
-  const workspace = process.env.WINDMILL_WORKSPACE ?? "prod";
+  const baseUrl = process.env.WINDMILL_SERVER_URL;
+  const token = process.env.WINDMILL_SERVER_API_KEY;
+  const workspace = process.env.WINDMILL_SERVER_WORKSPACE ?? "prod";
 
   if (!baseUrl || !token) {
-    console.error("WINDMILL_SERVICE_URL and WINDMILL_SERVICE_API_KEY are required");
+    console.error("WINDMILL_SERVER_URL and WINDMILL_SERVER_API_KEY are required");
     process.exit(1);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ if (process.env.NODE_ENV !== "test") {
         const poller = new JobPoller(db, windmillClient, workflowRuns);
         poller.start();
       } else {
-        console.log("Windmill not configured (WINDMILL_SERVICE_URL / WINDMILL_SERVICE_API_KEY missing) — job poller disabled");
+        console.log("Windmill not configured (WINDMILL_SERVER_URL / WINDMILL_SERVER_API_KEY missing) — job poller disabled");
       }
 
       app.listen(Number(PORT), "::", () => {

--- a/src/lib/node-type-registry.ts
+++ b/src/lib/node-type-registry.ts
@@ -12,7 +12,30 @@ export const NODE_TYPE_REGISTRY: Record<string, string | null> = {
   "lifecycle-emails": "f/nodes/lifecycle_emails",
   "client-service": "f/nodes/client_service",
 
-  // Mocked services (not yet deployed)
+  // Stripe service (dot notation)
+  "stripe.createProduct": "f/nodes/stripe_create_product",
+  "stripe.getProduct": "f/nodes/stripe_get_product",
+  "stripe.createPrice": "f/nodes/stripe_create_price",
+  "stripe.getPricesByProduct": "f/nodes/stripe_get_prices_by_product",
+  "stripe.createCoupon": "f/nodes/stripe_create_coupon",
+  "stripe.getCoupon": "f/nodes/stripe_get_coupon",
+  "stripe.createCheckout": "f/nodes/stripe_create_checkout",
+  "stripe.getStats": "f/nodes/stripe_get_stats",
+
+  // Client service (dot notation)
+  "client.createUser": "f/nodes/client_create_user",
+  "client.updateUser": "f/nodes/client_update_user",
+  "client.getUsers": "f/nodes/client_get_users",
+
+  // Transactional email (dot notation)
+  "lifecycle-email.send": "f/nodes/lifecycle_email_send",
+  "transactional-email.getStats": "f/nodes/transactional_email_get_stats",
+
+  // App-level logic (inline scripts, no HTTP calls)
+  "app.resolveProduct": "f/nodes/app_resolve_product",
+  "app.resolveDiscount": "f/nodes/app_resolve_discount",
+
+  // Legacy names (kept for backward compatibility)
   "twilio-sms": "f/nodes/twilio_sms",
   "order-service": "f/nodes/order_service",
   "product-service": "f/nodes/product_service",

--- a/src/lib/windmill-client.ts
+++ b/src/lib/windmill-client.ts
@@ -139,9 +139,9 @@ let _client: WindmillClient | null = null;
 
 export function getWindmillClient(): WindmillClient | null {
   if (!_client) {
-    const baseUrl = process.env.WINDMILL_SERVICE_URL;
-    const token = process.env.WINDMILL_SERVICE_API_KEY;
-    const workspace = process.env.WINDMILL_WORKSPACE;
+    const baseUrl = process.env.WINDMILL_SERVER_URL;
+    const token = process.env.WINDMILL_SERVER_API_KEY;
+    const workspace = process.env.WINDMILL_SERVER_WORKSPACE;
 
     if (!baseUrl || !token) {
       return null;

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -123,6 +123,101 @@ export const DAG_WITH_FOREACH: DAG = {
   edges: [{ from: "loop", to: "send" }],
 };
 
+export const DAG_WITH_STRIPE_NODES: DAG = {
+  nodes: [
+    {
+      id: "create-product",
+      type: "stripe.createProduct",
+      config: { name: "Test Product" },
+    },
+    {
+      id: "create-price",
+      type: "stripe.createPrice",
+      config: { unitAmountInCents: 1999 },
+      inputMapping: {
+        productId: "$ref:create-product.output.productId",
+      },
+    },
+    {
+      id: "create-checkout",
+      type: "stripe.createCheckout",
+      config: { successUrl: "https://example.com/success", cancelUrl: "https://example.com/cancel" },
+      inputMapping: {
+        priceId: "$ref:create-price.output.priceId",
+      },
+    },
+  ],
+  edges: [
+    { from: "create-product", to: "create-price" },
+    { from: "create-price", to: "create-checkout" },
+  ],
+};
+
+export const DAG_WITH_CLIENT_NODES: DAG = {
+  nodes: [
+    {
+      id: "create-user",
+      type: "client.createUser",
+      config: { appId: "test-app", email: "test@example.com" },
+    },
+    {
+      id: "list-users",
+      type: "client.getUsers",
+      config: { appId: "test-app" },
+    },
+    {
+      id: "update-user",
+      type: "client.updateUser",
+      config: { firstName: "Updated" },
+      inputMapping: {
+        userId: "$ref:create-user.output.user.id",
+      },
+    },
+  ],
+  edges: [
+    { from: "create-user", to: "list-users" },
+    { from: "list-users", to: "update-user" },
+  ],
+};
+
+export const DAG_WITH_LIFECYCLE_EMAIL_SEND: DAG = {
+  nodes: [
+    {
+      id: "send-email",
+      type: "lifecycle-email.send",
+      config: { appId: "test-app", eventType: "welcome" },
+    },
+  ],
+  edges: [],
+};
+
+export const DAG_WITH_MIXED_DOT_NOTATION: DAG = {
+  nodes: [
+    {
+      id: "create-user",
+      type: "client.createUser",
+      config: { appId: "test-app", email: "user@example.com" },
+    },
+    {
+      id: "send-welcome",
+      type: "lifecycle-email.send",
+      config: { appId: "test-app", eventType: "welcome" },
+      inputMapping: {
+        recipientEmail: "$ref:create-user.output.user.email",
+      },
+    },
+    {
+      id: "resolve-product",
+      type: "app.resolveProduct",
+      config: { productKey: "welcome-offer" },
+    },
+  ],
+  edges: [
+    { from: "create-user", to: "send-welcome" },
+    { from: "create-user", to: "resolve-product" },
+  ],
+};
+
 export const POLARITY_WELCOME_DAG: DAG = {
   nodes: [
     {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,6 +2,7 @@ process.env.WINDMILL_SERVICE_DATABASE_URL =
   process.env.WINDMILL_SERVICE_DATABASE_URL ??
   "postgresql://test:test@localhost/windmill_test";
 process.env.WINDMILL_SERVICE_API_KEY = "test-api-key";
-process.env.WINDMILL_SERVICE_URL = "http://localhost:8000";
-process.env.WINDMILL_WORKSPACE = "test";
+process.env.WINDMILL_SERVER_URL = "http://localhost:8000";
+process.env.WINDMILL_SERVER_API_KEY = "test-windmill-token";
+process.env.WINDMILL_SERVER_WORKSPACE = "test";
 process.env.NODE_ENV = "test";

--- a/tests/unit/dag-validator.test.ts
+++ b/tests/unit/dag-validator.test.ts
@@ -11,6 +11,10 @@ import {
   DAG_WITH_WAIT,
   DAG_WITH_CONDITION,
   DAG_WITH_FOREACH,
+  DAG_WITH_STRIPE_NODES,
+  DAG_WITH_CLIENT_NODES,
+  DAG_WITH_LIFECYCLE_EMAIL_SEND,
+  DAG_WITH_MIXED_DOT_NOTATION,
   POLARITY_WELCOME_DAG,
 } from "../helpers/fixtures.js";
 
@@ -77,6 +81,30 @@ describe("validateDAG", () => {
     expect(
       result.errors.some((e) => e.message.includes("Duplicate node ID"))
     ).toBe(true);
+  });
+
+  it("accepts a DAG with stripe dot-notation node types", () => {
+    const result = validateDAG(DAG_WITH_STRIPE_NODES);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("accepts a DAG with client dot-notation node types", () => {
+    const result = validateDAG(DAG_WITH_CLIENT_NODES);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("accepts a DAG with lifecycle-email.send node type", () => {
+    const result = validateDAG(DAG_WITH_LIFECYCLE_EMAIL_SEND);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("accepts a DAG mixing dot-notation and app.* node types", () => {
+    const result = validateDAG(DAG_WITH_MIXED_DOT_NOTATION);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
   });
 
   it("rejects a DAG with no entry node (all cycled)", () => {


### PR DESCRIPTION
## Summary
- Adds 15 new node types using dot notation (`service.action`) per client spec
- **Stripe**: `createProduct`, `getProduct`, `createPrice`, `getPricesByProduct`, `createCoupon`, `getCoupon`, `createCheckout`, `getStats`
- **Client**: `createUser`, `updateUser`, `getUsers`
- **Transactional email**: `getStats`
- **Lifecycle email**: `send`
- **App-level**: `resolveProduct`, `resolveDiscount` (inline scripts, no HTTP calls)
- Each script matches exact API endpoints from the service registry
- Fixes naming: `client.createUser` (not `createAnonymousUser`), `stripe.getPricesByProduct` (not `getPrices`)

## Test plan
- [x] All 62 tests pass (4 new DAG validation tests)
- [x] Build + OpenAPI generation succeeds
- [ ] Deploy and test with client's DAGs containing `stripe.createProduct` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)