### PR TITLE
feat: add workflow metadata (displayName, category, filters)

### DIFF
--- a/drizzle/0002_add_workflow_metadata.sql
+++ b/drizzle/0002_add_workflow_metadata.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "display_name" text;
+--> statement-breakpoint
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "category" text;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_workflows_app_name_unique" ON "workflows" ("app_id", "name") WHERE status != 'deleted';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1771152306410,
       "tag": "0001_add_app_id",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1771238706410,
+      "tag": "0002_add_workflow_metadata",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -40,6 +40,15 @@
           "service"
         ]
       },
+      "WorkflowCategory": {
+        "type": "string",
+        "nullable": true,
+        "enum": [
+          "sales",
+          "pr"
+        ],
+        "description": "Workflow category (sales, pr)."
+      },
       "WorkflowResponse": {
         "type": "object",
         "properties": {
@@ -73,9 +82,17 @@
             "type": "string",
             "description": "Workflow name. Use this with appId to execute via /workflows/by-name/{name}/execute."
           },
+          "displayName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Human-readable display name. Falls back to name if not set."
+          },
           "description": {
             "type": "string",
             "nullable": true
+          },
+          "category": {
+            "$ref": "#/components/schemas/WorkflowCategory"
           },
           "dag": {
             "nullable": true,
@@ -109,7 +126,9 @@
           "campaignId",
           "subrequestId",
           "name",
+          "displayName",
           "description",
+          "category",
           "windmillFlowPath",
           "windmillWorkspace",
           "status",
@@ -443,6 +462,20 @@
           "name": {
             "type": "string"
           },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "category": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowCategory"
+              },
+              {
+                "description": "Workflow category."
+              }
+            ]
+          },
           "action": {
             "type": "string",
             "enum": [
@@ -454,6 +487,8 @@
         "required": [
           "id",
           "name",
+          "displayName",
+          "category",
           "action"
         ]
       },
@@ -477,11 +512,26 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "description": "Workflow name. Must be unique within the appId. Used to execute via /workflows/by-name/{name}/execute."
+            "pattern": "^[a-z0-9][a-z0-9-]*$",
+            "description": "Workflow name (slug). Must be unique within the appId. Used to execute via /workflows/by-name/{name}/execute."
+          },
+          "displayName": {
+            "type": "string",
+            "description": "Human-readable display name for dashboards. Falls back to name if not set."
           },
           "description": {
             "type": "string",
             "description": "Human-readable description."
+          },
+          "category": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowCategory"
+              },
+              {
+                "description": "Workflow category."
+              }
+            ]
           },
           "dag": {
             "$ref": "#/components/schemas/DAG"
@@ -634,6 +684,14 @@
               "type": "string"
             },
             "required": false,
+            "name": "appId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
             "name": "brandId",
             "in": "query"
           },
@@ -643,6 +701,22 @@
             },
             "required": false,
             "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/WorkflowCategory"
+                },
+                {
+                  "description": "Workflow category."
+                }
+              ]
+            },
+            "required": false,
+            "description": "Workflow category.",
+            "name": "category",
             "in": "query"
           },
           {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -5,7 +5,9 @@ import {
   jsonb,
   timestamp,
   index,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 
 export const workflows = pgTable(
   "workflows",
@@ -17,7 +19,9 @@ export const workflows = pgTable(
     campaignId: text("campaign_id"),
     subrequestId: text("subrequest_id"),
     name: text("name").notNull(),
+    displayName: text("display_name"),
     description: text("description"),
+    category: text("category"),
     dag: jsonb("dag").notNull(),
     windmillFlowPath: text("windmill_flow_path"),
     windmillWorkspace: text("windmill_workspace").notNull().default("prod"),
@@ -30,6 +34,9 @@ export const workflows = pgTable(
     index("idx_workflows_org").on(table.orgId),
     index("idx_workflows_campaign").on(table.campaignId),
     index("idx_workflows_status").on(table.status),
+    uniqueIndex("idx_workflows_app_name_unique")
+      .on(table.appId, table.name)
+      .where(sql`status != 'deleted'`),
   ]
 );
 


### PR DESCRIPTION
## Summary
- Add `displayName` (string, optional) and `category` (enum: `sales` | `pr`) fields to workflows
- Add `appId` and `category` query filters to `GET /workflows`
- Enforce workflow `name` as lowercase slug (`^[a-z0-9][a-z0-9-]*$`)
- Add unique partial index on `(app_id, name) WHERE status != 'deleted'` for cross-service identity safety
- Deploy endpoint (`PUT /workflows/deploy`) accepts, stores, and returns the new fields
- All GET responses include `displayName` and `category`

## Context
Requested by Runs Service for dashboard cost aggregation by workflow. Category enum starts with `sales` and `pr` — extensible via migration later.

## Test plan
- [x] Deploy with displayName and category returns them in response
- [x] Deploy without displayName/category returns null
- [x] Invalid category value rejected (400)
- [x] Non-slug name format rejected (400)
- [x] Name starting with hyphen rejected (400)
- [x] Update preserves existing displayName/category when not re-sent
- [x] GET /workflows returns new fields
- [x] All 145 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)