### PR TITLE
feat: add stopAfterIf config for graceful flow termination

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -149,7 +149,7 @@
             "additionalProperties": {
               "nullable": true
             },
-            "description": "Static parameters passed to the node. For http.call: { service, method, path, body?, query? }. For wait: { seconds }. For for-each: { iterator, parallel?, skipFailures? }. Each key becomes a direct parameter of the underlying script."
+            "description": "Static parameters passed to the node. For http.call: { service, method, path, body?, query?, headers? }. For wait: { seconds }. For for-each: { iterator, parallel?, skipFailures? }. Each key becomes a direct parameter of the underlying script. Special config keys (stripped before passing to script): retries (number) — override default retry count; validateResponse ({ field, equals }) — throw error if response[field] !== equals, triggers onError handler; stopAfterIf (string) — JS expression evaluated after step completes using 'result' variable, stops the flow gracefully (no onError) when true. Example: \"result.found == false\"."
           },
           "inputMapping": {
             "type": "object",
@@ -212,7 +212,7 @@
           },
           "onError": {
             "type": "string",
-            "description": "Node ID of an error handler that runs when any node in the DAG fails. The handler receives error context (failedNodeId, errorMessage) and can access outputs from previously completed nodes via $ref syntax. Use this to call end-run with success: false immediately on failure."
+            "description": "Node ID of an error handler that runs when any node in the DAG fails (including validateResponse failures). Auto-injected parameters (available as script params, no inputMapping needed): failedNodeId (string) — the module ID of the step that failed; errorMessage (string) — the error message text. Can also access outputs from previously completed nodes via $ref syntax. Use this to call end-run with success: false. Tip: check errorMessage to distinguish expected stops (e.g. 'validation failed: expected found=true') from real errors."
           }
         },
         "required": [

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -379,6 +379,31 @@ export const DAG_WITH_DOT_NOTATION_AND_STATIC_BASE: DAG = {
   edges: [],
 };
 
+export const DAG_WITH_STOP_AFTER_IF: DAG = {
+  nodes: [
+    {
+      id: "fetch-lead",
+      type: "http.call",
+      config: {
+        service: "lead",
+        method: "POST",
+        path: "/buffer/next",
+        stopAfterIf: "result.found == false",
+      },
+      retries: 0,
+    },
+    {
+      id: "email-gen",
+      type: "content-generation",
+      config: { contentType: "cold-email" },
+      inputMapping: {
+        leadData: "$ref:fetch-lead.output.lead",
+      },
+    },
+  ],
+  edges: [{ from: "fetch-lead", to: "email-gen" }],
+};
+
 export const POLARITY_WELCOME_DAG: DAG = {
   nodes: [
     {


### PR DESCRIPTION
## Summary
- New DAG node config: `stopAfterIf` — JS expression evaluated after step completes. When `true`, flow stops gracefully (no `onError` triggered). Maps to Windmill's native `stop_after_if`.
- Documented `validateResponse` and `stopAfterIf` in the `config` schema description
- Documented `onError` auto-injected params (`failedNodeId`, `errorMessage`) so consumers can distinguish expected stops from real errors
- Updated `openapi.json` with improved descriptions

## Use case
`fetch-lead` returns `{ found: false }` when lead buffer is empty. Previously, `validateResponse` threw → triggered `onError` → `end-run-error(success=false)` → re-trigger loop. With `stopAfterIf: "result.found == false"`, the flow stops cleanly.

## Two flow-control options for consumers

| Config | Behavior | Use case |
|--------|----------|----------|
| `validateResponse: { field, equals }` | Throws error → triggers `onError` | Hard failures (gate-check blocked) |
| `stopAfterIf: "result.found == false"` | Stops flow gracefully → no `onError` | Expected conditions (empty buffer) |

## Test plan
- [x] 3 new tests: stopAfterIf produces stop_after_if, stripped from input_transforms, absent by default
- [x] All 128 tests pass
- [x] openapi.json regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)