### PR TITLE
feat: add debug endpoint for per-step execution details

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -405,6 +405,34 @@
           }
         }
       },
+      "WorkflowRunDebugResponse": {
+        "type": "object",
+        "properties": {
+          "runId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "windmillJobId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "flowStatus": {
+            "nullable": true,
+            "description": "Windmill flow_status object. Contains per-module execution details including resolved inputs, outputs, and timing for each step in the flow."
+          },
+          "result": {
+            "nullable": true,
+            "description": "Final flow result."
+          }
+        },
+        "required": [
+          "runId",
+          "windmillJobId",
+          "status"
+        ]
+      },
       "DeployWorkflowResult": {
         "type": "object",
         "properties": {
@@ -905,6 +933,53 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/WorkflowRunResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflow-runs/{id}/debug": {
+      "get": {
+        "summary": "Debug a workflow run",
+        "description": "Returns per-step execution details from the Windmill engine, including resolved inputs and outputs for each module. Use this to diagnose runtime issues that aren't visible in the final result.",
+        "tags": [
+          "Workflow Runs"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Debug details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowRunDebugResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Run not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -428,6 +428,46 @@ registry.registerPath({
   },
 });
 
+export const WorkflowRunDebugResponseSchema = z
+  .object({
+    runId: z.string().uuid(),
+    windmillJobId: z.string(),
+    status: z.string(),
+    flowStatus: z.unknown().nullable().describe(
+      "Windmill flow_status object. Contains per-module execution details including " +
+      "resolved inputs, outputs, and timing for each step in the flow."
+    ),
+    result: z.unknown().nullable().describe("Final flow result."),
+  })
+  .openapi("WorkflowRunDebugResponse");
+
+registry.registerPath({
+  method: "get",
+  path: "/workflow-runs/{id}/debug",
+  summary: "Debug a workflow run",
+  description:
+    "Returns per-step execution details from the Windmill engine, including " +
+    "resolved inputs and outputs for each module. Use this to diagnose " +
+    "runtime issues that aren't visible in the final result.",
+  tags: ["Workflow Runs"],
+  security: [{ apiKey: [] }],
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+  },
+  responses: {
+    200: {
+      description: "Debug details",
+      content: {
+        "application/json": { schema: WorkflowRunDebugResponseSchema },
+      },
+    },
+    404: {
+      description: "Run not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
 registry.registerPath({
   method: "get",
   path: "/workflow-runs",


### PR DESCRIPTION
## Summary
- Adds `GET /workflow-runs/:id/debug` endpoint that fetches Windmill's `flow_status` for a given run, exposing per-module resolved inputs and outputs
- Needed to investigate the campaign duplicate-email bug — code review confirmed $ref resolution is correct, but runtime per-step data was missing to identify which service in the chain (emailgeneration vs email-gateway) returned duplicate content
- Includes OpenAPI schema registration and 5 integration tests

## Test plan
- [x] All 138 tests pass (`npx vitest run`)
- [x] New tests cover: success with flow_status, 404 for unknown run, 400 for missing job ID, null flow_status, auth required
- [ ] After deploy: call `GET /workflow-runs/{id}/debug` for the 3 campaign runs to get per-step data

🤖 Generated with [Claude Code](https://claude.com/claude-code)