### PR TITLE
feat: add deploy-nodes script to push scripts to Windmill

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest",
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",
+    "deploy:nodes": "tsx scripts/deploy-nodes.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",

--- a/scripts/deploy-nodes.ts
+++ b/scripts/deploy-nodes.ts
@@ -1,0 +1,101 @@
+/**
+ * Deploy all node scripts to Windmill.
+ *
+ * Reads every scripts/nodes/*.ts file, maps the filename to the
+ * Windmill script path (f/nodes/<name_with_underscores>), then
+ * creates or updates each script via the Windmill API.
+ *
+ * Usage:
+ *   WINDMILL_SERVER_URL=... WINDMILL_SERVER_API_KEY=... npx tsx scripts/deploy-nodes.ts
+ *
+ * Or with a .env file already loaded.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { WindmillClient } from "../src/lib/windmill-client.js";
+
+function filenameToWindmillPath(filename: string): string {
+  const name = filename.replace(/\.ts$/, "").replace(/-/g, "_");
+  return `f/nodes/${name}`;
+}
+
+function filenameToSummary(filename: string): string {
+  return filename
+    .replace(/\.ts$/, "")
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export async function deployNodes(client: WindmillClient): Promise<
+  { path: string; action: "created" | "updated" }[]
+> {
+  const nodesDir = path.resolve(import.meta.dirname ?? __dirname, "nodes");
+  const files = fs.readdirSync(nodesDir).filter((f) => f.endsWith(".ts"));
+
+  const results: { path: string; action: "created" | "updated" }[] = [];
+
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(nodesDir, file), "utf-8");
+    const wmPath = filenameToWindmillPath(file);
+    const summary = filenameToSummary(file);
+
+    const existing = await client.getScript(wmPath);
+
+    if (existing) {
+      // Content unchanged — skip
+      if (existing.content.trim() === content.trim()) {
+        console.log(`  skip  ${wmPath} (unchanged)`);
+        continue;
+      }
+      await client.createScript({
+        path: wmPath,
+        summary,
+        content,
+        language: "bun",
+        parent_hash: existing.hash,
+      });
+      results.push({ path: wmPath, action: "updated" });
+      console.log(`  update ${wmPath}`);
+    } else {
+      await client.createScript({
+        path: wmPath,
+        summary,
+        content,
+        language: "bun",
+      });
+      results.push({ path: wmPath, action: "created" });
+      console.log(`  create ${wmPath}`);
+    }
+  }
+
+  return results;
+}
+
+// --- CLI entry point (skipped when imported as module in tests) ---
+const isCLI = process.argv[1]?.endsWith("deploy-nodes.ts");
+
+async function cliMain() {
+  const baseUrl = process.env.WINDMILL_SERVER_URL;
+  const token = process.env.WINDMILL_SERVER_API_KEY;
+  const workspace = process.env.WINDMILL_SERVER_WORKSPACE;
+
+  if (!baseUrl || !token) {
+    console.error("Missing WINDMILL_SERVER_URL or WINDMILL_SERVER_API_KEY");
+    process.exit(1);
+  }
+
+  const client = new WindmillClient({ baseUrl, token, workspace });
+
+  console.log(`Deploying node scripts to ${baseUrl} (workspace: ${workspace ?? "prod"})...`);
+  const results = await deployNodes(client);
+  console.log(`\nDone: ${results.length} script(s) deployed.`);
+}
+
+if (isCLI) {
+  cliMain().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/src/lib/windmill-client.ts
+++ b/src/lib/windmill-client.ts
@@ -98,12 +98,22 @@ export class WindmillClient {
 
   // === SCRIPTS ===
 
+  async getScript(path: string): Promise<{ hash: string; content: string; path: string; language: string; summary: string } | null> {
+    try {
+      return await this.request("GET", `/scripts/get/p/${path}`);
+    } catch (err) {
+      if (err instanceof Error && err.message.includes("404")) return null;
+      throw err;
+    }
+  }
+
   async createScript(script: {
     path: string;
     summary: string;
     description?: string;
     content: string;
     language: string;
+    parent_hash?: string;
   }): Promise<void> {
     await this.request("POST", "/scripts/create", script);
   }

--- a/tests/unit/deploy-nodes.test.ts
+++ b/tests/unit/deploy-nodes.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { deployNodes } from "../../scripts/deploy-nodes.js";
+import type { WindmillClient } from "../../src/lib/windmill-client.js";
+
+function mockClient(scripts: Map<string, { hash: string; content: string }>) {
+  return {
+    getScript: vi.fn(async (path: string) => {
+      const s = scripts.get(path);
+      if (!s) return null;
+      return { hash: s.hash, content: s.content, path, language: "bun", summary: "" };
+    }),
+    createScript: vi.fn(async () => {}),
+  } as unknown as WindmillClient;
+}
+
+describe("deployNodes", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates scripts that don't exist in Windmill", async () => {
+    const client = mockClient(new Map());
+    const results = await deployNodes(client);
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((r) => r.action === "created")).toBe(true);
+    expect((client.createScript as ReturnType<typeof vi.fn>).mock.calls.length).toBe(results.length);
+
+    // Verify no parent_hash on create calls
+    for (const call of (client.createScript as ReturnType<typeof vi.fn>).mock.calls) {
+      expect(call[0].parent_hash).toBeUndefined();
+      expect(call[0].language).toBe("bun");
+      expect(call[0].path).toMatch(/^f\/nodes\//);
+    }
+  });
+
+  it("updates scripts with changed content", async () => {
+    const scripts = new Map([
+      ["f/nodes/client_create_user", { hash: "abc123", content: "old content" }],
+    ]);
+    const client = mockClient(scripts);
+    const results = await deployNodes(client);
+
+    const updated = results.filter((r) => r.path === "f/nodes/client_create_user");
+    expect(updated).toHaveLength(1);
+    expect(updated[0].action).toBe("updated");
+
+    const updateCall = (client.createScript as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c: unknown[]) => (c[0] as { path: string }).path === "f/nodes/client_create_user"
+    );
+    expect(updateCall).toBeDefined();
+    expect(updateCall![0].parent_hash).toBe("abc123");
+  });
+
+  it("skips scripts with unchanged content", async () => {
+    // Read actual content of one script to simulate "unchanged"
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const actualContent = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../../scripts/nodes/client-create-user.ts"),
+      "utf-8"
+    );
+
+    const scripts = new Map([
+      ["f/nodes/client_create_user", { hash: "abc123", content: actualContent }],
+    ]);
+    const client = mockClient(scripts);
+    const results = await deployNodes(client);
+
+    // client_create_user should NOT be in results (skipped)
+    const skipped = results.find((r) => r.path === "f/nodes/client_create_user");
+    expect(skipped).toBeUndefined();
+  });
+
+  it("maps filenames to correct Windmill paths", async () => {
+    const client = mockClient(new Map());
+    const results = await deployNodes(client);
+
+    const paths = results.map((r) => r.path);
+    expect(paths).toContain("f/nodes/client_create_user");
+    expect(paths).toContain("f/nodes/lead_service");
+    expect(paths).toContain("f/nodes/transactional_email_send");
+    expect(paths).toContain("f/nodes/stripe_create_product");
+    // No dashes in paths
+    expect(paths.every((p) => !p.includes("-"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/deploy-nodes.ts` — reads all `scripts/nodes/*.ts` files and pushes them to Windmill via the API
- Adds `getScript` method to `WindmillClient` to check existing scripts and get their hash for versioning
- Adds `parent_hash` support to `createScript` for updating existing scripts
- Adds `npm run deploy:nodes` command
- Skips unchanged scripts (content comparison)

## Usage
```bash
WINDMILL_SERVER_URL=... WINDMILL_SERVER_API_KEY=... npm run deploy:nodes
```

## Test plan
- [x] Unit tests for create, update, skip (unchanged), and path mapping
- [x] Full test suite passes (76 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)