### PR TITLE
fix: resolve Anthropic key from key-service

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -730,6 +730,14 @@
           "generatedDescription"
         ]
       },
+      "KeySource": {
+        "type": "string",
+        "enum": [
+          "app",
+          "byok"
+        ],
+        "description": "Required. Where to resolve the Anthropic API key: \"app\" or \"byok\"."
+      },
       "GenerateWorkflowHints": {
         "type": "object",
         "properties": {
@@ -770,6 +778,9 @@
             "minLength": 1,
             "description": "Organization ID."
           },
+          "keySource": {
+            "$ref": "#/components/schemas/KeySource"
+          },
           "description": {
             "type": "string",
             "minLength": 10,
@@ -782,6 +793,7 @@
         "required": [
           "appId",
           "orgId",
+          "keySource",
           "description"
         ]
       },

--- a/src/lib/workflow-generator.ts
+++ b/src/lib/workflow-generator.ts
@@ -8,6 +8,7 @@ import {
 
 export interface GenerateWorkflowInput {
   description: string;
+  anthropicApiKey?: string;
   hints?: {
     services?: string[];
     nodeTypes?: string[];
@@ -28,11 +29,14 @@ const MODEL = "claude-sonnet-4-20250514";
 
 let anthropicClient: Anthropic | null = null;
 
-function getAnthropicClient(): Anthropic {
+function getAnthropicClient(apiKey?: string): Anthropic {
+  if (apiKey) {
+    return new Anthropic({ apiKey });
+  }
   if (!anthropicClient) {
-    const apiKey = process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) throw new Error("ANTHROPIC_API_KEY is not set");
-    anthropicClient = new Anthropic({ apiKey });
+    const envKey = process.env.ANTHROPIC_API_KEY;
+    if (!envKey) throw new Error("ANTHROPIC_API_KEY is not set");
+    anthropicClient = new Anthropic({ apiKey: envKey });
   }
   return anthropicClient;
 }
@@ -45,7 +49,9 @@ export function setAnthropicClient(client: Anthropic | null): void {
 export async function generateWorkflow(
   input: GenerateWorkflowInput,
 ): Promise<GenerateWorkflowResult> {
-  const client = getAnthropicClient();
+  const client = input.anthropicApiKey
+    ? getAnthropicClient(input.anthropicApiKey)
+    : getAnthropicClient();
   const systemPrompt = buildSystemPrompt(input.hints?.services);
 
   let userMessage = input.description;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -270,10 +270,22 @@ export const GenerateWorkflowHintsSchema = z
   })
   .openapi("GenerateWorkflowHints");
 
+export const KeySourceSchema = z
+  .enum(["app", "byok"])
+  .describe(
+    "Where to resolve the Anthropic API key. " +
+    '"app" fetches the key registered for the appId via /internal/app-keys/anthropic/decrypt. ' +
+    '"byok" fetches the user\'s own key via /internal/keys/anthropic/decrypt.'
+  )
+  .openapi("KeySource");
+
 export const GenerateWorkflowSchema = z
   .object({
     appId: z.string().min(1).describe("Application identifier. The generated workflow will be deployed under this appId."),
     orgId: z.string().min(1).describe("Organization ID."),
+    keySource: KeySourceSchema.describe(
+      'Required. Where to resolve the Anthropic API key: "app" or "byok".'
+    ),
     description: z.string().min(10).describe(
       "Natural language description of the desired workflow. Be specific about the steps, services, and data flow."
     ),

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -5,7 +5,6 @@ process.env.WORKFLOW_SERVICE_API_KEY = "test-api-key";
 process.env.WINDMILL_SERVER_URL = "http://localhost:8000";
 process.env.WINDMILL_SERVER_API_KEY = "test-windmill-token";
 process.env.WINDMILL_SERVER_WORKSPACE = "test";
-process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
 process.env.KEY_SERVICE_URL = "http://localhost:4000";
 process.env.KEY_SERVICE_API_KEY = "test-key-svc-key";
 process.env.NODE_ENV = "test";

--- a/tests/unit/key-service-client.test.ts
+++ b/tests/unit/key-service-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { fetchProviderRequirements } from "../../src/lib/key-service-client.js";
+import { fetchProviderRequirements, fetchAnthropicKey } from "../../src/lib/key-service-client.js";
 
 describe("fetchProviderRequirements", () => {
   const originalUrl = process.env.KEY_SERVICE_URL;
@@ -96,5 +96,111 @@ describe("fetchProviderRequirements", () => {
         { service: "apollo", method: "POST", path: "/search" },
       ])
     ).rejects.toThrow("key-service error:");
+  });
+});
+
+describe("fetchAnthropicKey", () => {
+  const originalUrl = process.env.KEY_SERVICE_URL;
+  const originalKey = process.env.KEY_SERVICE_API_KEY;
+
+  beforeEach(() => {
+    process.env.KEY_SERVICE_URL = "http://localhost:4000";
+    process.env.KEY_SERVICE_API_KEY = "test-key-svc-key";
+  });
+
+  afterEach(() => {
+    process.env.KEY_SERVICE_URL = originalUrl;
+    process.env.KEY_SERVICE_API_KEY = originalKey;
+    vi.restoreAllMocks();
+  });
+
+  it("calls app-keys decrypt endpoint when keySource is 'app'", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ provider: "anthropic", key: "sk-ant-app-key" }),
+      })
+    );
+
+    const key = await fetchAnthropicKey("app", { appId: "my-app", orgId: "org-1" });
+
+    expect(key).toBe("sk-ant-app-key");
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:4000/internal/app-keys/anthropic/decrypt?appId=my-app",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          "x-api-key": "test-key-svc-key",
+          "x-caller-service": "workflow",
+          "x-caller-method": "POST",
+          "x-caller-path": "/workflows/generate",
+        }),
+      })
+    );
+  });
+
+  it("calls byok keys decrypt endpoint when keySource is 'byok'", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ provider: "anthropic", key: "sk-ant-byok-key" }),
+      })
+    );
+
+    const key = await fetchAnthropicKey("byok", { appId: "my-app", orgId: "org-1" });
+
+    expect(key).toBe("sk-ant-byok-key");
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:4000/internal/keys/anthropic/decrypt?orgId=org-1",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          "x-api-key": "test-key-svc-key",
+          "x-caller-service": "workflow",
+        }),
+      })
+    );
+  });
+
+  it("throws on non-2xx response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        text: () => Promise.resolve("key not configured"),
+      })
+    );
+
+    await expect(
+      fetchAnthropicKey("app", { appId: "my-app", orgId: "org-1" })
+    ).rejects.toThrow("key-service error:");
+  });
+
+  it("throws if KEY_SERVICE_URL is not set", async () => {
+    delete process.env.KEY_SERVICE_URL;
+    await expect(
+      fetchAnthropicKey("app", { appId: "my-app", orgId: "org-1" })
+    ).rejects.toThrow("KEY_SERVICE_URL and KEY_SERVICE_API_KEY must be set");
+  });
+
+  it("encodes appId and orgId in query params", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ provider: "anthropic", key: "sk-key" }),
+      })
+    );
+
+    await fetchAnthropicKey("app", { appId: "app with spaces", orgId: "org-1" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:4000/internal/app-keys/anthropic/decrypt?appId=app%20with%20spaces",
+      expect.anything()
+    );
   });
 });

