### PR TITLE
feat: per-node retries + DAG onError handler

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -157,6 +157,11 @@
               "type": "string"
             },
             "description": "Dynamic input references using $ref syntax. Use \"$ref:flow_input.fieldName\" for workflow execution inputs, or \"$ref:node-id.output.fieldName\" for a previous node's output. Keys in inputMapping override same-named keys in config."
+          },
+          "retries": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of retry attempts on failure. Defaults to 3 if omitted. Set to 0 for non-idempotent operations (e.g., sending emails, consuming queue items) to prevent duplicates."
           }
         },
         "required": [
@@ -204,6 +209,10 @@
               "$ref": "#/components/schemas/DAGEdge"
             },
             "description": "Execution order between nodes. Empty array for single-node workflows."
+          },
+          "onError": {
+            "type": "string",
+            "description": "Node ID of an error handler that runs when any node in the DAG fails. The handler receives error context (failedNodeId, errorMessage) and can access outputs from previously completed nodes via $ref syntax. Use this to call end-run with success: false immediately on failure."
           }
         },
         "required": [

--- a/src/lib/dag-validator.ts
+++ b/src/lib/dag-validator.ts
@@ -5,6 +5,7 @@ export interface DAGNode {
   type: string;
   config?: Record<string, unknown>;
   inputMapping?: Record<string, string>;
+  retries?: number;
 }
 
 export interface DAGEdge {
@@ -16,6 +17,7 @@ export interface DAGEdge {
 export interface DAG {
   nodes: DAGNode[];
   edges: DAGEdge[];
+  onError?: string;
 }
 
 export interface ValidationError {
@@ -100,6 +102,14 @@ export function validateDAG(dag: DAG): ValidationResult {
     errors.push({
       field: "nodes",
       message: "No entry node found (all nodes have incoming edges)",
+    });
+  }
+
+  // 7. onError references an existing node
+  if (dag.onError && !nodeIdSet.has(dag.onError)) {
+    errors.push({
+      field: "onError",
+      message: `onError references unknown node: "${dag.onError}"`,
     });
   }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -37,6 +37,10 @@ export const DAGNodeSchema = z
       "or \"$ref:node-id.output.fieldName\" for a previous node's output. " +
       "Keys in inputMapping override same-named keys in config."
     ),
+    retries: z.number().int().min(0).optional().describe(
+      "Number of retry attempts on failure. Defaults to 3 if omitted. " +
+      "Set to 0 for non-idempotent operations (e.g., sending emails, consuming queue items) to prevent duplicates."
+    ),
   })
   .openapi("DAGNode");
 
@@ -55,6 +59,11 @@ export const DAGSchema = z
   .object({
     nodes: z.array(DAGNodeSchema).min(1).describe("The steps of the workflow. Must contain at least one node."),
     edges: z.array(DAGEdgeSchema).describe("Execution order between nodes. Empty array for single-node workflows."),
+    onError: z.string().optional().describe(
+      "Node ID of an error handler that runs when any node in the DAG fails. " +
+      "The handler receives error context (failedNodeId, errorMessage) and can access outputs " +
+      "from previously completed nodes via $ref syntax. Use this to call end-run with success: false immediately on failure."
+    ),
   })
   .openapi("DAG");
 

--- a/tests/unit/dag-validator.test.ts
+++ b/tests/unit/dag-validator.test.ts
@@ -18,6 +18,9 @@ import {
   POLARITY_WELCOME_DAG,
   DAG_WITH_HTTP_CALL,
   DAG_WITH_HTTP_CALL_CHAIN,
+  DAG_WITH_ON_ERROR,
+  DAG_WITH_BAD_ON_ERROR,
+  DAG_WITH_RETRIES_ZERO,
 } from "../helpers/fixtures.js";
 
 describe("validateDAG", () => {
@@ -127,5 +130,25 @@ describe("validateDAG", () => {
     expect(
       result.errors.some((e) => e.message.includes("No entry node"))
     ).toBe(true);
+  });
+
+  it("accepts a DAG with valid onError pointing to existing node", () => {
+    const result = validateDAG(DAG_WITH_ON_ERROR);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("rejects a DAG with onError pointing to non-existent node", () => {
+    const result = validateDAG(DAG_WITH_BAD_ON_ERROR);
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.message.includes("onError references unknown node"))
+    ).toBe(true);
+  });
+
+  it("accepts a DAG with retries: 0 on a node", () => {
+    const result = validateDAG(DAG_WITH_RETRIES_ZERO);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- **Per-node retries**: Nodes can now set `retries: 0` to disable automatic retries on non-idempotent operations (email sends, queue consumers). Defaults to 3 when omitted — no breaking change for existing DAGs.
- **DAG-level onError handler**: `dag.onError` points to a node ID that becomes Windmill's `failure_module`. Runs immediately on failure with error context (`failedNodeId`, `errorMessage`) and access to prior node outputs via `$ref` syntax. The onError node is excluded from the main execution flow.

**Why**: Retries were hardcoded to 3, silently causing duplicates on non-idempotent calls (email sends, lead buffer pops). The onError handler eliminates the 30-minute stale cleanup delay — failures are handled instantly.

## Test plan
- [x] `retries: 0` omits the retry block entirely
- [x] Custom retry count is respected
- [x] Default retries (omitted field) still produces 3 attempts
- [x] `onError` generates a `failure_module` with correct input transforms
- [x] `onError` node is excluded from main modules list
- [x] `$ref` input mappings work in the failure module
- [x] Error context fields (`failedNodeId`, `errorMessage`) are auto-injected
- [x] Validator rejects `onError` pointing to non-existent node
- [x] All 97 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)