### PR TITLE
fix: nest downstream nodes inside branchone/forloopflow modules

### DIFF
--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -434,6 +434,65 @@ export const DAG_WITH_SKIP_IF: DAG = {
   ],
 };
 
+export const DAG_WITH_CONDITION_CHAIN: DAG = {
+  nodes: [
+    {
+      id: "fetch-lead",
+      type: "http.call",
+      config: { service: "lead", method: "POST", path: "/buffer/next" },
+      retries: 0,
+    },
+    { id: "check-lead", type: "condition" },
+    {
+      id: "email-gen",
+      type: "http.call",
+      config: { service: "ai", method: "POST", path: "/generate" },
+    },
+    {
+      id: "email-send",
+      type: "http.call",
+      config: { service: "email", method: "POST", path: "/send" },
+    },
+    {
+      id: "end-run",
+      type: "http.call",
+      config: { service: "runs", method: "POST", path: "/runs/end" },
+    },
+  ],
+  edges: [
+    { from: "fetch-lead", to: "check-lead" },
+    { from: "check-lead", to: "email-gen", condition: "results.fetch_lead.found == true" },
+    { from: "email-gen", to: "email-send" },
+    { from: "check-lead", to: "end-run" },
+  ],
+};
+
+export const DAG_WITH_TWO_BRANCHES: DAG = {
+  nodes: [
+    { id: "check-score", type: "condition" },
+    {
+      id: "send-email",
+      type: "http.call",
+      config: { service: "email", method: "POST", path: "/send" },
+    },
+    {
+      id: "send-sms",
+      type: "http.call",
+      config: { service: "sms", method: "POST", path: "/send" },
+    },
+    {
+      id: "log-result",
+      type: "http.call",
+      config: { service: "log", method: "POST", path: "/log" },
+    },
+  ],
+  edges: [
+    { from: "check-score", to: "send-email", condition: "results.check_score.score > 50" },
+    { from: "check-score", to: "send-sms", condition: "results.check_score.score <= 50" },
+    { from: "check-score", to: "log-result" },
+  ],
+};
+
 export const POLARITY_WELCOME_DAG: DAG = {
   nodes: [
     {

--- a/tests/unit/polarity-workflows.test.ts
+++ b/tests/unit/polarity-workflows.test.ts
@@ -52,13 +52,23 @@ describe("Polarity workflows", () => {
       expect(wf.dag.nodes[2].type).toBe("transactional-email.send");
     });
 
-    it("translates for-each to forloopflow module", () => {
+    it("translates for-each to forloopflow module with nested body", () => {
       const openflow = dagToOpenFlow(wf.dag, wf.name);
       const loopModule = openflow.value.modules.find(
         (m) => m.id === "loop_contacts"
       );
       expect(loopModule).toBeDefined();
       expect(loopModule!.value.type).toBe("forloopflow");
+
+      if (loopModule!.value.type === "forloopflow") {
+        // send-reminder should be inside the loop body, not top-level
+        expect(loopModule!.value.modules).toHaveLength(1);
+        expect(loopModule!.value.modules[0].id).toBe("send_reminder");
+      }
+
+      // send_reminder should NOT appear as a top-level module
+      const topLevelIds = openflow.value.modules.map((m) => m.id);
+      expect(topLevelIds).not.toContain("send_reminder");
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixes condition nodes creating branchone with empty `modules: []` — downstream nodes now properly nest inside branches
- Fixes for-each nodes creating forloopflow with empty loop body — body nodes now nest inside the loop
- Enables campaign-service pattern: `fetch-lead → IF found → [email-gen → email-send] → end-run`

## How it works
Two-pass approach in `buildModules()`:
1. **Pre-compute**: walk DAG to determine which nodes belong inside which container (branch/loop)
2. **Build**: iterate topologically, skip consumed nodes, build containers with nested modules

A node joins a branch if ALL its incoming edges come from nodes already in that branch. Non-conditional edges from a condition node mark "after-branch" convergence points (like `end-run`).

## Campaign-service DAG example
```json
{
  "edges": [
    { "from": "fetch-lead", "to": "check-lead" },
    { "from": "check-lead", "to": "email-gen", "condition": "results.fetch_lead.found == true" },
    { "from": "email-gen", "to": "email-send" },
    { "from": "check-lead", "to": "end-run" }
  ]
}
```
→ `[fetch_lead, branchone{found=true: [email_gen, email_send]}, end_run]`

When `found == false`: no branch matches → default (empty) → end-run always executes.

## Test plan
- [x] Updated condition test: branch targets nested inside branchone, not top-level
- [x] Updated for-each test: body node nested inside forloopflow, not top-level
- [x] New test: condition chain (email-gen → email-send inside branch, end-run after)
- [x] New test: two branches with different conditions + unconditional after-branch node
- [x] Updated polarity reminder-sequence test: send-reminder inside loop body
- [x] All 133 tests pass, TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)