### PR TITLE
refactor: replace Clerk IDs with internal orgId/userId

### DIFF
--- a/scripts/nodes/brand-intel.ts
+++ b/scripts/nodes/brand-intel.ts
@@ -17,7 +17,7 @@ export async function main(
     {
       headers: {
         "x-api-key": apiKey,
-        "x-clerk-org-id": context.orgId,
+        "x-org-id": context.orgId,
       },
     }
   );

--- a/scripts/nodes/client-update-user.ts
+++ b/scripts/nodes/client-update-user.ts
@@ -4,7 +4,7 @@ export async function main(
   firstName?: string,
   lastName?: string,
   phone?: string,
-  clerkUserId?: string | null,
+  linkedUserId?: string | null,
   orgId?: string | null,
   metadata?: Record<string, unknown> | null,
   serviceEnvs?: Record<string, string>,
@@ -23,7 +23,7 @@ export async function main(
         "Content-Type": "application/json",
         "x-api-key": apiKey,
       },
-      body: JSON.stringify({ firstName, lastName, phone, clerkUserId, orgId, metadata }),
+      body: JSON.stringify({ firstName, lastName, phone, userId: linkedUserId, orgId, metadata }),
     }
   );
 

--- a/scripts/nodes/content-generation.ts
+++ b/scripts/nodes/content-generation.ts
@@ -23,7 +23,7 @@ export async function main(
       headers: {
         "Content-Type": "application/json",
         "x-api-key": apiKey,
-        "x-clerk-org-id": context.orgId,
+        "x-org-id": context.orgId,
       },
       body: JSON.stringify({
         contentType,

--- a/scripts/nodes/content-sentiment.ts
+++ b/scripts/nodes/content-sentiment.ts
@@ -18,7 +18,7 @@ export async function main(
       headers: {
         "Content-Type": "application/json",
         "x-api-key": apiKey,
-        "x-clerk-org-id": context.orgId,
+        "x-org-id": context.orgId,
       },
       body: JSON.stringify({ content: emailContent }),
     }

--- a/scripts/nodes/lead-service.ts
+++ b/scripts/nodes/lead-service.ts
@@ -23,7 +23,7 @@ export async function main(
       headers: {
         "Content-Type": "application/json",
         "x-api-key": apiKey,
-        "x-clerk-org-id": context.orgId,
+        "x-org-id": context.orgId,
       },
       body: JSON.stringify({
         campaignId: context.campaignId,

--- a/scripts/nodes/outbound-sending.ts
+++ b/scripts/nodes/outbound-sending.ts
@@ -25,7 +25,7 @@ export async function main(
       headers: {
         "Content-Type": "application/json",
         "x-api-key": apiKey,
-        "x-clerk-org-id": context.orgId,
+        "x-org-id": context.orgId,
       },
       body: JSON.stringify({
         type: sendType,

--- a/scripts/nodes/stripe-get-stats.ts
+++ b/scripts/nodes/stripe-get-stats.ts
@@ -1,7 +1,7 @@
 // Windmill node script — calls stripe POST /stats
 export async function main(
   runIds?: string[],
-  clerkOrgId?: string,
+  orgId?: string,
   brandId?: string,
   appId?: string,
   campaignId?: string,
@@ -20,7 +20,7 @@ export async function main(
         "Content-Type": "application/json",
         "X-API-Key": apiKey,
       },
-      body: JSON.stringify({ runIds, clerkOrgId, brandId, appId, campaignId }),
+      body: JSON.stringify({ runIds, orgId, brandId, appId, campaignId }),
     }
   );
 

--- a/scripts/nodes/transactional-email-get-stats.ts
+++ b/scripts/nodes/transactional-email-get-stats.ts
@@ -1,8 +1,8 @@
 // Windmill node script — calls transactional-email POST /stats
 export async function main(
   appId?: string,
-  clerkOrgId?: string,
-  clerkUserId?: string,
+  orgId?: string,
+  userId?: string,
   eventType?: string,
   serviceEnvs?: Record<string, string>,
 ) {
@@ -19,7 +19,7 @@ export async function main(
         "Content-Type": "application/json",
         "x-api-key": apiKey,
       },
-      body: JSON.stringify({ appId, clerkOrgId, clerkUserId, eventType }),
+      body: JSON.stringify({ appId, orgId, userId, eventType }),
     }
   );
 

--- a/scripts/nodes/transactional-email-send.ts
+++ b/scripts/nodes/transactional-email-send.ts
@@ -6,8 +6,8 @@ export async function main(
   brandId?: string,
   campaignId?: string,
   productId?: string,
-  clerkUserId?: string,
-  clerkOrgId?: string,
+  userId?: string,
+  orgId?: string,
   metadata?: Record<string, unknown>,
   serviceEnvs?: Record<string, string>,
 ) {
@@ -24,7 +24,7 @@ export async function main(
         "Content-Type": "application/json",
         "x-api-key": apiKey,
       },
-      body: JSON.stringify({ appId, eventType, recipientEmail, brandId, campaignId, productId, clerkUserId, clerkOrgId, metadata }),
+      body: JSON.stringify({ appId, eventType, recipientEmail, brandId, campaignId, productId, userId, orgId, metadata }),
     }
   );
 

--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -167,13 +167,13 @@ Prefer "http.call" over legacy named types for new workflows.
       "id": "gate-check",
       "type": "http.call",
       "config": { "service": "campaign", "method": "POST", "path": "/internal/gate-check", "stopAfterIf": "result.allowed == false" },
-      "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId", "body.clerkOrgId": "$ref:flow_input.clerkOrgId" }
+      "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId", "body.orgId": "$ref:flow_input.orgId" }
     },
     {
       "id": "start-run",
       "type": "http.call",
       "config": { "service": "campaign", "method": "POST", "path": "/internal/start-run" },
-      "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId", "body.clerkOrgId": "$ref:flow_input.clerkOrgId" }
+      "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId", "body.orgId": "$ref:flow_input.orgId" }
     },
     {
       "id": "fetch-lead",

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -333,7 +333,7 @@ export const DAG_WITH_FLOW_INPUT_REFS: DAG = {
       config: { service: "campaign", method: "POST", path: "/internal/start-run" },
       inputMapping: {
         "body.campaignId": "$ref:flow_input.campaignId",
-        "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+        "body.orgId": "$ref:flow_input.orgId",
       },
       retries: 0,
     },
@@ -349,7 +349,7 @@ export const DAG_WITH_CONFIG_RETRIES: DAG = {
       config: { service: "campaign", method: "POST", path: "/internal/start-run", retries: 0 },
       inputMapping: {
         "body.campaignId": "$ref:flow_input.campaignId",
-        "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+        "body.orgId": "$ref:flow_input.orgId",
       },
     },
   ],

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -252,7 +252,7 @@ describe("PUT /workflows/deploy", () => {
       .set(AUTH)
       .send({
         appId: "mcpfactory",
-        orgId: "org_real_clerk_id",
+        orgId: "org_test_id",
         workflows: [
           {
             ...DEPLOY_ITEM,
@@ -265,7 +265,7 @@ describe("PUT /workflows/deploy", () => {
     expect(res.status).toBe(200);
     // Verify the DB row got the correct orgId
     const inserted = mockDbRows[mockDbRows.length - 1];
-    expect(inserted.orgId).toBe("org_real_clerk_id");
+    expect(inserted.orgId).toBe("org_test_id");
     expect(inserted.appId).toBe("mcpfactory");
   });
 

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -319,7 +319,7 @@ describe("dagToOpenFlow", () => {
     const props = (result.schema as Record<string, unknown>).properties as Record<string, unknown>;
     expect(props.appId).toEqual({ type: "string", description: "Application identifier" });
     expect(props.campaignId).toEqual({ type: "string" });
-    expect(props.clerkOrgId).toEqual({ type: "string" });
+    expect(props.orgId).toEqual({ type: "string" });
   });
 
   it("declares flow_input fields from all nodes including onError handler", () => {
@@ -373,12 +373,12 @@ describe("dagToOpenFlow", () => {
       >;
       // Should NOT have flat dot-notation keys
       expect(transforms["body.campaignId"]).toBeUndefined();
-      expect(transforms["body.clerkOrgId"]).toBeUndefined();
+      expect(transforms["body.orgId"]).toBeUndefined();
       // Should have a collapsed body transform
       expect(transforms.body).toBeDefined();
       expect(transforms.body.type).toBe("javascript");
       expect(transforms.body.expr).toContain("flow_input.campaignId");
-      expect(transforms.body.expr).toContain("flow_input.clerkOrgId");
+      expect(transforms.body.expr).toContain("flow_input.orgId");
     }
   });
 

--- a/tests/unit/input-mapping.test.ts
+++ b/tests/unit/input-mapping.test.ts
@@ -115,18 +115,18 @@ describe("buildInputTransforms", () => {
   it("collapses dot-notation keys into a nested object expression", () => {
     const result = buildInputTransforms(undefined, {
       "body.campaignId": "$ref:flow_input.campaignId",
-      "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+      "body.orgId": "$ref:flow_input.orgId",
     });
 
     // Should NOT have flat dot-notation keys
     expect(result["body.campaignId"]).toBeUndefined();
-    expect(result["body.clerkOrgId"]).toBeUndefined();
+    expect(result["body.orgId"]).toBeUndefined();
 
     // Should have a single body transform with a JavaScript expression
     expect(result.body).toBeDefined();
     expect(result.body.type).toBe("javascript");
     expect(result.body.expr).toContain("flow_input.campaignId");
-    expect(result.body.expr).toContain("flow_input.clerkOrgId");
+    expect(result.body.expr).toContain("flow_input.orgId");
   });
 
   it("merges dot-notation keys with static config base", () => {


### PR DESCRIPTION
## Summary
- Replace `x-clerk-org-id` header with `x-org-id` in all 5 node scripts that call downstream services
- Rename `clerkOrgId`/`clerkUserId` params to `orgId`/`userId` in 4 node scripts (transactional-email-send, transactional-email-get-stats, stripe-get-stats, client-update-user)
- Update test fixtures, prompt templates, unit tests, and integration tests to remove all Clerk references

## Context
Clerk is a frontend implementation detail. Backend services now use internal UUIDs from client-service (`orgId`, `userId`) instead of Clerk-specific identifiers. Breaking change — no backward compat needed (dev only, no clients).

DB schema, Zod schemas, route handlers, and OpenAPI spec already used `orgId` — no migration needed there.

## Test plan
- [x] All 211 tests pass (16 test files)
- [x] Zero `clerk` references remaining in `src/`, `scripts/`, `tests/`
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)