### PR TITLE
fix: add headers parameter to http_call script

### DIFF
--- a/scripts/nodes/http-call.ts
+++ b/scripts/nodes/http-call.ts
@@ -12,6 +12,7 @@ export async function main(
   body?: Record<string, unknown>,
   query?: Record<string, string>,
   serviceEnvs?: Record<string, string>,
+  headers?: Record<string, string>,
 ) {
   // Convert service name to env var prefix: "transactional-email" → "TRANSACTIONAL_EMAIL"
   const envPrefix = service.toUpperCase().replace(/-/g, "_");
@@ -36,15 +37,16 @@ export async function main(
     url += `?${params}`;
   }
 
-  // Build request
-  const headers: Record<string, string> = {
+  // Build request — merge caller-supplied headers with defaults
+  const reqHeaders: Record<string, string> = {
     "Content-Type": "application/json",
+    ...headers,
   };
   if (apiKey) {
-    headers["x-api-key"] = apiKey;
+    reqHeaders["x-api-key"] = apiKey;
   }
 
-  const options: RequestInit = { method, headers };
+  const options: RequestInit = { method, headers: reqHeaders };
 
   if (body && ["POST", "PUT", "PATCH"].includes(method.toUpperCase())) {
     options.body = JSON.stringify(body);

--- a/tests/unit/http-call.test.ts
+++ b/tests/unit/http-call.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { main } from "../../scripts/nodes/http-call.js";
+
+// Mock Bun.env globally (script runs in Bun but we test in Node)
+const mockEnv: Record<string, string> = {};
+vi.stubGlobal("Bun", { env: mockEnv });
+
+// Capture fetch calls
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("http-call script", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(mockEnv)) delete mockEnv[key];
+  });
+
+  const serviceEnvs: Record<string, string> = {
+    LEAD_SERVICE_URL: "https://lead.example.com",
+    LEAD_SERVICE_API_KEY: "lead-key-123",
+    CAMPAIGN_SERVICE_URL: "https://campaign.example.com",
+    CAMPAIGN_SERVICE_API_KEY: "campaign-key-456",
+  };
+
+  it("sends default headers (Content-Type + x-api-key)", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    await main("lead", "POST", "/buffer/next", { foo: "bar" }, undefined, serviceEnvs);
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers["Content-Type"]).toBe("application/json");
+    expect(options.headers["x-api-key"]).toBe("lead-key-123");
+  });
+
+  it("merges custom headers with defaults", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ found: true }));
+
+    await main(
+      "lead", "POST", "/buffer/next",
+      { campaignId: "c1" },
+      undefined,
+      serviceEnvs,
+      { "x-app-id": "app-1", "x-org-id": "org-1" },
+    );
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers["Content-Type"]).toBe("application/json");
+    expect(options.headers["x-api-key"]).toBe("lead-key-123");
+    expect(options.headers["x-app-id"]).toBe("app-1");
+    expect(options.headers["x-org-id"]).toBe("org-1");
+  });
+
+  it("x-api-key takes precedence over custom headers", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    await main(
+      "lead", "POST", "/test",
+      undefined,
+      undefined,
+      serviceEnvs,
+      { "x-api-key": "should-be-overridden" },
+    );
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers["x-api-key"]).toBe("lead-key-123");
+  });
+
+  it("works without custom headers (backward compat)", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    await main("campaign", "GET", "/status", undefined, undefined, serviceEnvs);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://campaign.example.com/status");
+    expect(options.headers["Content-Type"]).toBe("application/json");
+    expect(options.headers["x-api-key"]).toBe("campaign-key-456");
+  });
+
+  it("throws when service URL is missing", async () => {
+    await expect(
+      main("unknown", "GET", "/test", undefined, undefined, serviceEnvs),
+    ).rejects.toThrow("Missing: UNKNOWN_SERVICE_URL");
+  });
+});


### PR DESCRIPTION
## Summary
- The `http_call` script silently ignored custom `headers` passed via input_transforms because it had no `headers` parameter
- `fetch_lead` node was failing with `x-app-id and x-org-id headers required` because those headers were never sent
- Added optional `headers` param that merges with defaults (`Content-Type`, `x-api-key`)

## Test plan
- [x] 5 new unit tests for header merging, precedence, and backward compatibility
- [x] All 121 tests pass
- [ ] After merge, GitHub Actions deploys updated script to Windmill
- [ ] Re-trigger a campaign to verify `fetch_lead` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)