### PR TITLE
ci: auto-deploy node scripts to Windmill

### DIFF
--- a/.github/workflows/deploy-nodes.yml
+++ b/.github/workflows/deploy-nodes.yml
@@ -1,0 +1,23 @@
+name: Deploy node scripts to Windmill
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/nodes/**"
+      - "scripts/deploy-nodes.ts"
+      - "src/lib/windmill-client.ts"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run deploy:nodes
+        env:
+          WINDMILL_SERVER_URL: ${{ secrets.WINDMILL_SERVER_URL }}
+          WINDMILL_SERVER_API_KEY: ${{ secrets.WINDMILL_SERVER_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that runs `npm run deploy:nodes` on push to main
- Only triggers when `scripts/nodes/**`, `scripts/deploy-nodes.ts`, or `src/lib/windmill-client.ts` change
- Uses repo secrets for Windmill credentials

## Setup required
Add these secrets in GitHub repo settings (Settings > Secrets and variables > Actions):
- `WINDMILL_SERVER_URL` — Windmill server URL (same as Railway env var)
- `WINDMILL_SERVER_API_KEY` — Windmill API token (same as Railway env var)

## Test plan
- [x] Workflow syntax validated
- [x] All existing tests pass (76 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)