### PR TITLE
feat: add POST /workflows/generate for LLM-powered workflow creation

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -626,6 +626,107 @@
           "workflows"
         ]
       },
+      "GenerateWorkflowResponse": {
+        "type": "object",
+        "properties": {
+          "workflow": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeployWorkflowResult"
+              },
+              {
+                "description": "The deployed workflow metadata."
+              }
+            ]
+          },
+          "dag": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DAG"
+              },
+              {
+                "description": "The generated DAG definition."
+              }
+            ]
+          },
+          "category": {
+            "$ref": "#/components/schemas/WorkflowCategory"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/WorkflowChannel"
+          },
+          "audienceType": {
+            "$ref": "#/components/schemas/WorkflowAudienceType"
+          },
+          "generatedDescription": {
+            "type": "string",
+            "description": "LLM-generated description of what this workflow does."
+          }
+        },
+        "required": [
+          "workflow",
+          "dag",
+          "category",
+          "channel",
+          "audienceType",
+          "generatedDescription"
+        ]
+      },
+      "GenerateWorkflowHints": {
+        "type": "object",
+        "properties": {
+          "services": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Scope generation to these services. Reduces prompt size and improves accuracy."
+          },
+          "nodeTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Suggest specific node types for the LLM to use."
+          },
+          "expectedInputs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Expected flow_input field names (e.g. campaignId, email)."
+          }
+        },
+        "description": "Optional hints to guide generation."
+      },
+      "GenerateWorkflowRequest": {
+        "type": "object",
+        "properties": {
+          "appId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Application identifier. The generated workflow will be deployed under this appId."
+          },
+          "orgId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Organization ID."
+          },
+          "description": {
+            "type": "string",
+            "minLength": 10,
+            "description": "Natural language description of the desired workflow. Be specific about the steps, services, and data flow."
+          },
+          "hints": {
+            "$ref": "#/components/schemas/GenerateWorkflowHints"
+          }
+        },
+        "required": [
+          "appId",
+          "orgId",
+          "description"
+        ]
+      },
       "ExecuteByNameRequest": {
         "type": "object",
         "properties": {
@@ -1268,6 +1369,62 @@
           },
           "400": {
             "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/generate": {
+      "post": {
+        "summary": "Generate a workflow from natural language",
+        "description": "Uses an LLM (Claude) to transform a natural language description into a valid DAG workflow. Validates the generated DAG and deploys it automatically. Returns the deployed workflow metadata along with the generated DAG.",
+        "tags": [
+          "Workflows"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateWorkflowRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Workflow generated and deployed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateWorkflowResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "LLM generated an invalid DAG that could not be fixed after retries",
             "content": {
               "application/json": {
                 "schema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@mcpfactory/workflow-service",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.78.0",
         "@asteasolutions/zod-to-openapi": "^7.3.0",
         "cors": "^2.8.5",
         "drizzle-orm": "^0.36.0",
@@ -27,6 +28,26 @@
         "vitest": "^3.0.0"
       }
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
+      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@asteasolutions/zod-to-openapi": {
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-7.3.4.tgz",
@@ -37,6 +58,15 @@
       },
       "peerDependencies": {
         "zod": "^3.20.2"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -2587,6 +2617,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -3320,6 +3363,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.78.0",
     "@asteasolutions/zod-to-openapi": "^7.3.0",
     "cors": "^2.8.5",
     "drizzle-orm": "^0.36.0",

--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -1,0 +1,264 @@
+import { NODE_TYPE_REGISTRY } from "./node-type-registry.js";
+import { getServiceCatalogForPrompt } from "./service-catalog.js";
+
+/**
+ * Claude tool_use schema for structured DAG output.
+ * Forces the LLM to return valid JSON matching this shape.
+ */
+export const DAG_GENERATION_TOOL = {
+  name: "create_workflow" as const,
+  description: "Create a valid DAG workflow with dimensions based on the user's description",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      category: {
+        type: "string" as const,
+        enum: ["sales", "pr"],
+        description: "Workflow category",
+      },
+      channel: {
+        type: "string" as const,
+        enum: ["email"],
+        description: "Distribution channel",
+      },
+      audienceType: {
+        type: "string" as const,
+        enum: ["cold-outreach"],
+        description: "Audience type",
+      },
+      description: {
+        type: "string" as const,
+        description: "Human-readable description of what this workflow does (1-2 sentences)",
+      },
+      dag: {
+        type: "object" as const,
+        properties: {
+          nodes: {
+            type: "array" as const,
+            items: {
+              type: "object" as const,
+              properties: {
+                id: { type: "string" as const },
+                type: { type: "string" as const },
+                config: { type: "object" as const },
+                inputMapping: { type: "object" as const },
+                retries: { type: "number" as const },
+              },
+              required: ["id", "type"],
+            },
+          },
+          edges: {
+            type: "array" as const,
+            items: {
+              type: "object" as const,
+              properties: {
+                from: { type: "string" as const },
+                to: { type: "string" as const },
+                condition: { type: "string" as const },
+              },
+              required: ["from", "to"],
+            },
+          },
+          onError: { type: "string" as const },
+        },
+        required: ["nodes", "edges"],
+      },
+    },
+    required: ["category", "channel", "audienceType", "description", "dag"],
+  },
+};
+
+export function buildSystemPrompt(filterServices?: string[]): string {
+  const nodeTypes = Object.entries(NODE_TYPE_REGISTRY)
+    .map(([type, path]) => {
+      if (path === null) return `- "${type}" (native flow control)`;
+      return `- "${type}"`;
+    })
+    .join("\n");
+
+  const serviceCatalog = getServiceCatalogForPrompt(filterServices);
+
+  return `You are a workflow architect that generates valid DAG (Directed Acyclic Graph) workflows.
+
+## DAG Format
+
+A workflow DAG has:
+- **nodes**: Array of steps. Each node: { id (string, kebab-case), type (string), config? (object), inputMapping? (object), retries? (number) }
+- **edges**: Array of { from, to, condition? } defining execution order.
+- **onError**: Optional node ID that runs when any step fails.
+
+## Recommended Node Type: http.call
+
+Use "http.call" for all service calls. Config:
+- service (string): service name, maps to {SERVICE}_SERVICE_URL env var
+- method (string): HTTP verb (GET, POST, PUT, DELETE)
+- path (string): endpoint path
+- body (object, optional): static request body parts
+- query (object, optional): query params
+
+Example:
+{
+  "id": "fetch-lead",
+  "type": "http.call",
+  "config": { "service": "lead", "method": "POST", "path": "/buffer/next" },
+  "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId" },
+  "retries": 0
+}
+
+## Flow Control Node Types
+
+- "condition": if/then/else branching. Outgoing edges WITH a condition expression define branches (target nodes are nested inside that branch). Outgoing edges WITHOUT condition are after-branch steps that always execute after the branchone completes.
+- "wait": delay. config: { seconds: number }
+- "for-each": loop over items. config: { iterator: string (JS expression), parallel?: boolean, skipFailures?: boolean }
+
+## Input Mapping ($ref syntax)
+
+Use inputMapping to pass dynamic data between nodes:
+- "$ref:flow_input.fieldName" — from workflow execution inputs
+- "$ref:node-id.output.fieldName" — from a previous node's output
+- "$ref:node-id.output" — entire output of a previous node
+
+Dot-notation keys create nested objects:
+- "body.campaignId": "$ref:flow_input.campaignId" → body: { campaignId: ... }
+- "body.metadata.source": "$ref:flow_input.source" → body: { metadata: { source: ... } }
+
+Static body fields go in config.body, dynamic overrides go in inputMapping with dot-notation.
+
+## Special Config Keys (stripped before passing to script)
+
+- retries (number): retry attempts on failure. Default 3. Set 0 for non-idempotent ops (email sends, SMS, queue consumes).
+- stopAfterIf (string): JS expression using "result" variable. Stops the entire flow gracefully when true. No onError triggered. Example: "result.allowed == false"
+- skipIf (string): JS expression using "results.<module_id>". Skips only this step when true. Example: "results.fetch_lead.found == false"
+- validateResponse ({ field, equals }): throws error if response[field] !== equals, triggers onError handler.
+
+## Dimension Enums (MUST pick from these)
+
+- category: "sales" | "pr"
+- channel: "email"
+- audienceType: "cold-outreach"
+
+## Available Services
+
+${serviceCatalog}
+
+## All Registered Node Types
+
+${nodeTypes}
+
+Prefer "http.call" over legacy named types for new workflows.
+
+## Rules
+
+1. Node IDs: unique, kebab-case, descriptive (e.g. "fetch-lead", "send-email", "check-status")
+2. No cycles — edges must form a DAG
+3. Every $ref must reference an existing node ID or flow_input
+4. Set retries: 0 for non-idempotent operations (email sends, SMS, queue consumes)
+5. Use onError for workflows that need cleanup on failure (e.g. mark run as failed via end-run)
+6. Use "condition" nodes for branching, not skipIf (skipIf only skips one step)
+7. The http.call node auto-injects appId and serviceEnvs from flow_input — no need to map them
+8. Campaign workflows should use the chassis pattern: gate-check → start-run → ... → end-run, with onError → end-run-error
+
+## Example: Cold Email Outreach with Branching
+
+\`\`\`json
+{
+  "nodes": [
+    {
+      "id": "gate-check",
+      "type": "http.call",
+      "config": { "service": "campaign", "method": "POST", "path": "/internal/gate-check", "stopAfterIf": "result.allowed == false" },
+      "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId", "body.clerkOrgId": "$ref:flow_input.clerkOrgId" }
+    },
+    {
+      "id": "start-run",
+      "type": "http.call",
+      "config": { "service": "campaign", "method": "POST", "path": "/internal/start-run" },
+      "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId", "body.clerkOrgId": "$ref:flow_input.clerkOrgId" }
+    },
+    {
+      "id": "fetch-lead",
+      "type": "http.call",
+      "config": { "service": "lead", "method": "POST", "path": "/buffer/next" },
+      "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId", "body.appId": "$ref:start-run.output.appId" },
+      "retries": 0
+    },
+    { "id": "check-lead", "type": "condition" },
+    {
+      "id": "brand-profile",
+      "type": "http.call",
+      "config": { "service": "brand", "method": "POST", "path": "/sales-profile" },
+      "inputMapping": { "body.brandId": "$ref:start-run.output.brandId" }
+    },
+    {
+      "id": "email-generate",
+      "type": "http.call",
+      "config": { "service": "content-generation", "method": "POST", "path": "/generate" },
+      "inputMapping": { "body.lead": "$ref:fetch-lead.output.lead", "body.brandProfile": "$ref:brand-profile.output" },
+      "retries": 0
+    },
+    {
+      "id": "email-send",
+      "type": "http.call",
+      "config": { "service": "email-gateway", "method": "POST", "path": "/send" },
+      "inputMapping": { "body.to": "$ref:fetch-lead.output.lead.data.email", "body.subject": "$ref:email-generate.output.subject", "body.bodyHtml": "$ref:email-generate.output.bodyHtml" },
+      "retries": 0
+    },
+    {
+      "id": "end-run",
+      "type": "http.call",
+      "config": { "service": "campaign", "method": "POST", "path": "/internal/end-run", "body": { "success": true } },
+      "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId", "body.leadFound": "$ref:fetch-lead.output.found" }
+    },
+    {
+      "id": "end-run-error",
+      "type": "http.call",
+      "config": { "service": "campaign", "method": "POST", "path": "/internal/end-run", "body": { "success": false } },
+      "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId" }
+    }
+  ],
+  "edges": [
+    { "from": "gate-check", "to": "start-run" },
+    { "from": "start-run", "to": "fetch-lead" },
+    { "from": "fetch-lead", "to": "check-lead" },
+    { "from": "check-lead", "to": "brand-profile", "condition": "results.fetch_lead.found == true" },
+    { "from": "brand-profile", "to": "email-generate" },
+    { "from": "email-generate", "to": "email-send" },
+    { "from": "check-lead", "to": "end-run" }
+  ],
+  "onError": "end-run-error"
+}
+\`\`\`
+
+## Example: Simple For-Each Loop
+
+\`\`\`json
+{
+  "nodes": [
+    { "id": "fetch-contacts", "type": "http.call", "config": { "service": "client", "method": "GET", "path": "/users" } },
+    { "id": "loop-contacts", "type": "for-each", "config": { "iterator": "results.fetch_contacts.users", "parallel": false } },
+    { "id": "send-email", "type": "http.call", "config": { "service": "transactional-email", "method": "POST", "path": "/send" }, "inputMapping": { "body.recipientEmail": "$ref:loop-contacts.output.email" }, "retries": 0 }
+  ],
+  "edges": [
+    { "from": "fetch-contacts", "to": "loop-contacts" },
+    { "from": "loop-contacts", "to": "send-email" }
+  ]
+}
+\`\`\`
+
+Generate a single workflow DAG that fulfills the user's description. Use the create_workflow tool to return the result.`;
+}
+
+export function buildRetryUserMessage(
+  originalDescription: string,
+  validationErrors: Array<{ field: string; message: string }>,
+): string {
+  const errorList = validationErrors
+    .map((e) => `- ${e.field}: ${e.message}`)
+    .join("\n");
+
+  return `The DAG you generated was invalid. Fix these errors and try again:
+
+${errorList}
+
+Original request: ${originalDescription}`;
+}

--- a/src/lib/service-catalog.ts
+++ b/src/lib/service-catalog.ts
@@ -1,0 +1,123 @@
+export interface ServiceInfo {
+  name: string;
+  description: string;
+  keyEndpoints: string[];
+}
+
+export const SERVICE_CATALOG: ServiceInfo[] = [
+  {
+    name: "campaign",
+    description: "Campaign lifecycle: gate-check (budget/volume validation), start-run (creates execution run), end-run (finalizes run, auto-retriggers if budget remains)",
+    keyEndpoints: ["POST /internal/gate-check", "POST /internal/start-run", "POST /internal/end-run"],
+  },
+  {
+    name: "lead",
+    description: "Lead buffer management: push leads, pull next lead for outreach, search leads",
+    keyEndpoints: ["POST /buffer/next", "POST /buffer/push", "GET /leads"],
+  },
+  {
+    name: "brand",
+    description: "Brand intelligence: company profiles, sales profiles, tone of voice, value propositions",
+    keyEndpoints: ["GET /brands/:id", "POST /sales-profile"],
+  },
+  {
+    name: "content-generation",
+    description: "AI-powered content generation: emails, subject lines using stored prompt templates",
+    keyEndpoints: ["POST /generate", "POST /generate/content"],
+  },
+  {
+    name: "email-gateway",
+    description: "Low-level email sending via configured provider (Postmark, SES)",
+    keyEndpoints: ["POST /send"],
+  },
+  {
+    name: "transactional-email",
+    description: "Template-based transactional emails by eventType (welcome, confirmation, etc.)",
+    keyEndpoints: ["POST /send", "GET /stats"],
+  },
+  {
+    name: "runs",
+    description: "Execution tracking: create runs, add costs, mark complete/failed",
+    keyEndpoints: ["POST /runs/start", "POST /runs/end", "POST /runs/:id/costs"],
+  },
+  {
+    name: "costs",
+    description: "Unit price registry for cost tracking",
+    keyEndpoints: ["GET /prices"],
+  },
+  {
+    name: "key",
+    description: "API key management: per-app BYOK secrets (Stripe keys, etc.)",
+    keyEndpoints: ["POST /internal/app-keys", "GET /internal/app-keys/:provider/decrypt"],
+  },
+  {
+    name: "client",
+    description: "User/contact management: CRUD users and contacts for an app",
+    keyEndpoints: ["POST /users", "GET /users", "PUT /users/:id"],
+  },
+  {
+    name: "stripe",
+    description: "Stripe operations: products, prices, checkout sessions, coupons",
+    keyEndpoints: ["POST /products", "POST /prices", "POST /checkout-sessions"],
+  },
+  {
+    name: "twilio",
+    description: "SMS sending via Twilio",
+    keyEndpoints: ["POST /send"],
+  },
+  {
+    name: "instantly",
+    description: "Cold email sending via Instantly.ai platform",
+    keyEndpoints: ["POST /send"],
+  },
+  {
+    name: "reply-qualification",
+    description: "AI classification of email replies: interested, not interested, bounce, etc.",
+    keyEndpoints: ["POST /qualify"],
+  },
+  {
+    name: "outlets",
+    description: "Media outlet database for PR outreach: find relevant outlets by topic/industry",
+    keyEndpoints: ["GET /outlets", "GET /outlets/:id"],
+  },
+  {
+    name: "journalists",
+    description: "Journalist database for PR outreach: find and rank journalists by outlet",
+    keyEndpoints: ["GET /journalists", "GET /journalists/:id"],
+  },
+  {
+    name: "articles",
+    description: "Article database: journalist articles for ranking and context",
+    keyEndpoints: ["GET /articles"],
+  },
+  {
+    name: "press-kits",
+    description: "Press kit management: generate/cache press kits, return public URL",
+    keyEndpoints: ["GET /press-kits/:id", "POST /press-kits"],
+  },
+  {
+    name: "scraping",
+    description: "Web scraping: extract structured data from URLs",
+    keyEndpoints: ["POST /scrape"],
+  },
+  {
+    name: "apollo",
+    description: "Apollo.io integration: people search, enrichment",
+    keyEndpoints: ["POST /search", "POST /enrich"],
+  },
+  {
+    name: "ahref",
+    description: "Ahrefs SEO data: backlinks, domain rating",
+    keyEndpoints: ["POST /analyze"],
+  },
+];
+
+export function getServiceCatalogForPrompt(filterServices?: string[]): string {
+  const services = filterServices
+    ? SERVICE_CATALOG.filter((s) => filterServices.includes(s.name))
+    : SERVICE_CATALOG;
+
+  return services
+    .map((s) => `- **${s.name}**: ${s.description}\n  Endpoints: ${s.keyEndpoints.join(", ")}`)
+    .join("\n");
+}

--- a/src/lib/workflow-generator.ts
+++ b/src/lib/workflow-generator.ts
@@ -1,0 +1,143 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { validateDAG, type DAG } from "./dag-validator.js";
+import {
+  buildSystemPrompt,
+  buildRetryUserMessage,
+  DAG_GENERATION_TOOL,
+} from "./prompt-templates.js";
+
+export interface GenerateWorkflowInput {
+  description: string;
+  hints?: {
+    services?: string[];
+    nodeTypes?: string[];
+    expectedInputs?: string[];
+  };
+}
+
+export interface GenerateWorkflowResult {
+  dag: DAG;
+  category: string;
+  channel: string;
+  audienceType: string;
+  description: string;
+}
+
+const MAX_RETRIES = 2;
+const MODEL = "claude-sonnet-4-20250514";
+
+let anthropicClient: Anthropic | null = null;
+
+function getAnthropicClient(): Anthropic {
+  if (!anthropicClient) {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) throw new Error("ANTHROPIC_API_KEY is not set");
+    anthropicClient = new Anthropic({ apiKey });
+  }
+  return anthropicClient;
+}
+
+/** Exported for testing — allows injecting a mock client */
+export function setAnthropicClient(client: Anthropic | null): void {
+  anthropicClient = client;
+}
+
+export async function generateWorkflow(
+  input: GenerateWorkflowInput,
+): Promise<GenerateWorkflowResult> {
+  const client = getAnthropicClient();
+  const systemPrompt = buildSystemPrompt(input.hints?.services);
+
+  let userMessage = input.description;
+  if (input.hints?.services?.length) {
+    userMessage += `\n\nRelevant services: ${input.hints.services.join(", ")}`;
+  }
+  if (input.hints?.nodeTypes?.length) {
+    userMessage += `\nPreferred node types: ${input.hints.nodeTypes.join(", ")}`;
+  }
+  if (input.hints?.expectedInputs?.length) {
+    userMessage += `\nExpected flow_input fields: ${input.hints.expectedInputs.join(", ")}`;
+  }
+
+  const messages: Anthropic.Messages.MessageParam[] = [
+    { role: "user", content: userMessage },
+  ];
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const response = await client.messages.create({
+      model: MODEL,
+      max_tokens: 4096,
+      system: systemPrompt,
+      messages,
+      tools: [DAG_GENERATION_TOOL],
+      tool_choice: { type: "tool", name: "create_workflow" },
+    });
+
+    const toolUse = response.content.find(
+      (block): block is Anthropic.Messages.ToolUseBlock =>
+        block.type === "tool_use" && block.name === "create_workflow",
+    );
+
+    if (!toolUse) {
+      throw new Error("LLM did not return a tool use response");
+    }
+
+    const result = toolUse.input as {
+      category: string;
+      channel: string;
+      audienceType: string;
+      description: string;
+      dag: DAG;
+    };
+
+    const validation = validateDAG(result.dag);
+
+    if (validation.valid) {
+      return {
+        dag: result.dag,
+        category: result.category,
+        channel: result.channel,
+        audienceType: result.audienceType,
+        description: result.description,
+      };
+    }
+
+    if (attempt < MAX_RETRIES) {
+      messages.push({
+        role: "assistant",
+        content: response.content,
+      });
+      messages.push({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: toolUse.id,
+            is_error: true,
+            content: buildRetryUserMessage(input.description, validation.errors),
+          },
+        ],
+      });
+    } else {
+      throw new GenerationValidationError(
+        "Generated DAG is invalid after retries",
+        validation.errors,
+      );
+    }
+  }
+
+  throw new Error("Unexpected: generation loop exited without result");
+}
+
+export class GenerationValidationError extends Error {
+  public readonly validationErrors: Array<{ field: string; message: string }>;
+
+  constructor(
+    message: string,
+    errors: Array<{ field: string; message: string }>,
+  ) {
+    super(message);
+    this.name = "GenerationValidationError";
+    this.validationErrors = errors;
+  }
+}

