### PR TITLE
feat: add skipIf config for conditional step skipping

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -149,7 +149,7 @@
             "additionalProperties": {
               "nullable": true
             },
-            "description": "Static parameters passed to the node. For http.call: { service, method, path, body?, query?, headers? }. For wait: { seconds }. For for-each: { iterator, parallel?, skipFailures? }. Each key becomes a direct parameter of the underlying script. Special config keys (stripped before passing to script): retries (number) — override default retry count; validateResponse ({ field, equals }) — throw error if response[field] !== equals, triggers onError handler; stopAfterIf (string) — JS expression evaluated after step completes using 'result' variable, stops the flow gracefully (no onError) when true. Example: \"result.found == false\"."
+            "description": "Static parameters passed to the node. For http.call: { service, method, path, body?, query?, headers? }. For wait: { seconds }. For for-each: { iterator, parallel?, skipFailures? }. Each key becomes a direct parameter of the underlying script. Special config keys (stripped before passing to script): retries (number) — override default retry count; validateResponse ({ field, equals }) — throw error if response[field] !== equals, triggers onError handler; stopAfterIf (string) — JS expression evaluated after step completes using 'result' variable, stops the flow gracefully (no onError) when true. Example: \"result.found == false\"; skipIf (string) — JS expression evaluated before this step runs, skips the step when true. Can reference previous results or flow_input. Example: \"results.fetch_lead.found == false\" to skip email generation when no leads."
           },
           "inputMapping": {
             "type": "object",

--- a/src/lib/dag-to-openflow.ts
+++ b/src/lib/dag-to-openflow.ts
@@ -13,6 +13,7 @@ export interface FlowModule {
   sleep?: { type: "javascript"; expr: string } | { type: "static"; value: number };
   retry?: { constant?: { attempts: number; seconds: number } };
   stop_after_if?: { expr: string; skip_if_stopped?: boolean };
+  skip_if?: { expr: string };
 }
 
 interface ScriptModule {
@@ -185,7 +186,9 @@ function nodeToModule(node: DAGNode, dag: DAG): FlowModule | null {
     ?? (typeof node.config?.retries === "number" ? node.config.retries : 3);
   const stopAfterIf = typeof node.config?.stopAfterIf === "string"
     ? node.config.stopAfterIf : undefined;
-  const { retries: _r, stopAfterIf: _s, ...scriptConfig } = node.config ?? {};
+  const skipIf = typeof node.config?.skipIf === "string"
+    ? node.config.skipIf : undefined;
+  const { retries: _r, stopAfterIf: _s, skipIf: _sk, ...scriptConfig } = node.config ?? {};
 
   const inputTransforms = buildInputTransforms(
     Object.keys(scriptConfig).length > 0 ? scriptConfig : undefined,
@@ -214,6 +217,9 @@ function nodeToModule(node: DAGNode, dag: DAG): FlowModule | null {
 
   if (stopAfterIf) {
     mod.stop_after_if = { expr: stopAfterIf, skip_if_stopped: true };
+  }
+  if (skipIf) {
+    mod.skip_if = { expr: skipIf };
   }
 
   return mod;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -34,7 +34,10 @@ export const DAGNodeSchema = z
       "retries (number) — override default retry count; " +
       "validateResponse ({ field, equals }) — throw error if response[field] !== equals, triggers onError handler; " +
       "stopAfterIf (string) — JS expression evaluated after step completes using 'result' variable, " +
-      "stops the flow gracefully (no onError) when true. Example: \"result.found == false\"."
+      "stops the flow gracefully (no onError) when true. Example: \"result.found == false\"; " +
+      "skipIf (string) — JS expression evaluated before this step runs, " +
+      "skips the step when true. Can reference previous results or flow_input. " +
+      "Example: \"results.fetch_lead.found == false\" to skip email generation when no leads."
     ),
     inputMapping: z.record(z.string()).optional().describe(
       "Dynamic input references using $ref syntax. " +

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -404,6 +404,36 @@ export const DAG_WITH_STOP_AFTER_IF: DAG = {
   edges: [{ from: "fetch-lead", to: "email-gen" }],
 };
 
+export const DAG_WITH_SKIP_IF: DAG = {
+  nodes: [
+    {
+      id: "fetch-lead",
+      type: "http.call",
+      config: { service: "lead", method: "POST", path: "/buffer/next" },
+      retries: 0,
+    },
+    {
+      id: "email-gen",
+      type: "http.call",
+      config: {
+        service: "ai",
+        method: "POST",
+        path: "/generate",
+        skipIf: "results.fetch_lead.found == false",
+      },
+    },
+    {
+      id: "end-run",
+      type: "http.call",
+      config: { service: "campaign", method: "POST", path: "/end-run" },
+    },
+  ],
+  edges: [
+    { from: "fetch-lead", to: "email-gen" },
+    { from: "email-gen", to: "end-run" },
+  ],
+};
+
 export const POLARITY_WELCOME_DAG: DAG = {
   nodes: [
     {


### PR DESCRIPTION
## Summary
- Adds `skipIf` config option for DAG nodes — a JS expression evaluated before a step runs
- Maps to Windmill's native `skip_if` module property
- Unlike `stopAfterIf` (halts the entire flow), `skipIf` only skips one step and lets subsequent steps continue
- This enables conditional branching: skip processing steps when no data, but always run cleanup/end-run

## Use case
Campaign-service needs `end-run` to always execute, even when `fetch-lead` returns `found: false`. With `skipIf`, they can skip `email-gen` and `email-send` while still reaching `end-run`.

## Test plan
- [x] Test: `skipIf` expression produces correct `skip_if` on module
- [x] Test: `skipIf` stripped from input_transforms
- [x] Test: modules without `skipIf` don't get `skip_if`
- [x] All 131 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)