### PR TITLE
fix: use orgId instead of appId in PUT /workflows/deploy

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -665,6 +665,11 @@
             "minLength": 1,
             "description": "Your application identifier. Workflows are scoped to (appId + signature). Use the same appId when executing. This is idempotent — deploying the same DAG updates the existing workflow."
           },
+          "orgId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Organization ID that owns these workflows. If omitted, falls back to appId for backward compatibility."
+          },
           "workflows": {
             "type": "array",
             "items": {

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -297,6 +297,7 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
       .where(eq(workflows.appId, body.appId));
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
 
+    const orgId = body.orgId ?? body.appId;
     const results: { id: string; name: string; category: string; channel: string; audienceType: string; signature: string; signatureName: string; action: "created" | "updated" }[] = [];
 
     for (const wf of body.workflows) {
@@ -335,6 +336,7 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
         const [updated] = await db
           .update(workflows)
           .set({
+            orgId,
             description: wf.description ?? existing.description,
             category: wf.category,
             channel: wf.channel,
@@ -383,7 +385,7 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
           .insert(workflows)
           .values({
             appId: body.appId,
-            orgId: body.appId,
+            orgId,
             name,
             displayName: name,
             description: wf.description,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -215,6 +215,9 @@ export const DeployWorkflowsSchema = z
       "Your application identifier. Workflows are scoped to (appId + signature). " +
       "Use the same appId when executing. This is idempotent — deploying the same DAG updates the existing workflow."
     ),
+    orgId: z.string().min(1).optional().describe(
+      "Organization ID that owns these workflows. If omitted, falls back to appId for backward compatibility."
+    ),
     workflows: z.array(DeployWorkflowItemSchema).min(1).describe("The workflows to deploy."),
   })
   .openapi("DeployWorkflowsRequest");


### PR DESCRIPTION
## Summary
- **Bug**: `PUT /workflows/deploy` used `appId` as the `org_id` when inserting workflows into the DB, causing incorrect org_id values (e.g. `mcpfactory` instead of `org_38y0ZSEtw1lz0KtH9Kwy53jBu67`)
- **Fix**: Added optional `orgId` field to `DeployWorkflowsRequest` schema (falls back to `appId` for backward compatibility) and use it in both the create and update paths
- **DB fix**: Updated 3 affected rows in production (`workflows` table, project `old-pond-00882067`)

## Test plan
- [x] Regression test: deploy with explicit `orgId` stores correct org_id
- [x] Regression test: deploy without `orgId` falls back to `appId`
- [x] Regression test: re-deploy updates `orgId` on existing workflow
- [x] All 211 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)