### PR TITLE
fix: rename LIFECYCLE_EMAILS_* env vars to TRANSACTIONAL_EMAIL_SERVICE_*

### DIFF
--- a/scripts/nodes/transactional-email-get-stats.ts
+++ b/scripts/nodes/transactional-email-get-stats.ts
@@ -7,10 +7,10 @@ export async function main(
     eventType?: string;
   }
 ) {
-  const baseUrl = Bun.env.LIFECYCLE_EMAILS_URL;
-  const apiKey = Bun.env.LIFECYCLE_EMAILS_API_KEY;
-  if (!baseUrl) throw new Error("LIFECYCLE_EMAILS_URL is not set");
-  if (!apiKey) throw new Error("LIFECYCLE_EMAILS_API_KEY is not set");
+  const baseUrl = Bun.env.TRANSACTIONAL_EMAIL_SERVICE_URL;
+  const apiKey = Bun.env.TRANSACTIONAL_EMAIL_SERVICE_API_KEY;
+  if (!baseUrl) throw new Error("TRANSACTIONAL_EMAIL_SERVICE_URL is not set");
+  if (!apiKey) throw new Error("TRANSACTIONAL_EMAIL_SERVICE_API_KEY is not set");
 
   const response = await fetch(
     `${baseUrl}/stats`,

--- a/scripts/nodes/transactional-email-send.ts
+++ b/scripts/nodes/transactional-email-send.ts
@@ -12,10 +12,10 @@ export async function main(
     metadata?: Record<string, unknown>;
   }
 ) {
-  const baseUrl = Bun.env.LIFECYCLE_EMAILS_URL;
-  const apiKey = Bun.env.LIFECYCLE_EMAILS_API_KEY;
-  if (!baseUrl) throw new Error("LIFECYCLE_EMAILS_URL is not set");
-  if (!apiKey) throw new Error("LIFECYCLE_EMAILS_API_KEY is not set");
+  const baseUrl = Bun.env.TRANSACTIONAL_EMAIL_SERVICE_URL;
+  const apiKey = Bun.env.TRANSACTIONAL_EMAIL_SERVICE_API_KEY;
+  if (!baseUrl) throw new Error("TRANSACTIONAL_EMAIL_SERVICE_URL is not set");
+  if (!apiKey) throw new Error("TRANSACTIONAL_EMAIL_SERVICE_API_KEY is not set");
 
   const response = await fetch(
     `${baseUrl}/send`,


### PR DESCRIPTION
## Summary

- Renames `LIFECYCLE_EMAILS_URL` → `TRANSACTIONAL_EMAIL_SERVICE_URL`
- Renames `LIFECYCLE_EMAILS_API_KEY` → `TRANSACTIONAL_EMAIL_SERVICE_API_KEY`
- Matches the actual env var names set on Railway

## Test plan

- [x] All 72 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)