### PR TITLE
fix: add description field to deploy-nodes Windmill API calls

### DIFF
--- a/scripts/deploy-nodes.ts
+++ b/scripts/deploy-nodes.ts
@@ -52,6 +52,7 @@ export async function deployNodes(client: WindmillClient): Promise<
       await client.createScript({
         path: wmPath,
         summary,
+        description: "",
         content,
         language: "bun",
         parent_hash: existing.hash,
@@ -62,6 +63,7 @@ export async function deployNodes(client: WindmillClient): Promise<
       await client.createScript({
         path: wmPath,
         summary,
+        description: "",
         content,
         language: "bun",
       });


### PR DESCRIPTION
## Summary
- Windmill API returns 422 when `description` field is missing from `POST /scripts/create`
- Adds empty `description` to both create and update calls in `deploy-nodes.ts`
- Also includes the CI workflow from PR #14 (rebased on latest main)

## Test plan
- [x] Manually deployed 21 scripts to production Windmill successfully
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)