--- a/tests/integration/generate-workflow.test.ts
+++ b/tests/integration/generate-workflow.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { VALID_LINEAR_DAG } from "../helpers/fixtures.js";
+
+// Mock DB (same pattern as workflows.test.ts)
+const mockDbRows: Record<string, unknown>[] = [];
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    insert: () => ({
+      values: (row: Record<string, unknown>) => {
+        const newRow = {
+          id: "wf-" + Math.random().toString(36).slice(2, 10),
+          ...row,
+          windmillWorkspace: row.windmillWorkspace ?? "prod",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+        mockDbRows.push(newRow);
+        return {
+          returning: () => Promise.resolve([newRow]),
+        };
+      },
+    }),
+    select: () => ({
+      from: () => ({
+        where: () => {
+          return Promise.resolve(mockDbRows);
+        },
+      }),
+    }),
+    update: () => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => {
+          const row = mockDbRows[mockDbRows.length - 1];
+          if (row) Object.assign(row, values);
+          return {
+            returning: () => Promise.resolve([{ ...row, ...values }]),
+          };
+        },
+      }),
+    }),
+  },
+  sql: {
+    end: () => Promise.resolve(),
+  },
+}));
+
+// Mock Windmill client
+vi.mock("../../src/lib/windmill-client.js", () => ({
+  getWindmillClient: () => ({
+    createFlow: vi.fn().mockResolvedValue("f/workflows/test/flow"),
+    updateFlow: vi.fn().mockResolvedValue(undefined),
+    deleteFlow: vi.fn().mockResolvedValue(undefined),
+    getFlow: vi.fn().mockResolvedValue({ path: "f/workflows/test/flow" }),
+    healthCheck: vi.fn().mockResolvedValue(true),
+  }),
+  WindmillClient: vi.fn(),
+  resetWindmillClient: vi.fn(),
+}));
+
+// Mock the workflow generator
+const mockGenerateWorkflow = vi.fn();
+vi.mock("../../src/lib/workflow-generator.js", () => {
+  class MockGenerationValidationError extends Error {
+    validationErrors: unknown[];
+    constructor(msg: string, errors: unknown[]) {
+      super(msg);
+      this.name = "GenerationValidationError";
+      this.validationErrors = errors;
+    }
+  }
+  return {
+    generateWorkflow: (...args: unknown[]) => mockGenerateWorkflow(...args),
+    GenerationValidationError: MockGenerationValidationError,
+  };
+});
+
+import supertest from "supertest";
+import app from "../../src/index.js";
+
+const request = supertest(app);
+const AUTH = { "x-api-key": "test-api-key" };
+
+describe("POST /workflows/generate", () => {
+  beforeEach(() => {
+    mockDbRows.length = 0;
+    mockGenerateWorkflow.mockReset();
+  });
+
+  it("generates and deploys a workflow from description", async () => {
+    mockGenerateWorkflow.mockResolvedValueOnce({
+      dag: VALID_LINEAR_DAG,
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      description: "Search leads, generate email, send",
+    });
+
+    const res = await request
+      .post("/workflows/generate")
+      .set(AUTH)
+      .send({
+        appId: "test-app",
+        orgId: "org-1",
+        description: "I want a cold email outreach workflow that finds leads and sends emails",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.workflow).toBeDefined();
+    expect(res.body.workflow.action).toBe("created");
+    expect(res.body.workflow.category).toBe("sales");
+    expect(res.body.workflow.name).toContain("sales-email-cold-outreach");
+    expect(res.body.dag).toEqual(VALID_LINEAR_DAG);
+    expect(res.body.generatedDescription).toBe("Search leads, generate email, send");
+    expect(res.body.category).toBe("sales");
+    expect(res.body.channel).toBe("email");
+    expect(res.body.audienceType).toBe("cold-outreach");
+  });
+
+  it("returns 422 when LLM generates invalid DAG after retries", async () => {
+    const { GenerationValidationError } = await import("../../src/lib/workflow-generator.js");
+    mockGenerateWorkflow.mockRejectedValueOnce(
+      new GenerationValidationError("Generated DAG is invalid after retries", [
+        { field: "nodes", message: 'Unknown node type: "bad-type"' },
+      ]),
+    );
+
+    const res = await request
+      .post("/workflows/generate")
+      .set(AUTH)
+      .send({
+        appId: "test-app",
+        orgId: "org-1",
+        description: "A workflow that does something impossible with bad types",
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("invalid");
+    expect(res.body.details).toBeDefined();
+  });
+
+  it("requires authentication", async () => {
+    const res = await request.post("/workflows/generate").send({
+      appId: "test-app",
+      orgId: "org-1",
+      description: "test workflow description here",
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("validates request body (missing description)", async () => {
+    const res = await request
+      .post("/workflows/generate")
+      .set(AUTH)
+      .send({ appId: "test-app", orgId: "org-1" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("validates description minimum length", async () => {
+    const res = await request
+      .post("/workflows/generate")
+      .set(AUTH)
+      .send({ appId: "test-app", orgId: "org-1", description: "hi" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("passes hints through to generator", async () => {
+    mockGenerateWorkflow.mockResolvedValueOnce({
+      dag: VALID_LINEAR_DAG,
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      description: "Test",
+    });
+
+    await request
+      .post("/workflows/generate")
+      .set(AUTH)
+      .send({
+        appId: "test-app",
+        orgId: "org-1",
+        description: "Cold email outreach with lead search",
+        hints: { services: ["lead", "email-gateway"] },
+      });
+
+    expect(mockGenerateWorkflow).toHaveBeenCalledWith({
+      description: "Cold email outreach with lead search",
+      hints: { services: ["lead", "email-gateway"] },
+    });
+  });
+
+  it("returns 500 when LLM throws unexpected error", async () => {
+    mockGenerateWorkflow.mockRejectedValueOnce(
+      new Error("ANTHROPIC_API_KEY is not set"),
+    );
+
+    const res = await request
+      .post("/workflows/generate")
+      .set(AUTH)
+      .send({
+        appId: "test-app",
+        orgId: "org-1",
+        description: "Some workflow description for testing errors",
+      });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain("ANTHROPIC_API_KEY");
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -5,4 +5,5 @@ process.env.WORKFLOW_SERVICE_API_KEY = "test-api-key";
 process.env.WINDMILL_SERVER_URL = "http://localhost:8000";
 process.env.WINDMILL_SERVER_API_KEY = "test-windmill-token";
 process.env.WINDMILL_SERVER_WORKSPACE = "test";
+process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
 process.env.NODE_ENV = "test";

--- a/tests/unit/service-catalog.test.ts
+++ b/tests/unit/service-catalog.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { SERVICE_CATALOG, getServiceCatalogForPrompt } from "../../src/lib/service-catalog.js";
+
+describe("SERVICE_CATALOG", () => {
+  it("has entries for all key services", () => {
+    const names = SERVICE_CATALOG.map((s) => s.name);
+    expect(names).toContain("campaign");
+    expect(names).toContain("lead");
+    expect(names).toContain("content-generation");
+    expect(names).toContain("email-gateway");
+    expect(names).toContain("stripe");
+    expect(names).toContain("runs");
+    expect(names).toContain("brand");
+    expect(names).toContain("outlets");
+    expect(names).toContain("journalists");
+  });
+
+  it("every entry has name, description, and keyEndpoints", () => {
+    for (const service of SERVICE_CATALOG) {
+      expect(service.name).toBeTruthy();
+      expect(service.description).toBeTruthy();
+      expect(service.keyEndpoints.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("getServiceCatalogForPrompt", () => {
+  it("returns all services when no filter", () => {
+    const text = getServiceCatalogForPrompt();
+    expect(text).toContain("campaign");
+    expect(text).toContain("stripe");
+    expect(text).toContain("lead");
+  });
+
+  it("filters to specified services", () => {
+    const text = getServiceCatalogForPrompt(["campaign", "lead"]);
+    expect(text).toContain("campaign");
+    expect(text).toContain("lead");
+    expect(text).not.toContain("stripe");
+  });
+
+  it("returns empty string for empty filter", () => {
+    const text = getServiceCatalogForPrompt([]);
+    expect(text).toBe("");
+  });
+});

--- a/tests/unit/workflow-generator.test.ts
+++ b/tests/unit/workflow-generator.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type Anthropic from "@anthropic-ai/sdk";
+import {
+  generateWorkflow,
+  setAnthropicClient,
+  GenerationValidationError,
+} from "../../src/lib/workflow-generator.js";
+import {
+  buildSystemPrompt,
+  buildRetryUserMessage,
+} from "../../src/lib/prompt-templates.js";
+import { VALID_LINEAR_DAG } from "../helpers/fixtures.js";
+
+// --- Prompt building tests ---
+
+describe("buildSystemPrompt", () => {
+  it("includes DAG format documentation", () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain("DAG Format");
+    expect(prompt).toContain("http.call");
+    expect(prompt).toContain("$ref:flow_input");
+    expect(prompt).toContain("$ref:node-id.output");
+  });
+
+  it("includes all dimension enum values", () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain('"sales"');
+    expect(prompt).toContain('"pr"');
+    expect(prompt).toContain('"email"');
+    expect(prompt).toContain('"cold-outreach"');
+  });
+
+  it("includes service catalog", () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain("campaign");
+    expect(prompt).toContain("lead");
+    expect(prompt).toContain("content-generation");
+  });
+
+  it("filters service catalog when filterServices is provided", () => {
+    const prompt = buildSystemPrompt(["campaign", "lead"]);
+    expect(prompt).toContain("campaign");
+    expect(prompt).toContain("lead");
+    // stripe should not appear in the services section
+    // but may appear in node types; check services section specifically
+    expect(prompt).toContain("**campaign**");
+    expect(prompt).toContain("**lead**");
+  });
+
+  it("includes example DAGs", () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain("Example");
+    expect(prompt).toContain("gate-check");
+    expect(prompt).toContain("fetch-lead");
+  });
+
+  it("includes special config keys documentation", () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain("stopAfterIf");
+    expect(prompt).toContain("skipIf");
+    expect(prompt).toContain("validateResponse");
+    expect(prompt).toContain("retries");
+  });
+
+  it("includes node type registry", () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain('"http.call"');
+    expect(prompt).toContain('"condition"');
+    expect(prompt).toContain('"wait"');
+    expect(prompt).toContain('"for-each"');
+  });
+});
+
+describe("buildRetryUserMessage", () => {
+  it("includes validation errors and original description", () => {
+    const msg = buildRetryUserMessage("Send an email to leads", [
+      { field: "nodes[bad-ref].inputMapping.data", message: 'References unknown node: "nonexistent"' },
+      { field: "edges", message: "Workflow contains a cycle" },
+    ]);
+    expect(msg).toContain("References unknown node");
+    expect(msg).toContain("cycle");
+    expect(msg).toContain("Send an email to leads");
+  });
+});
+
+// --- Generator tests ---
+
+function createMockToolResponse(dag: unknown, overrides?: Record<string, unknown>) {
+  return {
+    id: "msg_test",
+    type: "message" as const,
+    role: "assistant" as const,
+    model: "claude-sonnet-4-20250514",
+    stop_reason: "tool_use" as const,
+    content: [
+      {
+        type: "tool_use" as const,
+        id: "tool_test_" + Math.random().toString(36).slice(2, 6),
+        name: "create_workflow",
+        input: {
+          category: "sales",
+          channel: "email",
+          audienceType: "cold-outreach",
+          description: "Generated workflow description",
+          dag,
+          ...overrides,
+        },
+      },
+    ],
+    usage: { input_tokens: 100, output_tokens: 200, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+  };
+}
+
+describe("generateWorkflow", () => {
+  let mockCreate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockCreate = vi.fn();
+    setAnthropicClient({
+      messages: { create: mockCreate },
+    } as unknown as Anthropic);
+  });
+
+  afterEach(() => {
+    setAnthropicClient(null);
+  });
+
+  it("returns valid DAG on first attempt", async () => {
+    mockCreate.mockResolvedValueOnce(
+      createMockToolResponse(VALID_LINEAR_DAG),
+    );
+
+    const result = await generateWorkflow({
+      description: "Search leads and send cold emails",
+    });
+
+    expect(result.dag).toEqual(VALID_LINEAR_DAG);
+    expect(result.category).toBe("sales");
+    expect(result.channel).toBe("email");
+    expect(result.audienceType).toBe("cold-outreach");
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries with error feedback when DAG is invalid", async () => {
+    const invalidDag = {
+      nodes: [{ id: "a", type: "unknown-type-xyz" }],
+      edges: [],
+    };
+
+    mockCreate.mockResolvedValueOnce(createMockToolResponse(invalidDag));
+    mockCreate.mockResolvedValueOnce(createMockToolResponse(VALID_LINEAR_DAG));
+
+    const result = await generateWorkflow({
+      description: "Search leads and send cold emails",
+    });
+
+    expect(result.dag).toEqual(VALID_LINEAR_DAG);
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+
+    // Verify retry message includes error context
+    const retryCall = mockCreate.mock.calls[1][0];
+    const lastMessage = retryCall.messages[retryCall.messages.length - 1];
+    expect(lastMessage.content[0].is_error).toBe(true);
+  });
+
+  it("throws GenerationValidationError after max retries", async () => {
+    const invalidDag = {
+      nodes: [{ id: "a", type: "unknown-type-xyz" }],
+      edges: [],
+    };
+
+    mockCreate.mockResolvedValue(createMockToolResponse(invalidDag));
+
+    await expect(
+      generateWorkflow({ description: "Bad workflow" }),
+    ).rejects.toThrow(GenerationValidationError);
+
+    // 1 initial + 2 retries = 3 calls
+    expect(mockCreate).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws if ANTHROPIC_API_KEY is not set", async () => {
+    setAnthropicClient(null);
+    const saved = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+
+    await expect(
+      generateWorkflow({ description: "test workflow" }),
+    ).rejects.toThrow("ANTHROPIC_API_KEY is not set");
+
+    process.env.ANTHROPIC_API_KEY = saved;
+  });
+
+  it("passes hints to the user message", async () => {
+    mockCreate.mockResolvedValueOnce(createMockToolResponse(VALID_LINEAR_DAG));
+
+    await generateWorkflow({
+      description: "Send email to leads",
+      hints: {
+        services: ["lead", "email-gateway"],
+        expectedInputs: ["campaignId"],
+      },
+    });
+
+    const call = mockCreate.mock.calls[0][0];
+    const userMsg = call.messages[0].content;
+    expect(userMsg).toContain("lead, email-gateway");
+    expect(userMsg).toContain("campaignId");
+  });
+
+  it("throws if LLM returns no tool use block", async () => {
+    mockCreate.mockResolvedValueOnce({
+      id: "msg_test",
+      type: "message",
+      role: "assistant",
+      model: "claude-sonnet-4-20250514",
+      content: [{ type: "text", text: "I cannot generate a workflow" }],
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+
+    await expect(
+      generateWorkflow({ description: "test workflow" }),
+    ).rejects.toThrow("LLM did not return a tool use response");
+  });
+
+  it("includes system prompt with DAG schema", async () => {
+    mockCreate.mockResolvedValueOnce(createMockToolResponse(VALID_LINEAR_DAG));
+
+    await generateWorkflow({ description: "test workflow" });
+
+    const call = mockCreate.mock.calls[0][0];
+    expect(call.system).toContain("DAG Format");
+    expect(call.system).toContain("http.call");
+  });
+
+  it("uses tool_choice to force structured output", async () => {
+    mockCreate.mockResolvedValueOnce(createMockToolResponse(VALID_LINEAR_DAG));
+
+    await generateWorkflow({ description: "test workflow" });
+
+    const call = mockCreate.mock.calls[0][0];
+    expect(call.tool_choice).toEqual({ type: "tool", name: "create_workflow" });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `POST /workflows/generate` endpoint that transforms natural language descriptions into valid, deployed DAG workflows using Claude (Anthropic SDK)
- LLM infers the 3 dimension enums (category, channel, audienceType) and generates a complete DAG with proper node types, input mappings, and retry configs
- Uses Claude tool_use for structured JSON output with validation retry loop (up to 2 retries with error feedback)
- Auto-deploys generated workflows to DB + Windmill, returns workflow name + DAG to caller

## New files
- `src/lib/service-catalog.ts` — static service descriptions embedded in LLM prompt
- `src/lib/prompt-templates.ts` — system prompt builder, tool schema, retry message builder
- `src/lib/workflow-generator.ts` — LLM orchestration with Anthropic SDK + validation retry loop

## Test plan
- [x] Unit tests: service catalog, prompt building, generator with mocked LLM (valid/invalid/retry scenarios)
- [x] Integration tests: endpoint returns 200/400/422/500 correctly, passes hints, requires auth
- [x] All 189 tests passing (143 unit + 46 integration)
- [x] TypeScript builds cleanly
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)