### PR TITLE
fix: optional chaining for deep $ref expressions

### DIFF
--- a/src/lib/input-mapping.ts
+++ b/src/lib/input-mapping.ts
@@ -37,13 +37,20 @@ export function buildInputTransforms(
         } else {
           // "node-id.output.field" → "results.node_id.field"
           // "node-id.output" → "results.node_id" (whole output)
+          // Deep paths use optional chaining to prevent TypeError on null/undefined intermediates:
+          // "node-id.output.lead.data.email" → "results.node_id.lead?.data?.email"
           const parts = path.split(".");
           const nodeId = parts[0].replace(/-/g, "_");
           // Skip "output" part if present
           const rest = parts.slice(1).filter((p) => p !== "output");
-          expr = rest.length > 0
-            ? `results.${nodeId}.${rest.join(".")}`
-            : `results.${nodeId}`;
+          if (rest.length <= 1) {
+            expr = rest.length > 0
+              ? `results.${nodeId}.${rest[0]}`
+              : `results.${nodeId}`;
+          } else {
+            // Deep path: optional chaining on intermediate properties
+            expr = `results.${nodeId}.${rest[0]}${rest.slice(1).map(p => `?.${p}`).join("")}`;
+          }
         }
 
         transforms[key] = { type: "javascript", expr };

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -542,8 +542,8 @@ describe("dagToOpenFlow", () => {
       // Static base should be spread
       expect(expr).toContain('"cold-email"');
       expect(expr).toContain('"broadcast"');
-      // Dynamic fields should be present
-      expect(expr).toContain("results.start_run.lead.data.email");
+      // Dynamic fields should be present (deep paths use optional chaining)
+      expect(expr).toContain("results.start_run.lead?.data?.email");
       expect(expr).toContain("results.start_run.appId");
       // Nested metadata should merge static source with dynamic emailGenerationId
       expect(expr).toContain('"source"');

--- a/tests/unit/input-mapping.test.ts
+++ b/tests/unit/input-mapping.test.ts
@@ -24,14 +24,36 @@ describe("buildInputTransforms", () => {
     });
   });
 
-  it("handles nested output paths", () => {
+  it("handles nested output paths with optional chaining", () => {
     const result = buildInputTransforms(undefined, {
       email: "$ref:lead-search.output.lead.email",
     });
 
     expect(result.email).toEqual({
       type: "javascript",
-      expr: "results.lead_search.lead.email",
+      expr: "results.lead_search.lead?.email",
+    });
+  });
+
+  it("uses optional chaining for deeply nested output paths", () => {
+    const result = buildInputTransforms(undefined, {
+      email: "$ref:fetch-lead.output.lead.data.email",
+    });
+
+    expect(result.email).toEqual({
+      type: "javascript",
+      expr: "results.fetch_lead.lead?.data?.email",
+    });
+  });
+
+  it("does not use optional chaining for single-level output paths", () => {
+    const result = buildInputTransforms(undefined, {
+      runId: "$ref:start-run.output.runId",
+    });
+
+    expect(result.runId).toEqual({
+      type: "javascript",
+      expr: "results.start_run.runId",
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds optional chaining (`?.`) to JavaScript expressions generated from deep `$ref` paths in input mappings
- Prevents `TypeError` when intermediate objects are null/undefined in workflow step outputs
- Example: `$ref:fetch-lead.output.lead.data.email` now generates `results.fetch_lead.lead?.data?.email` instead of `results.fetch_lead.lead.data.email`
- Single-level paths (`$ref:node.output.field`) are unchanged

## Context
Production workflow `sales-email-cold-outreach-sienna` was failing because `fetch-lead` returned `found: true` but with null email. The `email-send` step received `to: null` and crashed. The condition branch guard (`found == true`) was too loose — also fixed in production via API to add `&& lead?.data?.email != null`.

This code change makes all future workflow deployments more resilient to null intermediate objects in `$ref` paths.

## Test plan
- [x] Updated existing test for nested output paths
- [x] Added test for deeply nested paths (3+ levels) with optional chaining
- [x] Added test verifying single-level paths are unchanged
- [x] Updated dag-to-openflow test expectations for deep path expressions
- [x] All 165 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)