### PR TITLE
feat: add channel and audienceType dimension enums

### DIFF
--- a/drizzle/0003_add_channel_audience_type.sql
+++ b/drizzle/0003_add_channel_audience_type.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "channel" text;
+--> statement-breakpoint
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "audience_type" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1771238706410,
       "tag": "0002_add_workflow_metadata",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1771325106410,
+      "tag": "0003_add_channel_audience_type",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -49,6 +49,22 @@
         ],
         "description": "Workflow category (sales, pr)."
       },
+      "WorkflowChannel": {
+        "type": "string",
+        "nullable": true,
+        "enum": [
+          "email"
+        ],
+        "description": "Workflow distribution channel (email)."
+      },
+      "WorkflowAudienceType": {
+        "type": "string",
+        "nullable": true,
+        "enum": [
+          "cold-outreach"
+        ],
+        "description": "Workflow audience type (cold-outreach)."
+      },
       "WorkflowResponse": {
         "type": "object",
         "properties": {
@@ -94,6 +110,12 @@
           "category": {
             "$ref": "#/components/schemas/WorkflowCategory"
           },
+          "channel": {
+            "$ref": "#/components/schemas/WorkflowChannel"
+          },
+          "audienceType": {
+            "$ref": "#/components/schemas/WorkflowAudienceType"
+          },
           "dag": {
             "nullable": true,
             "description": "The DAG definition as submitted."
@@ -129,6 +151,8 @@
           "displayName",
           "description",
           "category",
+          "channel",
+          "audienceType",
           "windmillFlowPath",
           "windmillWorkspace",
           "status",
@@ -476,6 +500,26 @@
               }
             ]
           },
+          "channel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowChannel"
+              },
+              {
+                "description": "Workflow distribution channel."
+              }
+            ]
+          },
+          "audienceType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowAudienceType"
+              },
+              {
+                "description": "Workflow audience type."
+              }
+            ]
+          },
           "action": {
             "type": "string",
             "enum": [
@@ -489,6 +533,8 @@
           "name",
           "displayName",
           "category",
+          "channel",
+          "audienceType",
           "action"
         ]
       },
@@ -530,6 +576,26 @@
               },
               {
                 "description": "Workflow category."
+              }
+            ]
+          },
+          "channel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowChannel"
+              },
+              {
+                "description": "Workflow distribution channel."
+              }
+            ]
+          },
+          "audienceType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WorkflowAudienceType"
+              },
+              {
+                "description": "Workflow audience type."
               }
             ]
           },
@@ -717,6 +783,38 @@
             "required": false,
             "description": "Workflow category.",
             "name": "category",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/WorkflowChannel"
+                },
+                {
+                  "description": "Workflow distribution channel."
+                }
+              ]
+            },
+            "required": false,
+            "description": "Workflow distribution channel.",
+            "name": "channel",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/WorkflowAudienceType"
+                },
+                {
+                  "description": "Workflow audience type."
+                }
+              ]
+            },
+            "required": false,
+            "description": "Workflow audience type.",
+            "name": "audienceType",
             "in": "query"
           },
           {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -22,6 +22,8 @@ export const workflows = pgTable(
     displayName: text("display_name"),
     description: text("description"),
     category: text("category"),
+    channel: text("channel"),
+    audienceType: text("audience_type"),
     dag: jsonb("dag").notNull(),
     windmillFlowPath: text("windmill_flow_path"),
     windmillWorkspace: text("windmill_workspace").notNull().default("prod"),

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -108,7 +108,7 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
       return;
     }
 
-    const results: { id: string; name: string; displayName: string | null; category: string | null; action: "created" | "updated" }[] = [];
+    const results: { id: string; name: string; displayName: string | null; category: string | null; channel: string | null; audienceType: string | null; action: "created" | "updated" }[] = [];
 
     for (const wf of body.workflows) {
       const dag = wf.dag as DAG;
@@ -149,13 +149,15 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
             displayName: wf.displayName ?? existing.displayName,
             description: wf.description ?? existing.description,
             category: wf.category ?? existing.category,
+            channel: wf.channel ?? existing.channel,
+            audienceType: wf.audienceType ?? existing.audienceType,
             dag: wf.dag,
             updatedAt: new Date(),
           })
           .where(eq(workflows.id, existing.id))
           .returning();
 
