### PR TITLE
fix: pass anthropicApiKey as second arg (build fix)

### DIFF
--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -49,11 +49,10 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
       orgId: body.orgId,
     });
 
-    const generated = await generateWorkflow({
-      description: body.description,
-      hints: body.hints,
+    const generated = await generateWorkflow(
+      { description: body.description, hints: body.hints },
       anthropicApiKey,
-    });
+    );
 
     const dag = generated.dag as DAG;
     const signature = computeDAGSignature(generated.dag);


### PR DESCRIPTION
## Summary
- PR #55 squash-merged the pre-force-push version that still passed `anthropicApiKey` inside the input object instead of as a second argument to `generateWorkflow`
- This caused `TS2554: Expected 2 arguments, but got 1` on Railway build
- One-line fix: `generateWorkflow({ ... }, anthropicApiKey)` instead of `generateWorkflow({ ..., anthropicApiKey })`

## Test plan
- [x] `npm run build` passes locally
- [x] 219 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)