### PR TITLE
feat: narrow dimension enums to only values in use

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -44,24 +44,21 @@
         "type": "string",
         "enum": [
           "sales",
-          "pr",
-          "utility"
+          "pr"
         ],
         "description": "Workflow category."
       },
       "WorkflowChannel": {
         "type": "string",
         "enum": [
-          "email",
-          "api"
+          "email"
         ],
         "description": "Workflow distribution channel."
       },
       "WorkflowAudienceType": {
         "type": "string",
         "enum": [
-          "cold-outreach",
-          "internal"
+          "cold-outreach"
         ],
         "description": "Workflow audience type."
       },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -90,17 +90,17 @@ export const DAGSchema = z
 // --- Workflow enums ---
 
 export const WorkflowCategorySchema = z
-  .enum(["sales", "pr", "utility"])
+  .enum(["sales", "pr"])
   .describe("Workflow category.")
   .openapi("WorkflowCategory");
 
 export const WorkflowChannelSchema = z
-  .enum(["email", "api"])
+  .enum(["email"])
   .describe("Workflow distribution channel.")
   .openapi("WorkflowChannel");
 
 export const WorkflowAudienceTypeSchema = z
-  .enum(["cold-outreach", "internal"])
+  .enum(["cold-outreach"])
   .describe("Workflow audience type.")
   .openapi("WorkflowAudienceType");
 

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -392,6 +392,26 @@ describe("PUT /workflows/deploy", () => {
     expect(res.status).toBe(400);
   });
 
+  it("rejects removed enum values (utility, api, internal)", async () => {
+    const cases = [
+      { category: "utility", channel: "email", audienceType: "cold-outreach" },
+      { category: "sales", channel: "api", audienceType: "cold-outreach" },
+      { category: "sales", channel: "email", audienceType: "internal" },
+    ];
+
+    for (const dims of cases) {
+      const res = await request
+        .put("/workflows/deploy")
+        .set(AUTH)
+        .send({
+          appId: "mcpfactory",
+          workflows: [{ ...dims, dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND }],
+        });
+
+      expect(res.status).toBe(400);
+    }
+  });
+
   it("rejects if any DAG is invalid (no partial writes)", async () => {
     const res = await request
       .put("/workflows/deploy")


### PR DESCRIPTION
## Summary
- Remove unused enum values (`utility`, `api`, `internal`) from `WorkflowCategorySchema`, `WorkflowChannelSchema`, and `WorkflowAudienceTypeSchema`
- Aligns OpenAPI spec with what performance-service strictly parses: `category: "sales" | "pr"`, `channel: "email"`, `audienceType: "cold-outreach"`
- Adds regression test confirming the removed values are rejected

## Test plan
- [x] All 159 tests pass including new regression test for removed enum values
- [x] OpenAPI spec regenerated with narrowed enums
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)