-        results.push({ id: updated.id, name: updated.name, displayName: updated.displayName, category: updated.category, action: "updated" });
+        results.push({ id: updated.id, name: updated.name, displayName: updated.displayName, category: updated.category, channel: updated.channel, audienceType: updated.audienceType, action: "updated" });
       } else {
         // Create new workflow
         if (client) {
@@ -181,13 +183,15 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
             displayName: wf.displayName ?? null,
             description: wf.description,
             category: wf.category ?? null,
+            channel: wf.channel ?? null,
+            audienceType: wf.audienceType ?? null,
             dag: wf.dag,
             windmillFlowPath: flowPath,
             status: "active",
           })
           .returning();
 
-        results.push({ id: created.id, name: created.name, displayName: created.displayName, category: created.category, action: "created" });
+        results.push({ id: created.id, name: created.name, displayName: created.displayName, category: created.category, channel: created.channel, audienceType: created.audienceType, action: "created" });
       }
     }
 
@@ -205,7 +209,7 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
 // GET /workflows — List workflows
 router.get("/workflows", requireApiKey, async (req, res) => {
   try {
-    const { orgId, appId, brandId, campaignId, category, status } = req.query;
+    const { orgId, appId, brandId, campaignId, category, channel, audienceType, status } = req.query;
 
     if (!orgId || typeof orgId !== "string") {
       res.status(400).json({ error: "orgId query parameter is required" });
@@ -227,6 +231,12 @@ router.get("/workflows", requireApiKey, async (req, res) => {
     }
     if (category && typeof category === "string") {
       conditions.push(eq(workflows.category, category));
+    }
+    if (channel && typeof channel === "string") {
+      conditions.push(eq(workflows.channel, channel));
+    }
+    if (audienceType && typeof audienceType === "string") {
+      conditions.push(eq(workflows.audienceType, audienceType));
     }
     if (status && typeof status === "string") {
       conditions.push(eq(workflows.status, status));

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -94,6 +94,16 @@ export const WorkflowCategorySchema = z
   .describe("Workflow category.")
   .openapi("WorkflowCategory");
 
+export const WorkflowChannelSchema = z
+  .enum(["email"])
+  .describe("Workflow distribution channel.")
+  .openapi("WorkflowChannel");
+
+export const WorkflowAudienceTypeSchema = z
+  .enum(["cold-outreach"])
+  .describe("Workflow audience type.")
+  .openapi("WorkflowAudienceType");
+
 // --- Workflow schemas ---
 
 export const CreateWorkflowSchema = z
@@ -128,6 +138,8 @@ export const WorkflowResponseSchema = z
     displayName: z.string().nullable().describe("Human-readable display name. Falls back to name if not set."),
     description: z.string().nullable(),
     category: WorkflowCategorySchema.nullable().describe("Workflow category (sales, pr)."),
+    channel: WorkflowChannelSchema.nullable().describe("Workflow distribution channel (email)."),
+    audienceType: WorkflowAudienceTypeSchema.nullable().describe("Workflow audience type (cold-outreach)."),
     dag: z.unknown().describe("The DAG definition as submitted."),
     windmillFlowPath: z.string().nullable().describe("Internal Windmill flow path (managed automatically)."),
     windmillWorkspace: z.string().describe("Windmill workspace (managed automatically)."),
@@ -188,6 +200,8 @@ export const DeployWorkflowItemSchema = z
     displayName: z.string().optional().describe("Human-readable display name for dashboards. Falls back to name if not set."),
     description: z.string().optional().describe("Human-readable description."),
     category: WorkflowCategorySchema.optional().describe("Workflow category."),
+    channel: WorkflowChannelSchema.optional().describe("Workflow distribution channel."),
+    audienceType: WorkflowAudienceTypeSchema.optional().describe("Workflow audience type."),
     dag: DAGSchema,
   })
   .openapi("DeployWorkflowItem");
@@ -208,6 +222,8 @@ export const DeployWorkflowResultSchema = z
     name: z.string(),
     displayName: z.string().nullable(),
     category: WorkflowCategorySchema.nullable(),
+    channel: WorkflowChannelSchema.nullable(),
+    audienceType: WorkflowAudienceTypeSchema.nullable(),
     action: z.enum(["created", "updated"]),
   })
   .openapi("DeployWorkflowResult");
@@ -301,6 +317,8 @@ registry.registerPath({
       brandId: z.string().optional(),
       campaignId: z.string().optional(),
       category: WorkflowCategorySchema.optional(),
+      channel: WorkflowChannelSchema.optional(),
+      audienceType: WorkflowAudienceTypeSchema.optional(),
       status: z.string().optional(),
     }),
   },

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -270,7 +270,31 @@ describe("PUT /workflows/deploy", () => {
     expect(res.body.workflows[0].category).toBe("sales");
   });
 
-  it("returns null displayName/category when not provided", async () => {
+  it("accepts all three dimension enums on deploy", async () => {
+    const res = await request
+      .put("/workflows/deploy")
+      .set(AUTH)
+      .send({
+        appId: "kevinlourd-com",
+        workflows: [
+          {
+            name: "full-metadata-flow",
+            displayName: "Full Metadata",
+            category: "sales",
+            channel: "email",
+            audienceType: "cold-outreach",
+            dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.workflows[0].category).toBe("sales");
+    expect(res.body.workflows[0].channel).toBe("email");
+    expect(res.body.workflows[0].audienceType).toBe("cold-outreach");
+  });
+
+  it("returns null for all dimension fields when not provided", async () => {
     const res = await request
       .put("/workflows/deploy")
       .set(AUTH)
@@ -287,6 +311,44 @@ describe("PUT /workflows/deploy", () => {
     expect(res.status).toBe(200);
     expect(res.body.workflows[0].displayName).toBeNull();
     expect(res.body.workflows[0].category).toBeNull();
+    expect(res.body.workflows[0].channel).toBeNull();
+    expect(res.body.workflows[0].audienceType).toBeNull();
+  });
+
+  it("rejects invalid channel value", async () => {
+    const res = await request
+      .put("/workflows/deploy")
+      .set(AUTH)
+      .send({
+        appId: "kevinlourd-com",
+        workflows: [
+          {
+            name: "bad-channel-flow",
+            channel: "smoke-signal",
+            dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid audienceType value", async () => {
+    const res = await request
+      .put("/workflows/deploy")
+      .set(AUTH)
+      .send({
+        appId: "kevinlourd-com",
+        workflows: [
+          {
+            name: "bad-audience-flow",
+            audienceType: "lukewarm",
+            dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(400);
   });
 
   it("rejects invalid category values", async () => {


### PR DESCRIPTION
## Summary
- Add `channel` (enum: `"email"`) and `audienceType` (enum: `"cold-outreach"`) as two new workflow dimension fields
- DB migration adds `channel` and `audience_type` columns to workflows table
- Zod enum validation on both fields; accepted on deploy, returned in responses, filterable on GET /workflows
- Together with `category`, these three dimensions power leaderboard/dashboard aggregation

## Test plan
- [x] Tests for all 3 dimension enums accepted on deploy
- [x] Tests for null defaults when dimensions not provided
- [x] Tests for invalid channel and audienceType values rejected (400)
- [x] All 148 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)