### PR TITLE
feat: add workflow DAG signature and signatureName

### DIFF
--- a/drizzle/0004_add_signature.sql
+++ b/drizzle/0004_add_signature.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "signature" text;
+--> statement-breakpoint
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "signature_name" text;

--- a/openapi.json
+++ b/openapi.json
@@ -116,6 +116,16 @@
           "audienceType": {
             "$ref": "#/components/schemas/WorkflowAudienceType"
           },
+          "signature": {
+            "type": "string",
+            "nullable": true,
+            "description": "Deterministic SHA-256 hash of the canonical DAG JSON. Changes when any node, edge, or config changes."
+          },
+          "signatureName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Human-readable name for this signature (e.g. 'Sequoia'). Used to distinguish workflow variants within the same category/channel/audienceType."
+          },
           "dag": {
             "nullable": true,
             "description": "The DAG definition as submitted."
@@ -153,6 +163,8 @@
           "category",
           "channel",
           "audienceType",
+          "signature",
+          "signatureName",
           "windmillFlowPath",
           "windmillWorkspace",
           "status",
@@ -520,6 +532,14 @@
               }
             ]
           },
+          "signature": {
+            "type": "string",
+            "nullable": true
+          },
+          "signatureName": {
+            "type": "string",
+            "nullable": true
+          },
           "action": {
             "type": "string",
             "enum": [
@@ -535,6 +555,8 @@
           "category",
           "channel",
           "audienceType",
+          "signature",
+          "signatureName",
           "action"
         ]
       },
@@ -598,6 +620,10 @@
                 "description": "Workflow audience type."
               }
             ]
