### PR TITLE
fix: remove env var fallback for Anthropic key

### DIFF
--- a/tests/integration/generate-workflow.test.ts
+++ b/tests/integration/generate-workflow.test.ts
@@ -127,7 +127,8 @@ describe("POST /workflows/generate", () => {
     expect(res.body.audienceType).toBe("cold-outreach");
     expect(mockFetchAnthropicKey).toHaveBeenCalledWith("app", { appId: "test-app", orgId: "org-1" });
     expect(mockGenerateWorkflow).toHaveBeenCalledWith(
-      expect.objectContaining({ anthropicApiKey: "resolved-anthropic-key" }),
+      { description: "I want a cold email outreach workflow that finds leads and sends emails", hints: undefined },
+      "resolved-anthropic-key",
     );
   });
 
@@ -221,11 +222,10 @@ describe("POST /workflows/generate", () => {
       });
 
     expect(mockFetchAnthropicKey).toHaveBeenCalledWith("byok", { appId: "test-app", orgId: "org-1" });
-    expect(mockGenerateWorkflow).toHaveBeenCalledWith({
-      description: "Cold email outreach with lead search",
-      hints: { services: ["lead", "email-gateway"] },
-      anthropicApiKey: "resolved-anthropic-key",
-    });
+    expect(mockGenerateWorkflow).toHaveBeenCalledWith(
+      { description: "Cold email outreach with lead search", hints: { services: ["lead", "email-gateway"] } },
+      "resolved-anthropic-key",
+    );
   });
 
   it("returns 500 when LLM throws unexpected error", async () => {


### PR DESCRIPTION
## Summary
- Removes the `ANTHROPIC_API_KEY` env var fallback from `workflow-generator.ts`
- `generateWorkflow` now takes the API key as a required second parameter — key comes **only** from key-service
- Follow-up to PR #54 (squash-merged before this commit was pushed)

## Test plan
- [x] All 219 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)