### PR TITLE
fix: auto-inject appId into module input_transforms

### DIFF
--- a/src/lib/dag-to-openflow.ts
+++ b/src/lib/dag-to-openflow.ts
@@ -68,7 +68,9 @@ export function dagToOpenFlow(dag: DAG, name: string): OpenFlow {
     schema: {
       $schema: "https://json-schema.org/draft/2020-12/schema",
       type: "object",
-      properties: {},
+      properties: {
+        appId: { type: "string", description: "Application identifier" },
+      },
       required: [],
     },
   };
@@ -145,6 +147,11 @@ function nodeToModule(node: DAGNode, dag: DAG): FlowModule | null {
   }
 
   const inputTransforms = buildInputTransforms(node.config, node.inputMapping);
+
+  // Auto-inject appId from flow_input unless the node already maps it explicitly
+  if (!inputTransforms.appId) {
+    inputTransforms.appId = { type: "javascript", expr: "flow_input.appId" };
+  }
 
   return {
     id: node.id,


### PR DESCRIPTION
## Summary
- Fixes `appId` being `undefined` in Windmill node scripts (e.g. `client.createUser`) when the DAG doesn't hardcode `appId` in the node's config
- The previous fix (#19) injected `appId` into flow-level inputs at execution time, but each module's `input_transforms` (built at deploy time) had no mapping for it — Windmill only passes values to script parameters that are declared in `input_transforms`
- Now `dagToOpenFlow` auto-adds `appId: { type: "javascript", expr: "flow_input.appId" }` to every script module's `input_transforms`, unless the node already maps `appId` explicitly

## Test plan
- [x] Regression test: script modules without explicit appId get `flow_input.appId` injected
- [x] Regression test: nodes with explicit appId in config are NOT overridden
- [x] Regression test: OpenFlow schema declares appId property
- [x] All 86 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)