### PR TITLE
feat: enforce NOT NULL on appId column

### DIFF
--- a/drizzle/0008_appid_not_null.sql
+++ b/drizzle/0008_appid_not_null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workflows" ALTER COLUMN "app_id" SET NOT NULL;

--- a/openapi.json
+++ b/openapi.json
@@ -75,8 +75,7 @@
           },
           "appId": {
             "type": "string",
-            "nullable": true,
-            "description": "App ID (set via deploy endpoint)."
+            "description": "Application identifier."
           },
           "orgId": {
             "type": "string",
@@ -276,6 +275,11 @@
       "CreateWorkflowRequest": {
         "type": "object",
         "properties": {
+          "appId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Application identifier. Workflows are scoped to appId."
+          },
           "orgId": {
             "type": "string",
             "minLength": 1,
@@ -296,7 +300,7 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "description": "Workflow name. Must be unique within the orgId. Used to execute by name later."
+            "description": "Workflow name. Must be unique within the appId. Used to execute by name later."
           },
           "description": {
             "type": "string",
@@ -316,6 +320,7 @@
           }
         },
         "required": [
+          "appId",
           "orgId",
           "name",
           "category",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -13,7 +13,7 @@ export const workflows = pgTable(
   "workflows",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    appId: text("app_id"),
+    appId: text("app_id").notNull(),
     orgId: text("org_id").notNull(),
     brandId: text("brand_id"),
     campaignId: text("campaign_id"),

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -72,7 +72,7 @@ router.post("/workflows", requireApiKey, async (req, res) => {
       .from(workflows)
       .where(
         and(
-          eq(workflows.orgId, body.orgId),
+          eq(workflows.appId, body.appId),
           rawSql`${workflows.status} != 'deleted'`
         )
       );
@@ -83,6 +83,7 @@ router.post("/workflows", requireApiKey, async (req, res) => {
     const [workflow] = await db
       .insert(workflows)
       .values({
+        appId: body.appId,
         orgId: body.orgId,
         brandId: body.brandId,
         campaignId: body.campaignId,
@@ -193,9 +194,9 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
         results.push({
           id: updated.id,
           name: updated.name,
-          category: updated.category ?? wf.category,
-          channel: updated.channel ?? wf.channel,
-          audienceType: updated.audienceType ?? wf.audienceType,
+          category: updated.category,
+          channel: updated.channel,
+          audienceType: updated.audienceType,
           signature: updated.signature,
           signatureName: updated.signatureName,
           action: "updated",
@@ -246,9 +247,9 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
         results.push({
           id: created.id,
           name: created.name,
-          category: created.category ?? wf.category,
-          channel: created.channel ?? wf.channel,
-          audienceType: created.audienceType ?? wf.audienceType,
+          category: created.category,
+          channel: created.channel,
+          audienceType: created.audienceType,
           signature: created.signature,
           signatureName: created.signatureName,
           action: "created",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -108,11 +108,12 @@ export const WorkflowAudienceTypeSchema = z
 
 export const CreateWorkflowSchema = z
   .object({
+    appId: z.string().min(1).describe("Application identifier. Workflows are scoped to appId."),
     orgId: z.string().min(1).describe("Organization ID that owns this workflow."),
     brandId: z.string().optional().describe("Optional brand ID for scoping."),
     campaignId: z.string().optional().describe("Optional campaign ID for scoping."),
     subrequestId: z.string().optional().describe("Optional subrequest ID for cost tracking."),
-    name: z.string().min(1).describe("Workflow name. Must be unique within the orgId. Used to execute by name later."),
+    name: z.string().min(1).describe("Workflow name. Must be unique within the appId. Used to execute by name later."),
     description: z.string().optional().describe("Human-readable description of what this workflow does."),
     category: WorkflowCategorySchema.describe("Workflow category."),
     channel: WorkflowChannelSchema.describe("Workflow distribution channel."),
@@ -132,7 +133,7 @@ export const UpdateWorkflowSchema = z
 export const WorkflowResponseSchema = z
   .object({
     id: z.string().uuid().describe("Workflow UUID. Not needed for execution — use name + appId instead."),
-    appId: z.string().nullable().describe("App ID (set via deploy endpoint)."),
+    appId: z.string().describe("Application identifier."),
     orgId: z.string().describe("Organization ID."),
     brandId: z.string().nullable(),
     campaignId: z.string().nullable(),

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -81,6 +81,7 @@ describe("POST /workflows", () => {
       .post("/workflows")
       .set(AUTH)
       .send({
+        appId: "test-app",
         orgId: "org-1",
         name: "Test Flow",
         category: "sales",
@@ -91,6 +92,7 @@ describe("POST /workflows", () => {
 
     expect(res.status).toBe(201);
     expect(res.body.name).toBe("Test Flow");
+    expect(res.body.appId).toBe("test-app");
     expect(res.body.orgId).toBe("org-1");
     expect(res.body.status).toBe("active");
     expect(res.body.category).toBe("sales");
@@ -106,6 +108,7 @@ describe("POST /workflows", () => {
       .post("/workflows")
       .set(AUTH)
       .send({
+        appId: "test-app",
         orgId: "org-1",
         name: "Bad Flow",
         category: "sales",


### PR DESCRIPTION
## Summary
- Backfilled 6 legacy workflows with NULL `app_id` to `'legacy'` in prod
- Applied `ALTER TABLE workflows ALTER COLUMN app_id SET NOT NULL` in prod
- Added `appId` as required field in `CreateWorkflowSchema`
- Updated `WorkflowResponseSchema` to mark `appId` as non-nullable
- Updated Drizzle schema, routes, tests, and regenerated OpenAPI spec

## Test plan
- [x] All 158 tests pass
- [x] Prod constraint already applied and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)