+          },
+          "signatureName": {
+            "type": "string",
+            "description": "Human-readable name for this workflow variant (e.g. 'Sequoia'). Provided by the caller. The signature hash is computed server-side from the DAG."
           },
           "dag": {
             "$ref": "#/components/schemas/DAG"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -24,6 +24,8 @@ export const workflows = pgTable(
     category: text("category"),
     channel: text("channel"),
     audienceType: text("audience_type"),
+    signature: text("signature"),
+    signatureName: text("signature_name"),
     dag: jsonb("dag").notNull(),
     windmillFlowPath: text("windmill_flow_path"),
     windmillWorkspace: text("windmill_workspace").notNull().default("prod"),

--- a/src/lib/dag-signature.ts
+++ b/src/lib/dag-signature.ts
@@ -1,0 +1,28 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Recursively sorts object keys to ensure deterministic JSON serialization.
+ * Arrays preserve order (element order matters in a DAG).
+ */
+function canonicalize(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value === "object") {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[key] = canonicalize((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/**
+ * Computes a deterministic SHA-256 hash of a DAG object.
+ * Keys are sorted recursively so that `{a:1, b:2}` and `{b:2, a:1}`
+ * produce the same hash. Array element order is preserved.
+ */
+export function computeDAGSignature(dag: unknown): string {
+  const canonical = JSON.stringify(canonicalize(dag));
+  return createHash("sha256").update(canonical).digest("hex");
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -140,6 +140,8 @@ export const WorkflowResponseSchema = z
     category: WorkflowCategorySchema.nullable().describe("Workflow category (sales, pr)."),
     channel: WorkflowChannelSchema.nullable().describe("Workflow distribution channel (email)."),
     audienceType: WorkflowAudienceTypeSchema.nullable().describe("Workflow audience type (cold-outreach)."),
+    signature: z.string().nullable().describe("Deterministic SHA-256 hash of the canonical DAG JSON. Changes when any node, edge, or config changes."),
+    signatureName: z.string().nullable().describe("Human-readable name for this signature (e.g. 'Sequoia'). Used to distinguish workflow variants within the same category/channel/audienceType."),
     dag: z.unknown().describe("The DAG definition as submitted."),
     windmillFlowPath: z.string().nullable().describe("Internal Windmill flow path (managed automatically)."),
     windmillWorkspace: z.string().describe("Windmill workspace (managed automatically)."),
@@ -202,6 +204,7 @@ export const DeployWorkflowItemSchema = z
     category: WorkflowCategorySchema.optional().describe("Workflow category."),
     channel: WorkflowChannelSchema.optional().describe("Workflow distribution channel."),
     audienceType: WorkflowAudienceTypeSchema.optional().describe("Workflow audience type."),
+    signatureName: z.string().optional().describe("Human-readable name for this workflow variant (e.g. 'Sequoia'). Provided by the caller. The signature hash is computed server-side from the DAG."),
     dag: DAGSchema,
   })
   .openapi("DeployWorkflowItem");
@@ -224,6 +227,8 @@ export const DeployWorkflowResultSchema = z
     category: WorkflowCategorySchema.nullable(),
     channel: WorkflowChannelSchema.nullable(),
     audienceType: WorkflowAudienceTypeSchema.nullable(),
+    signature: z.string().nullable(),
+    signatureName: z.string().nullable(),
     action: z.enum(["created", "updated"]),
   })
   .openapi("DeployWorkflowResult");

--- a/tests/unit/dag-signature.test.ts
+++ b/tests/unit/dag-signature.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { computeDAGSignature } from "../../src/lib/dag-signature.js";
+import { VALID_LINEAR_DAG, DAG_WITH_TRANSACTIONAL_EMAIL_SEND } from "../helpers/fixtures.js";
+
+describe("computeDAGSignature", () => {
+  it("returns a 64-char hex string (SHA-256)", () => {
+    const sig = computeDAGSignature(VALID_LINEAR_DAG);
+    expect(sig).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("is deterministic — same DAG produces same hash", () => {
+    const a = computeDAGSignature(VALID_LINEAR_DAG);
+    const b = computeDAGSignature(VALID_LINEAR_DAG);
+    expect(a).toBe(b);
+  });
+
+  it("is key-order independent", () => {
+    const dag1 = { nodes: [{ id: "a", type: "b" }], edges: [] };
+    const dag2 = { edges: [], nodes: [{ type: "b", id: "a" }] };
+    expect(computeDAGSignature(dag1)).toBe(computeDAGSignature(dag2));
+  });
+
+  it("different DAGs produce different hashes", () => {
+    const sigA = computeDAGSignature(VALID_LINEAR_DAG);
+    const sigB = computeDAGSignature(DAG_WITH_TRANSACTIONAL_EMAIL_SEND);
+    expect(sigA).not.toBe(sigB);
+  });
+
+  it("changing a single config value changes the hash", () => {
+    const dagA = { nodes: [{ id: "a", type: "http.call", config: { path: "/v1" } }], edges: [] };
+    const dagB = { nodes: [{ id: "a", type: "http.call", config: { path: "/v2" } }], edges: [] };
+    expect(computeDAGSignature(dagA)).not.toBe(computeDAGSignature(dagB));
+  });
+
+  it("preserves array element order (different order = different hash)", () => {
+    const dagA = { nodes: [{ id: "a", type: "x" }, { id: "b", type: "y" }], edges: [] };
+    const dagB = { nodes: [{ id: "b", type: "y" }, { id: "a", type: "x" }], edges: [] };
+    expect(computeDAGSignature(dagA)).not.toBe(computeDAGSignature(dagB));
+  });
+
+  it("handles nested objects deterministically", () => {
+    const dag1 = {
+      nodes: [{ id: "a", type: "http.call", config: { body: { z: 1, a: 2 } } }],
+      edges: [],
+    };
+    const dag2 = {
+      nodes: [{ id: "a", type: "http.call", config: { body: { a: 2, z: 1 } } }],
+      edges: [],
+    };
+    expect(computeDAGSignature(dag1)).toBe(computeDAGSignature(dag2));
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `signature` (SHA-256 hash of canonical DAG JSON) and `signature_name` (human-readable label) columns to the workflows table
- Signature is computed server-side at deploy time; `signatureName` is optionally provided by the caller (campaign-service)
- Backfilled cold-email-outreach dimensions in prod: category=sales, channel=email, audience_type=cold-outreach
- Migration 0004 already applied to prod Neon

## Test plan
- [x] 7 new unit tests for `computeDAGSignature` (determinism, key-order independence, different DAGs produce different hashes)
- [x] 5 new integration tests for deploy endpoint signature fields (compute, store, preserve on update)
- [x] All 160 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)