--- a/tests/unit/workflow-generator.test.ts
+++ b/tests/unit/workflow-generator.test.ts
@@ -179,7 +179,7 @@ describe("generateWorkflow", () => {
     expect(mockCreate).toHaveBeenCalledTimes(3);
   });
 
-  it("throws if ANTHROPIC_API_KEY is not set", async () => {
+  it("throws if ANTHROPIC_API_KEY is not set and no apiKey provided", async () => {
     setAnthropicClient(null);
     const saved = process.env.ANTHROPIC_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;


### PR DESCRIPTION
## Summary
- The `POST /workflows/generate` endpoint was failing with `ANTHROPIC_API_KEY is not set` because it read the key from an env var
- Added a required `keySource` field (`"app"` or `"byok"`) to the generate request schema
- The route now calls key-service (`/internal/app-keys/anthropic/decrypt` or `/internal/keys/anthropic/decrypt`) to resolve the Anthropic API key at runtime, based on `keySource`
- Returns 502 with a clear error message when key-service is unreachable or the key is not configured

## Test plan
- [x] Unit tests for `fetchAnthropicKey` (app path, byok path, error cases, URL encoding)
- [x] Integration tests for generate endpoint with key-service mock (keySource validation, key resolution, 502 on key-service failure)
- [x] All 220 tests pass
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)