### PR TITLE
fix: spread config as individual params for Windmill input_transforms

### DIFF
--- a/scripts/nodes/app-resolve-discount.ts
+++ b/scripts/nodes/app-resolve-discount.ts
@@ -1,11 +1,9 @@
 // Windmill node script — resolves a coupon/discount by fetching live from Stripe
 export async function main(
-  config: {
-    couponId: string;
-  }
+  couponId: string,
 ) {
   const response = await fetch(
-    `${Bun.env.STRIPE_SERVICE_URL!}/coupons/${config.couponId}`,
+    `${Bun.env.STRIPE_SERVICE_URL!}/coupons/${couponId}`,
     {
       headers: {
         "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
@@ -15,7 +13,7 @@ export async function main(
 
   if (!response.ok) {
     const err = await response.text();
-    throw new Error(`app.resolveDiscount: failed to fetch coupon "${config.couponId}" (${response.status}): ${err}`);
+    throw new Error(`app.resolveDiscount: failed to fetch coupon "${couponId}" (${response.status}): ${err}`);
   }
 
   const data = await response.json() as {

--- a/scripts/nodes/app-resolve-product.ts
+++ b/scripts/nodes/app-resolve-product.ts
@@ -1,11 +1,9 @@
 // Windmill node script — resolves a product by fetching live from Stripe
 export async function main(
-  config: {
-    productId: string;
-  }
+  productId: string,
 ) {
   const response = await fetch(
-    `${Bun.env.STRIPE_SERVICE_URL!}/products/${config.productId}`,
+    `${Bun.env.STRIPE_SERVICE_URL!}/products/${productId}`,
     {
       headers: {
         "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
@@ -15,7 +13,7 @@ export async function main(
 
   if (!response.ok) {
     const err = await response.text();
-    throw new Error(`app.resolveProduct: failed to fetch product "${config.productId}" (${response.status}): ${err}`);
+    throw new Error(`app.resolveProduct: failed to fetch product "${productId}" (${response.status}): ${err}`);
   }
 
   const data = await response.json() as { productId: string; name: string; description?: string };

--- a/scripts/nodes/brand-intel.ts
+++ b/scripts/nodes/brand-intel.ts
@@ -1,6 +1,6 @@
 // Windmill node script — calls brand-service
 export async function main(
-  config: { action: string },
+  action: string,
   context: {
     orgId: string;
     brandId: string;

--- a/scripts/nodes/client-create-user.ts
+++ b/scripts/nodes/client-create-user.ts
@@ -1,14 +1,12 @@
 // Windmill node script — calls client POST /anonymous-users
 export async function main(
-  config: {
-    appId: string;
-    email: string;
-    firstName?: string;
-    lastName?: string;
-    phone?: string;
-    orgId?: string;
-    metadata?: Record<string, unknown>;
-  }
+  appId: string,
+  email: string,
+  firstName?: string,
+  lastName?: string,
+  phone?: string,
+  orgId?: string,
+  metadata?: Record<string, unknown>,
 ) {
   const response = await fetch(
     `${Bun.env.CLIENT_SERVICE_URL!}/anonymous-users`,
@@ -18,7 +16,7 @@ export async function main(
         "Content-Type": "application/json",
         "x-api-key": Bun.env.CLIENT_SERVICE_API_KEY!,
       },
-      body: JSON.stringify(config),
+      body: JSON.stringify({ appId, email, firstName, lastName, phone, orgId, metadata }),
     }
   );
 

--- a/scripts/nodes/client-get-users.ts
+++ b/scripts/nodes/client-get-users.ts
@@ -1,14 +1,12 @@
 // Windmill node script — calls client GET /anonymous-users?appId=...
 export async function main(
-  config: {
-    appId: string;
-    limit?: number;
-    offset?: number;
-  }
+  appId: string,
+  limit?: number,
+  offset?: number,
 ) {
-  const params = new URLSearchParams({ appId: config.appId });
-  if (config.limit) params.set("limit", String(config.limit));
-  if (config.offset) params.set("offset", String(config.offset));
+  const params = new URLSearchParams({ appId });
+  if (limit) params.set("limit", String(limit));
+  if (offset) params.set("offset", String(offset));
 
   const response = await fetch(
     `${Bun.env.CLIENT_SERVICE_URL!}/anonymous-users?${params}`,

--- a/scripts/nodes/client-service.ts
+++ b/scripts/nodes/client-service.ts
@@ -1,9 +1,7 @@
 // Windmill node script — calls client-service for contact/user management
 export async function main(
-  config: {
-    action: "create" | "get" | "list" | "update";
-    appId?: string;
-  },
+  action: "create" | "get" | "list" | "update",
+  appId?: string,
   contactData?: Record<string, unknown>,
   context?: {
     orgId?: string;
@@ -16,27 +14,27 @@ export async function main(
     "x-api-key": apiKey,
   };
 
-  if (config.action === "create" || config.action === "update") {
+  if (action === "create" || action === "update") {
     const response = await fetch(`${baseUrl}/anonymous-users`, {
       method: "POST",
       headers,
       body: JSON.stringify({
-        appId: config.appId,
+        appId,
         ...contactData,
       }),
     });
     return response.json();
   }
 
-  if (config.action === "list") {
+  if (action === "list") {
     const response = await fetch(
-      `${baseUrl}/anonymous-users?appId=${config.appId}`,
+      `${baseUrl}/anonymous-users?appId=${appId}`,
       { headers }
     );
     return response.json();
   }
 
-  if (config.action === "get" && contactData?.id) {
+  if (action === "get" && contactData?.id) {
     const response = await fetch(
       `${baseUrl}/anonymous-users/${contactData.id}`,
       { headers }
@@ -44,5 +42,5 @@ export async function main(
     return response.json();
   }
 
-  throw new Error(`Unknown client-service action: ${config.action}`);
+  throw new Error(`Unknown client-service action: ${action}`);
 }

--- a/scripts/nodes/client-update-user.ts
+++ b/scripts/nodes/client-update-user.ts
@@ -1,17 +1,13 @@
 // Windmill node script — calls client PATCH /anonymous-users/:id
 export async function main(
-  config: {
-    userId: string;
-    firstName?: string;
-    lastName?: string;
-    phone?: string;
-    clerkUserId?: string | null;
-    orgId?: string | null;
-    metadata?: Record<string, unknown> | null;
-  }
+  userId: string,
+  firstName?: string,
+  lastName?: string,
+  phone?: string,
+  clerkUserId?: string | null,
+  orgId?: string | null,
+  metadata?: Record<string, unknown> | null,
 ) {
-  const { userId, ...body } = config;
-
   const response = await fetch(
     `${Bun.env.CLIENT_SERVICE_URL!}/anonymous-users/${userId}`,
     {
@@ -20,7 +16,7 @@ export async function main(
         "Content-Type": "application/json",
         "x-api-key": Bun.env.CLIENT_SERVICE_API_KEY!,
       },
-      body: JSON.stringify(body),
+      body: JSON.stringify({ firstName, lastName, phone, clerkUserId, orgId, metadata }),
     }
   );
 

--- a/scripts/nodes/content-generation.ts
+++ b/scripts/nodes/content-generation.ts
@@ -1,6 +1,6 @@
 // Windmill node script — calls email-generation POST /generate
 export async function main(
-  config: { contentType: string },
+  contentType: string,
   leadData: Record<string, unknown>,
   clientData: Record<string, unknown>,
   context: {
@@ -20,7 +20,7 @@ export async function main(
         "x-clerk-org-id": context.orgId,
       },
       body: JSON.stringify({
-        contentType: config.contentType,
+        contentType,
         leadData,
         clientData,
         runId: context.runId,

--- a/scripts/nodes/content-sentiment.ts
+++ b/scripts/nodes/content-sentiment.ts
@@ -1,6 +1,5 @@
 // Windmill node script — calls reply-qualification POST /qualify
 export async function main(
-  config: Record<string, unknown>,
   emailContent: string,
   context: {
     orgId: string;
@@ -15,7 +14,7 @@ export async function main(
         "x-api-key": Bun.env.REPLY_QUALIFICATION_API_KEY!,
         "x-clerk-org-id": context.orgId,
       },
-      body: JSON.stringify({ content: emailContent, ...config }),
+      body: JSON.stringify({ content: emailContent }),
     }
   );
 

--- a/scripts/nodes/google-ads.ts
+++ b/scripts/nodes/google-ads.ts
@@ -1,6 +1,5 @@
 // STUB — Google Ads not yet implemented
 export async function main(
-  config: Record<string, unknown>,
   context?: { orgId: string; runId: string }
 ) {
   throw new Error(

--- a/scripts/nodes/lead-service.ts
+++ b/scripts/nodes/lead-service.ts
@@ -1,9 +1,7 @@
 // Windmill node script — calls lead-service POST /buffer/next
 export async function main(
-  config: {
-    source?: string;
-    searchParams?: Record<string, unknown>;
-  },
+  source: string | undefined,
+  searchParams: Record<string, unknown> | undefined,
   context: {
     orgId: string;
     brandId: string;
@@ -25,7 +23,7 @@ export async function main(
         campaignId: context.campaignId,
         brandId: context.brandId,
         parentRunId: context.runId,
-        searchParams: config.searchParams,
+        searchParams,
       }),
     }
   );

--- a/scripts/nodes/linkedin-connect.ts
+++ b/scripts/nodes/linkedin-connect.ts
@@ -1,6 +1,5 @@
 // STUB — LinkedIn Connect not yet implemented
 export async function main(
-  config: Record<string, unknown>,
   recipientLinkedinUrl: string,
   noteContent?: string,
   context?: { orgId: string; runId: string }

--- a/scripts/nodes/linkedin-dm.ts
+++ b/scripts/nodes/linkedin-dm.ts
@@ -1,6 +1,5 @@
 // STUB — LinkedIn DM via Unipile not yet implemented
 export async function main(
-  config: Record<string, unknown>,
   recipientLinkedinUrl: string,
   messageContent: string,
   context: { orgId: string; runId: string }

--- a/scripts/nodes/linkedin-post.ts
+++ b/scripts/nodes/linkedin-post.ts
@@ -1,6 +1,5 @@
 // STUB — LinkedIn Post not yet implemented
 export async function main(
-  config: Record<string, unknown>,
   postContent: string,
   context?: { orgId: string; runId: string }
 ) {

--- a/scripts/nodes/meta-ads.ts
+++ b/scripts/nodes/meta-ads.ts
@@ -1,6 +1,5 @@
 // STUB — Meta Ads not yet implemented
 export async function main(
-  config: Record<string, unknown>,
   context?: { orgId: string; runId: string }
 ) {
   throw new Error(

--- a/scripts/nodes/order-service.ts
+++ b/scripts/nodes/order-service.ts
@@ -1,12 +1,10 @@
 // MOCK — order-service not yet deployed
 export async function main(
-  config: {
-    action: "create" | "get" | "update";
-  },
+  action: "create" | "get" | "update",
   orderId?: string,
   data?: Record<string, unknown>
 ) {
   // TODO: Replace with real order-service call when deployed
-  console.log(`[MOCK] Order service ${config.action}`, { orderId, data });
+  console.log(`[MOCK] Order service ${action}`, { orderId, data });
   return { success: true, order: { id: orderId ?? `ord_mock_${Date.now()}`, ...data } };
 }

--- a/scripts/nodes/outbound-sending.ts
+++ b/scripts/nodes/outbound-sending.ts
@@ -1,6 +1,7 @@
 // Windmill node script — calls email-sending POST /send
 export async function main(
-  config: { channel: string; sendType: string },
+  channel: string,
+  sendType: string,
   toEmail: string,
   subject: string,
   bodyHtml: string,
@@ -21,8 +22,8 @@ export async function main(
         "x-clerk-org-id": context.orgId,
       },
       body: JSON.stringify({
-        type: config.sendType,
-        channel: config.channel,
+        type: sendType,
+        channel,
         toEmail,
         subject,
         bodyHtml,

--- a/scripts/nodes/product-service.ts
+++ b/scripts/nodes/product-service.ts
@@ -1,12 +1,10 @@
 // MOCK — product-service not yet deployed
 export async function main(
-  config: {
-    action: "get" | "register";
-  },
+  action: "get" | "register",
   productInstanceId?: string,
   registrationData?: Record<string, unknown>
 ) {
   // TODO: Replace with real product-service call when deployed
-  console.log(`[MOCK] Product service ${config.action}`, { productInstanceId, registrationData });
+  console.log(`[MOCK] Product service ${action}`, { productInstanceId, registrationData });
   return { success: true, product: { id: productInstanceId ?? "pi_webinar_001" } };
 }

--- a/scripts/nodes/stripe-create-checkout.ts
+++ b/scripts/nodes/stripe-create-checkout.ts
@@ -1,22 +1,18 @@
 // Windmill node script — calls stripe POST /checkout/create
 export async function main(
-  config: {
-    lineItems: { priceId: string; quantity: number }[];
-    successUrl: string;
-    cancelUrl: string;
-    mode?: "payment" | "subscription";
-    customerId?: string;
-    customerEmail?: string;
-    metadata?: Record<string, string>;
-    discounts?: { coupon?: string; promotionCode?: string }[];
-  },
-  context?: {
-    orgId?: string;
-    brandId?: string;
-    campaignId?: string;
-    runId?: string;
-    appId?: string;
-  }
+  lineItems: { priceId: string; quantity: number }[],
+  successUrl: string,
+  cancelUrl: string,
+  mode?: "payment" | "subscription",
+  customerId?: string,
+  customerEmail?: string,
+  metadata?: Record<string, string>,
+  discounts?: { coupon?: string; promotionCode?: string }[],
+  orgId?: string,
+  brandId?: string,
+  campaignId?: string,
+  runId?: string,
+  appId?: string,
 ) {
   const response = await fetch(
     `${Bun.env.STRIPE_SERVICE_URL!}/checkout/create`,
@@ -27,12 +23,8 @@ export async function main(
         "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
       },
       body: JSON.stringify({
-        ...config,
-        orgId: context?.orgId,
-        brandId: context?.brandId,
-        campaignId: context?.campaignId,
-        runId: context?.runId,
-        appId: context?.appId,
+        lineItems, successUrl, cancelUrl, mode, customerId, customerEmail,
+        metadata, discounts, orgId, brandId, campaignId, runId, appId,
       }),
     }
   );

--- a/scripts/nodes/stripe-create-coupon.ts
+++ b/scripts/nodes/stripe-create-coupon.ts
@@ -1,17 +1,15 @@
 // Windmill node script — calls stripe POST /coupons/create
 export async function main(
-  config: {
-    id?: string;
-    name?: string;
-    percentOff?: number;
-    amountOffInCents?: number;
-    currency?: string;
-    duration?: "once" | "repeating" | "forever";
-    durationInMonths?: number;
-    maxRedemptions?: number;
-    redeemBy?: string;
-    metadata?: Record<string, string>;
-  }
+  id?: string,
+  name?: string,
+  percentOff?: number,
+  amountOffInCents?: number,
+  currency?: string,
+  duration?: "once" | "repeating" | "forever",
+  durationInMonths?: number,
+  maxRedemptions?: number,
+  redeemBy?: string,
+  metadata?: Record<string, string>,
 ) {
   const response = await fetch(
     `${Bun.env.STRIPE_SERVICE_URL!}/coupons/create`,
@@ -21,7 +19,7 @@ export async function main(
         "Content-Type": "application/json",
         "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
       },
-      body: JSON.stringify(config),
+      body: JSON.stringify({ id, name, percentOff, amountOffInCents, currency, duration, durationInMonths, maxRedemptions, redeemBy, metadata }),
     }
   );
 

--- a/scripts/nodes/stripe-create-price.ts
+++ b/scripts/nodes/stripe-create-price.ts
@@ -1,12 +1,10 @@
 // Windmill node script — calls stripe POST /prices/create
 export async function main(
-  config: {
-    productId: string;
-    unitAmountInCents: number;
-    currency?: string;
-    recurring?: { interval: "day" | "week" | "month" | "year"; intervalCount?: number };
-    metadata?: Record<string, string>;
-  }
+  productId: string,
+  unitAmountInCents: number,
+  currency?: string,
+  recurring?: { interval: "day" | "week" | "month" | "year"; intervalCount?: number },
+  metadata?: Record<string, string>,
 ) {
   const response = await fetch(
     `${Bun.env.STRIPE_SERVICE_URL!}/prices/create`,
@@ -16,7 +14,7 @@ export async function main(
         "Content-Type": "application/json",
         "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
       },
-      body: JSON.stringify(config),
+      body: JSON.stringify({ productId, unitAmountInCents, currency, recurring, metadata }),
     }
   );
 

--- a/scripts/nodes/stripe-create-product.ts
+++ b/scripts/nodes/stripe-create-product.ts
@@ -1,11 +1,9 @@
 // Windmill node script — calls stripe POST /products/create
 export async function main(
-  config: {
-    name: string;
-    description?: string;
-    id?: string;
-    metadata?: Record<string, string>;
-  }
+  name: string,
+  description?: string,
+  id?: string,
+  metadata?: Record<string, string>,
 ) {
   const response = await fetch(
     `${Bun.env.STRIPE_SERVICE_URL!}/products/create`,
@@ -15,7 +13,7 @@ export async function main(
         "Content-Type": "application/json",
         "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
       },
-      body: JSON.stringify(config),
+      body: JSON.stringify({ name, description, id, metadata }),
     }
   );
 

--- a/scripts/nodes/stripe-get-coupon.ts
+++ b/scripts/nodes/stripe-get-coupon.ts
@@ -1,11 +1,9 @@
 // Windmill node script — calls stripe GET /coupons/:couponId
 export async function main(
-  config: {
-    couponId: string;
-  }
+  couponId: string,
 ) {
   const response = await fetch(
-    `${Bun.env.STRIPE_SERVICE_URL!}/coupons/${config.couponId}`,
+    `${Bun.env.STRIPE_SERVICE_URL!}/coupons/${couponId}`,
     {
       headers: {
         "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,

--- a/scripts/nodes/stripe-get-prices-by-product.ts
+++ b/scripts/nodes/stripe-get-prices-by-product.ts
@@ -1,11 +1,9 @@
 // Windmill node script — calls stripe GET /prices/by-product/:productId
 export async function main(
-  config: {
-    productId: string;
-  }
+  productId: string,
 ) {
   const response = await fetch(
-    `${Bun.env.STRIPE_SERVICE_URL!}/prices/by-product/${config.productId}`,
+    `${Bun.env.STRIPE_SERVICE_URL!}/prices/by-product/${productId}`,
     {
       headers: {
         "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,

--- a/scripts/nodes/stripe-get-product.ts
+++ b/scripts/nodes/stripe-get-product.ts
@@ -1,11 +1,9 @@
 // Windmill node script — calls stripe GET /products/:productId
 export async function main(
-  config: {
-    productId: string;
-  }
+  productId: string,
 ) {
   const response = await fetch(
-    `${Bun.env.STRIPE_SERVICE_URL!}/products/${config.productId}`,
+    `${Bun.env.STRIPE_SERVICE_URL!}/products/${productId}`,
     {
       headers: {
         "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,

--- a/scripts/nodes/stripe-get-stats.ts
+++ b/scripts/nodes/stripe-get-stats.ts
@@ -1,12 +1,10 @@
 // Windmill node script — calls stripe POST /stats
 export async function main(
-  config: {
-    runIds?: string[];
-    clerkOrgId?: string;
-    brandId?: string;
-    appId?: string;
-    campaignId?: string;
-  }
+  runIds?: string[],
+  clerkOrgId?: string,
+  brandId?: string,
+  appId?: string,
+  campaignId?: string,
 ) {
   const response = await fetch(
     `${Bun.env.STRIPE_SERVICE_URL!}/stats`,
@@ -16,7 +14,7 @@ export async function main(
         "Content-Type": "application/json",
         "X-API-Key": Bun.env.STRIPE_SERVICE_API_KEY!,
       },
-      body: JSON.stringify(config),
+      body: JSON.stringify({ runIds, clerkOrgId, brandId, appId, campaignId }),
     }
   );
 

--- a/scripts/nodes/stripe-service.ts
+++ b/scripts/nodes/stripe-service.ts
@@ -1,12 +1,10 @@
 // MOCK — stripe-service not yet deployed
 export async function main(
-  config: {
-    action: "create_checkout" | "get_payment";
-  },
+  action: "create_checkout" | "get_payment",
   sessionId?: string,
   data?: Record<string, unknown>
 ) {
   // TODO: Replace with real stripe-service call when deployed
-  console.log(`[MOCK] Stripe service ${config.action}`, { sessionId, data });
+  console.log(`[MOCK] Stripe service ${action}`, { sessionId, data });
   return { success: true, session: { id: sessionId ?? `cs_mock_${Date.now()}`, ...data } };
 }

--- a/scripts/nodes/transactional-email-get-stats.ts
+++ b/scripts/nodes/transactional-email-get-stats.ts
@@ -1,11 +1,9 @@
 // Windmill node script — calls transactional-email POST /stats
 export async function main(
-  config: {
-    appId?: string;
-    clerkOrgId?: string;
-    clerkUserId?: string;
-    eventType?: string;
-  }
+  appId?: string,
+  clerkOrgId?: string,
+  clerkUserId?: string,
+  eventType?: string,
 ) {
   const response = await fetch(
     `${Bun.env.LIFECYCLE_EMAILS_URL!}/stats`,
@@ -15,7 +13,7 @@ export async function main(
         "Content-Type": "application/json",
         "x-api-key": Bun.env.LIFECYCLE_EMAILS_API_KEY!,
       },
-      body: JSON.stringify(config),
+      body: JSON.stringify({ appId, clerkOrgId, clerkUserId, eventType }),
     }
   );
 

--- a/scripts/nodes/transactional-email-send.ts
+++ b/scripts/nodes/transactional-email-send.ts
@@ -1,16 +1,14 @@
 // Windmill node script — calls transactional-email POST /send
 export async function main(
-  config: {
-    appId: string;
-    eventType: string;
-    recipientEmail?: string;
-    brandId?: string;
-    campaignId?: string;
-    productId?: string;
-    clerkUserId?: string;
-    clerkOrgId?: string;
-    metadata?: Record<string, unknown>;
-  }
+  appId: string,
+  eventType: string,
+  recipientEmail?: string,
+  brandId?: string,
+  campaignId?: string,
+  productId?: string,
+  clerkUserId?: string,
+  clerkOrgId?: string,
+  metadata?: Record<string, unknown>,
 ) {
   const response = await fetch(
     `${Bun.env.LIFECYCLE_EMAILS_URL!}/send`,
@@ -20,7 +18,7 @@ export async function main(
         "Content-Type": "application/json",
         "x-api-key": Bun.env.LIFECYCLE_EMAILS_API_KEY!,
       },
-      body: JSON.stringify(config),
+      body: JSON.stringify({ appId, eventType, recipientEmail, brandId, campaignId, productId, clerkUserId, clerkOrgId, metadata }),
     }
   );
 

--- a/scripts/nodes/twilio-sms.ts
+++ b/scripts/nodes/twilio-sms.ts
@@ -1,6 +1,5 @@
 // MOCK — twilio-service not yet deployed
 export async function main(
-  config: Record<string, unknown>,
   to: string,
   body: string,
   metadata?: Record<string, unknown>

--- a/src/lib/input-mapping.ts
+++ b/src/lib/input-mapping.ts
@@ -18,7 +18,9 @@ export function buildInputTransforms(
   const transforms: Record<string, InputTransform> = {};
 
   if (config) {
-    transforms["config"] = { type: "static", value: config };
+    for (const [key, value] of Object.entries(config)) {
+      transforms[key] = { type: "static", value };
+    }
   }
 
   if (inputMapping) {

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -90,7 +90,7 @@ describe("dagToOpenFlow", () => {
     }
   });
 
-  it("translates static config to static transforms", () => {
+  it("spreads static config as individual transforms", () => {
     const result = dagToOpenFlow(POLARITY_WELCOME_DAG, "Welcome");
 
     const sendModule = result.value.modules[0];
@@ -99,15 +99,21 @@ describe("dagToOpenFlow", () => {
     if (sendModule.value.type === "script") {
       const transforms = sendModule.value.input_transforms as Record<
         string,
-        { type: string; value?: unknown }
+        { type: string; value?: unknown; expr?: string }
       >;
-      expect(transforms.config).toEqual({
+      expect(transforms.appId).toEqual({
         type: "static",
-        value: {
-          appId: "polaritycourse",
-          eventType: "webinar-registration-welcome",
-        },
+        value: "polaritycourse",
       });
+      expect(transforms.eventType).toEqual({
+        type: "static",
+        value: "webinar-registration-welcome",
+      });
+      expect(transforms.recipientEmail).toEqual({
+        type: "javascript",
+        expr: "flow_input.email",
+      });
+      expect(transforms.config).toBeUndefined();
     }
   });
 

--- a/tests/unit/input-mapping.test.ts
+++ b/tests/unit/input-mapping.test.ts
@@ -46,26 +46,32 @@ describe("buildInputTransforms", () => {
     });
   });
 
-  it("adds config as static transform", () => {
+  it("spreads config entries as individual static transforms", () => {
     const result = buildInputTransforms(
       { source: "apollo", limit: 10 },
       undefined
     );
 
-    expect(result.config).toEqual({
-      type: "static",
-      value: { source: "apollo", limit: 10 },
-    });
+    expect(result.source).toEqual({ type: "static", value: "apollo" });
+    expect(result.limit).toEqual({ type: "static", value: 10 });
+    expect(result.config).toBeUndefined();
   });
 
-  it("combines config and inputMapping", () => {
+  it("combines config and inputMapping as individual transforms", () => {
     const result = buildInputTransforms(
       { contentType: "cold-email" },
       { leadData: "$ref:lead-search.output.lead" }
     );
 
-    expect(result.config).toBeDefined();
-    expect(result.leadData).toBeDefined();
+    expect(result.contentType).toEqual({
+      type: "static",
+      value: "cold-email",
+    });
+    expect(result.leadData).toEqual({
+      type: "javascript",
+      expr: "results.lead_search.lead",
+    });
+    expect(result.config).toBeUndefined();
   });
 
   it("returns empty object for no inputs", () => {


### PR DESCRIPTION
## Summary
- **`buildInputTransforms`** now spreads config entries as individual static transforms instead of wrapping them in a single `config` key. This fixes the mismatch where Windmill maps `input_transforms` keys directly to function parameters.
- **All 30 node scripts** updated from `main(config: { field1, field2 })` to `main(field1, field2)` to match the new transform format.
- Tests updated to assert individual transform keys instead of a wrapped `config` object.

## Context
Node scripts expected `main(config: { productId })` but `buildInputTransforms` created `{ config: static, productId: javascript }` — Windmill would pass `config` and `productId` as separate params, so `productId` never reached the script's config object. Now both sides agree: individual params everywhere.

## Test plan
- [x] All 51 unit tests pass
- [x] Zero `config.` references remain in scripts/nodes/
- [ ] Deploy updated scripts to Windmill via `scripts/setup-windmill.ts`
- [ ] Verify end-to-end workflow execution with new param format

🤖 Generated with [Claude Code](https://claude.com/claude-code)