### PR TITLE
feat: add required-providers endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -321,6 +321,59 @@
           "dag"
         ]
       },
+      "ServiceEndpoint": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "type": "string",
+            "description": "Service name (e.g. 'apollo', 'stripe')."
+          },
+          "method": {
+            "type": "string",
+            "description": "HTTP method (e.g. 'POST', 'GET')."
+          },
+          "path": {
+            "type": "string",
+            "description": "Endpoint path (e.g. '/leads/search')."
+          }
+        },
+        "required": [
+          "service",
+          "method",
+          "path"
+        ]
+      },
+      "ProviderRequirementsResponse": {
+        "type": "object",
+        "properties": {
+          "endpoints": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServiceEndpoint"
+            },
+            "description": "The http.call endpoints extracted from the workflow DAG."
+          },
+          "requirements": {
+            "type": "array",
+            "items": {
+              "nullable": true
+            },
+            "description": "Provider requirements returned by key-service."
+          },
+          "providers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Unique provider names required by this workflow (e.g. ['apollo', 'firecrawl'])."
+          }
+        },
+        "required": [
+          "endpoints",
+          "requirements",
+          "providers"
+        ]
+      },
       "UpdateWorkflowRequest": {
         "type": "object",
         "properties": {
@@ -1054,6 +1107,63 @@
                   "required": [
                     "message"
                   ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{id}/required-providers": {
+      "get": {
+        "summary": "Get required BYOK providers for a workflow",
+        "description": "Analyzes the workflow DAG to extract all http.call endpoints, then queries key-service to determine which external providers (and their API keys) are needed to execute the workflow.",
+        "tags": [
+          "Workflows"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Provider requirements",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderRequirementsResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workflow not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Key service unavailable or returned an error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/src/lib/extract-http-endpoints.ts
+++ b/src/lib/extract-http-endpoints.ts
@@ -1,0 +1,35 @@
+import type { DAG } from "./dag-validator.js";
+
+export interface HttpEndpoint {
+  service: string;
+  method: string;
+  path: string;
+}
+
+export function extractHttpEndpoints(dag: DAG): HttpEndpoint[] {
+  const endpoints: HttpEndpoint[] = [];
+  const seen = new Set<string>();
+
+  for (const node of dag.nodes) {
+    if (node.type !== "http.call") continue;
+    if (!node.config) continue;
+
+    const { service, method, path } = node.config;
+
+    if (
+      typeof service !== "string" ||
+      typeof method !== "string" ||
+      typeof path !== "string"
+    ) {
+      continue;
+    }
+
+    const key = `${service}|${method}|${path}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    endpoints.push({ service, method, path });
+  }
+
+  return endpoints;
+}

--- a/src/lib/key-service-client.ts
+++ b/src/lib/key-service-client.ts
@@ -1,0 +1,38 @@
+import type { HttpEndpoint } from "./extract-http-endpoints.js";
+
+export interface ProviderRequirementsResponse {
+  requirements: unknown[];
+  providers: string[];
+}
+
+export async function fetchProviderRequirements(
+  endpoints: HttpEndpoint[]
+): Promise<ProviderRequirementsResponse> {
+  const baseUrl = process.env.KEY_SERVICE_URL;
+  const apiKey = process.env.KEY_SERVICE_API_KEY;
+
+  if (!baseUrl || !apiKey) {
+    throw new Error(
+      "KEY_SERVICE_URL and KEY_SERVICE_API_KEY must be set to fetch provider requirements"
+    );
+  }
+
+  const url = `${baseUrl.replace(/\/$/, "")}/internal/provider-requirements`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+    },
+    body: JSON.stringify({ endpoints }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `key-service error: POST /internal/provider-requirements -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  return res.json() as Promise<ProviderRequirementsResponse>;
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,4 +6,6 @@ process.env.WINDMILL_SERVER_URL = "http://localhost:8000";
 process.env.WINDMILL_SERVER_API_KEY = "test-windmill-token";
 process.env.WINDMILL_SERVER_WORKSPACE = "test";
 process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+process.env.KEY_SERVICE_URL = "http://localhost:4000";
+process.env.KEY_SERVICE_API_KEY = "test-key-svc-key";
 process.env.NODE_ENV = "test";

--- a/tests/unit/extract-http-endpoints.test.ts
+++ b/tests/unit/extract-http-endpoints.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { extractHttpEndpoints } from "../../src/lib/extract-http-endpoints.js";
+import {
+  VALID_LINEAR_DAG,
+  DAG_WITH_HTTP_CALL,
+  DAG_WITH_HTTP_CALL_CHAIN,
+} from "../helpers/fixtures.js";
+
+describe("extractHttpEndpoints", () => {
+  it("returns empty array for DAG with no http.call nodes", () => {
+    const result = extractHttpEndpoints(VALID_LINEAR_DAG);
+    expect(result).toEqual([]);
+  });
+
+  it("extracts single http.call endpoint", () => {
+    const result = extractHttpEndpoints(DAG_WITH_HTTP_CALL);
+    expect(result).toEqual([
+      { service: "stripe", method: "GET", path: "/products/prod_123" },
+    ]);
+  });
+
+  it("extracts multiple http.call endpoints from a chain", () => {
+    const result = extractHttpEndpoints(DAG_WITH_HTTP_CALL_CHAIN);
+    expect(result).toEqual([
+      { service: "client", method: "POST", path: "/users" },
+      { service: "transactional-email", method: "POST", path: "/send" },
+    ]);
+  });
+
+  it("deduplicates identical endpoints", () => {
+    const dag = {
+      nodes: [
+        { id: "call-1", type: "http.call", config: { service: "stripe", method: "POST", path: "/products" } },
+        { id: "call-2", type: "http.call", config: { service: "stripe", method: "POST", path: "/products" } },
+      ],
+      edges: [],
+    };
+    const result = extractHttpEndpoints(dag);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ service: "stripe", method: "POST", path: "/products" });
+  });
+
+  it("keeps endpoints with different methods as separate", () => {
+    const dag = {
+      nodes: [
+        { id: "call-1", type: "http.call", config: { service: "stripe", method: "GET", path: "/products" } },
+        { id: "call-2", type: "http.call", config: { service: "stripe", method: "POST", path: "/products" } },
+      ],
+      edges: [],
+    };
+    const result = extractHttpEndpoints(dag);
+    expect(result).toHaveLength(2);
+  });
+
+  it("skips http.call nodes with missing config", () => {
+    const dag = {
+      nodes: [
+        { id: "bad", type: "http.call" },
+        { id: "good", type: "http.call", config: { service: "stripe", method: "GET", path: "/products" } },
+      ],
+      edges: [],
+    };
+    const result = extractHttpEndpoints(dag);
+    expect(result).toHaveLength(1);
+  });
+
+  it("skips http.call nodes with non-string config values", () => {
+    const dag = {
+      nodes: [
+        { id: "bad", type: "http.call", config: { service: 123, method: "GET", path: "/x" } },
+      ],
+      edges: [],
+    };
+    const result = extractHttpEndpoints(dag);
+    expect(result).toEqual([]);
+  });
+
+  it("ignores non-http.call nodes even if they have service in config", () => {
+    const dag = {
+      nodes: [
+        { id: "lead", type: "lead-service", config: { service: "apollo", method: "POST", path: "/search" } },
+        { id: "call", type: "http.call", config: { service: "stripe", method: "GET", path: "/products" } },
+      ],
+      edges: [],
+    };
+    const result = extractHttpEndpoints(dag);
+    expect(result).toHaveLength(1);
+    expect(result[0].service).toBe("stripe");
+  });
+});

--- a/tests/unit/key-service-client.test.ts
+++ b/tests/unit/key-service-client.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchProviderRequirements } from "../../src/lib/key-service-client.js";
+
+describe("fetchProviderRequirements", () => {
+  const originalUrl = process.env.KEY_SERVICE_URL;
+  const originalKey = process.env.KEY_SERVICE_API_KEY;
+
+  beforeEach(() => {
+    process.env.KEY_SERVICE_URL = "http://localhost:4000";
+    process.env.KEY_SERVICE_API_KEY = "test-key-svc-key";
+  });
+
+  afterEach(() => {
+    process.env.KEY_SERVICE_URL = originalUrl;
+    process.env.KEY_SERVICE_API_KEY = originalKey;
+    vi.restoreAllMocks();
+  });
+
+  it("throws if KEY_SERVICE_URL is not set", async () => {
+    delete process.env.KEY_SERVICE_URL;
+    await expect(fetchProviderRequirements([])).rejects.toThrow(
+      "KEY_SERVICE_URL and KEY_SERVICE_API_KEY must be set"
+    );
+  });
+
+  it("throws if KEY_SERVICE_API_KEY is not set", async () => {
+    delete process.env.KEY_SERVICE_API_KEY;
+    await expect(fetchProviderRequirements([])).rejects.toThrow(
+      "KEY_SERVICE_URL and KEY_SERVICE_API_KEY must be set"
+    );
+  });
+
+  it("calls key-service and returns the response", async () => {
+    const mockResponse = {
+      requirements: [{ provider: "apollo", fields: ["apiKey"] }],
+      providers: ["apollo"],
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      })
+    );
+
+    const result = await fetchProviderRequirements([
+      { service: "apollo", method: "POST", path: "/search" },
+    ]);
+
+    expect(result).toEqual(mockResponse);
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:4000/internal/provider-requirements",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "x-api-key": "test-key-svc-key",
+        }),
+      })
+    );
+  });
+
+  it("strips trailing slash from KEY_SERVICE_URL", async () => {
+    process.env.KEY_SERVICE_URL = "http://localhost:4000/";
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ requirements: [], providers: [] }),
+      })
+    );
+
+    await fetchProviderRequirements([]);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:4000/internal/provider-requirements",
+      expect.anything()
+    );
+  });
+
+  it("throws on non-2xx response from key-service", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        text: () => Promise.resolve("boom"),
+      })
+    );
+
+    await expect(
+      fetchProviderRequirements([
+        { service: "apollo", method: "POST", path: "/search" },
+      ])
+    ).rejects.toThrow("key-service error:");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `GET /workflows/:id/required-providers` — dynamically computes which BYOK providers a workflow needs
- Extracts `{ service, method, path }` from all `http.call` nodes in the DAG
- Proxies them to key-service's new `POST /internal/provider-requirements` endpoint
- Returns `{ endpoints, requirements, providers }` — no DB storage, always fresh

## Test plan
- [x] Unit tests for `extractHttpEndpoints` (8 cases: empty, single, chain, dedup, malformed, non-string config)
- [x] Unit tests for `fetchProviderRequirements` (5 cases: missing env vars, success, trailing slash, non-2xx)
- [x] Integration tests for the endpoint (6 cases: 200 with providers, 200 empty, 404, 502 key-service error, 502 missing env, 401)
- [x] All 208 tests pass
- [x] TypeScript compiles clean
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)