### PR TITLE
fix: declare flow_input fields in schema and enforce retries: 0

### DIFF
--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -325,6 +325,22 @@ export const DAG_WITH_BAD_ON_ERROR: DAG = {
   onError: "nonexistent-handler",
 };
 
+export const DAG_WITH_FLOW_INPUT_REFS: DAG = {
+  nodes: [
+    {
+      id: "start-run",
+      type: "http.call",
+      config: { service: "campaign", method: "POST", path: "/internal/start-run" },
+      inputMapping: {
+        "body.campaignId": "$ref:flow_input.campaignId",
+        "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+      },
+      retries: 0,
+    },
+  ],
+  edges: [],
+};
+
 export const POLARITY_WELCOME_DAG: DAG = {
   nodes: [
     {


### PR DESCRIPTION
## Summary
- **$ref:flow_input fix**: The OpenFlow schema only declared `appId`, so Windmill stripped any other inputs (like `campaignId`, `clerkOrgId`) from `flow_input`. Now we scan all DAG nodes for `$ref:flow_input.xxx` references and auto-declare those fields in the schema.
- **retries: 0 fix**: When `retries: 0`, the retry block was omitted entirely. Windmill uses its own default retry behavior when retry is absent, causing nodes to retry despite `retries: 0`. Now we explicitly set `retry: { constant: { attempts: 0, seconds: 0 } }`.

## Test plan
- [x] Existing tests updated to match new retry behavior (`retries: 0` → explicit `{ attempts: 0, seconds: 0 }`)
- [x] New regression test: flow_input fields from inputMapping appear in OpenFlow schema
- [x] New regression test: onError handler's flow_input refs also appear in schema
- [x] New regression test: nested flow_input refs (e.g. `$ref:flow_input.brandIntel`) declare the top-level field
- [x] All 100 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)