### PR TITLE
fix: forward appId into Windmill flow inputs

### DIFF
--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -51,14 +51,15 @@ router.post(
         return;
       }
 
-      // Run in Windmill
+      // Run in Windmill — inject appId so nodes can access it via flow_input.appId
       let windmillJobId: string | null = null;
       const client = getWindmillClient();
       if (client) {
         try {
+          const flowInputs = { ...body.inputs, appId: body.appId };
           windmillJobId = await client.runFlow(
             workflow.windmillFlowPath,
-            body.inputs ?? {}
+            flowInputs
           );
         } catch (err) {
           console.error(
@@ -123,14 +124,15 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
       return;
     }
 
-    // Run in Windmill
+    // Run in Windmill — inject appId so nodes can access it via flow_input.appId
     let windmillJobId: string | null = null;
     const client = getWindmillClient();
     if (client) {
       try {
+        const flowInputs = { ...body.inputs, ...(workflow.appId ? { appId: workflow.appId } : {}) };
         windmillJobId = await client.runFlow(
           workflow.windmillFlowPath,
-          body.inputs ?? {}
+          flowInputs
         );
       } catch (err) {
         console.error("[workflow-runs] Failed to run flow in Windmill:", err);


### PR DESCRIPTION
## Summary
- Both execute endpoints (`/workflows/by-name/:name/execute` and `/workflows/:id/execute`) now inject `appId` into the Windmill flow inputs
- Previously `body.inputs` was passed directly, so `flow_input.appId` was always `undefined` inside Windmill — causing node scripts like `client_create_user` to send `appId: undefined` to downstream services
- Added 3 regression tests verifying `appId` appears in the `runFlow` call args

## Test plan
- [x] Regression tests verify `appId` is forwarded for execute-by-name (with and without other inputs)
- [x] Regression test verifies `workflow.appId` is forwarded for execute-by-id
- [x] All 83 tests pass
- [ ] Deploy and verify the failing `client.createUser` flow now succeeds in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)