### PR TITLE
feat: add deploy + by-name execute endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -354,6 +354,104 @@
             "type": "string"
           }
         }
+      },
+      "DeployWorkflowResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "created",
+              "updated"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "action"
+        ]
+      },
+      "DeployWorkflowsResponse": {
+        "type": "object",
+        "properties": {
+          "workflows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeployWorkflowResult"
+            }
+          }
+        },
+        "required": [
+          "workflows"
+        ]
+      },
+      "DeployWorkflowItem": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string"
+          },
+          "dag": {
+            "$ref": "#/components/schemas/DAG"
+          }
+        },
+        "required": [
+          "name",
+          "dag"
+        ]
+      },
+      "DeployWorkflowsRequest": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "workflows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeployWorkflowItem"
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "orgId",
+          "workflows"
+        ]
+      },
+      "ExecuteByNameRequest": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "inputs": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            }
+          },
+          "runId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "orgId"
+        ]
       }
     },
     "parameters": {}
@@ -852,6 +950,106 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/WorkflowRunResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/deploy": {
+      "put": {
+        "summary": "Deploy (upsert) workflows by name",
+        "tags": [
+          "Workflows"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeployWorkflowsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Workflows deployed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeployWorkflowsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/by-name/{name}/execute": {
+      "post": {
+        "summary": "Execute a workflow by name",
+        "tags": [
+          "Workflow Runs"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "name",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExecuteByNameRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Execution started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowRunResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workflow not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }


### PR DESCRIPTION
## Summary

- **`PUT /workflows/deploy`** — batch upsert workflows by (orgId + name). Validates all DAGs upfront; if any are invalid, rejects the entire batch. Idempotent — safe to call on every deploy.
- **`POST /workflows/by-name/:name/execute`** — execute a workflow by name instead of UUID. Takes `orgId` in body to disambiguate.

This eliminates the need to manually create workflows and copy UUIDs into env vars. The new provisioning flow:
1. One-time: get orgId from client-service
2. CI/deploy: `PUT /workflows/deploy` with all workflow DAGs
3. Runtime: `POST /workflows/by-name/newsletter-subscribe/execute`

## Test plan

- [x] Deploy creates new workflows
- [x] Deploy updates existing workflows (idempotent)
- [x] Deploy rejects batch if any DAG is invalid
- [x] Deploy requires auth
- [x] Execute by name succeeds
- [x] Execute by name returns 404 for unknown workflow
- [x] Execute by name requires orgId
- [x] Execute by name requires auth
- [x] All 71 existing + new tests pass
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)