### PR TITLE
fix: optional chaining after node_id in $ref expressions

### DIFF
--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -106,7 +106,7 @@ describe("dagToOpenFlow", () => {
       >;
       expect(transforms.leadData).toEqual({
         type: "javascript",
-        expr: "results.lead_search.lead",
+        expr: "results.lead_search?.lead",
       });
       expect(transforms.clientData).toEqual({
         type: "javascript",
@@ -285,7 +285,7 @@ describe("dagToOpenFlow", () => {
       // Should preserve $ref input mappings
       expect(transforms.runId).toEqual({
         type: "javascript",
-        expr: "results.start_run.runId",
+        expr: "results.start_run?.runId",
       });
       // Should inject error context
       expect(transforms.failedNodeId).toEqual({
@@ -543,11 +543,11 @@ describe("dagToOpenFlow", () => {
       expect(expr).toContain('"cold-email"');
       expect(expr).toContain('"broadcast"');
       // Dynamic fields should be present (deep paths use optional chaining)
-      expect(expr).toContain("results.start_run.lead?.data?.email");
-      expect(expr).toContain("results.start_run.appId");
+      expect(expr).toContain("results.start_run?.lead?.data?.email");
+      expect(expr).toContain("results.start_run?.appId");
       // Nested metadata should merge static source with dynamic emailGenerationId
       expect(expr).toContain('"source"');
-      expect(expr).toContain("results.email_generate.id");
+      expect(expr).toContain("results.email_generate?.id");
     }
   });
 });

--- a/tests/unit/input-mapping.test.ts
+++ b/tests/unit/input-mapping.test.ts
@@ -9,7 +9,7 @@ describe("buildInputTransforms", () => {
 
     expect(result.leadData).toEqual({
       type: "javascript",
-      expr: "results.lead_search.lead",
+      expr: "results.lead_search?.lead",
     });
   });
 
@@ -31,7 +31,7 @@ describe("buildInputTransforms", () => {
 
     expect(result.email).toEqual({
       type: "javascript",
-      expr: "results.lead_search.lead?.email",
+      expr: "results.lead_search?.lead?.email",
     });
   });
 
@@ -42,7 +42,7 @@ describe("buildInputTransforms", () => {
 
     expect(result.email).toEqual({
       type: "javascript",
-      expr: "results.fetch_lead.lead?.data?.email",
+      expr: "results.fetch_lead?.lead?.data?.email",
     });
   });
 
@@ -53,7 +53,7 @@ describe("buildInputTransforms", () => {
 
     expect(result.runId).toEqual({
       type: "javascript",
-      expr: "results.start_run.runId",
+      expr: "results.start_run?.runId",
     });
   });
 
@@ -91,7 +91,7 @@ describe("buildInputTransforms", () => {
     });
     expect(result.leadData).toEqual({
       type: "javascript",
-      expr: "results.lead_search.lead",
+      expr: "results.lead_search?.lead",
     });
     expect(result.config).toBeUndefined();
   });
@@ -139,7 +139,7 @@ describe("buildInputTransforms", () => {
     expect(result.body.type).toBe("javascript");
     // Should spread the static base and add the dynamic field
     expect(result.body.expr).toContain('"cold-email"');
-    expect(result.body.expr).toContain("results.start_run.email");
+    expect(result.body.expr).toContain("results.start_run?.email");
   });
 
   it("merges deeply nested dot-notation with static nested object", () => {
@@ -152,7 +152,7 @@ describe("buildInputTransforms", () => {
     expect(result.body.type).toBe("javascript");
     // Should spread the static metadata and add the dynamic field
     expect(result.body.expr).toContain('"source"');
-    expect(result.body.expr).toContain("results.gen.id");
+    expect(result.body.expr).toContain("results.gen?.id");
   });
 
   it("leaves non-dot-notation keys untouched", () => {


### PR DESCRIPTION
## Summary
- Follow-up to #48. When Windmill returns null for a step result (e.g. internal DispatchGone error), `results.fetch_lead` itself is null, so `results.fetch_lead.lead?.data?.email` still crashes with `cannot read property 'lead' of null`
- Adds `?.` immediately after the node_id: `results.fetch_lead?.lead?.data?.email`
- Also applies to single-level paths: `results.start_run?.runId`

## Test plan
- [x] Updated all expectations in `input-mapping.test.ts` and `dag-to-openflow.test.ts`
- [x] All 165 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)