### PR TITLE
fix: accept "platform" as valid keySource enum value

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -734,9 +734,10 @@
         "type": "string",
         "enum": [
           "app",
-          "byok"
+          "byok",
+          "platform"
         ],
-        "description": "Required. Where to resolve the Anthropic API key: \"app\" or \"byok\"."
+        "description": "Required. Where to resolve the Anthropic API key: \"app\", \"platform\", or \"byok\"."
       },
       "GenerateWorkflowHints": {
         "type": "object",

--- a/src/lib/key-service-client.ts
+++ b/src/lib/key-service-client.ts
@@ -44,7 +44,7 @@ export async function fetchProviderRequirements(
 }
 
 export async function fetchAnthropicKey(
-  keySource: "app" | "byok",
+  keySource: "app" | "byok" | "platform",
   opts: { appId: string; orgId: string },
 ): Promise<string> {
   const { baseUrl, apiKey } = getKeyServiceConfig();
@@ -56,7 +56,7 @@ export async function fetchAnthropicKey(
   };
 
   const path =
-    keySource === "app"
+    keySource === "app" || keySource === "platform"
       ? `/internal/app-keys/anthropic/decrypt?appId=${encodeURIComponent(opts.appId)}`
       : `/internal/keys/anthropic/decrypt?orgId=${encodeURIComponent(opts.orgId)}`;
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -271,10 +271,10 @@ export const GenerateWorkflowHintsSchema = z
   .openapi("GenerateWorkflowHints");
 
 export const KeySourceSchema = z
-  .enum(["app", "byok"])
+  .enum(["app", "byok", "platform"])
   .describe(
     "Where to resolve the Anthropic API key. " +
-    '"app" fetches the key registered for the appId via /internal/app-keys/anthropic/decrypt. ' +
+    '"app" or "platform" fetches the key registered for the appId via /internal/app-keys/anthropic/decrypt. ' +
     '"byok" fetches the user\'s own key via /internal/keys/anthropic/decrypt.'
   )
   .openapi("KeySource");
@@ -284,7 +284,7 @@ export const GenerateWorkflowSchema = z
     appId: z.string().min(1).describe("Application identifier. The generated workflow will be deployed under this appId."),
     orgId: z.string().min(1).describe("Organization ID."),
     keySource: KeySourceSchema.describe(
-      'Required. Where to resolve the Anthropic API key: "app" or "byok".'
+      'Required. Where to resolve the Anthropic API key: "app", "platform", or "byok".'
     ),
     description: z.string().min(10).describe(
       "Natural language description of the desired workflow. Be specific about the steps, services, and data flow."

--- a/tests/integration/generate-workflow.test.ts
+++ b/tests/integration/generate-workflow.test.ts
@@ -201,6 +201,29 @@ describe("POST /workflows/generate", () => {
     expect(res.status).toBe(400);
   });
 
+  it("accepts keySource 'platform' and resolves via app-keys", async () => {
+    mockGenerateWorkflow.mockResolvedValueOnce({
+      dag: VALID_LINEAR_DAG,
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      description: "Test",
+    });
+
+    const res = await request
+      .post("/workflows/generate")
+      .set(AUTH)
+      .send({
+        appId: "test-app",
+        orgId: "org-1",
+        keySource: "platform",
+        description: "A workflow that does things with platform key",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockFetchAnthropicKey).toHaveBeenCalledWith("platform", { appId: "test-app", orgId: "org-1" });
+  });
+
   it("passes hints through to generator", async () => {
     mockGenerateWorkflow.mockResolvedValueOnce({
       dag: VALID_LINEAR_DAG,

--- a/tests/unit/key-service-client.test.ts
+++ b/tests/unit/key-service-client.test.ts
@@ -140,6 +140,32 @@ describe("fetchAnthropicKey", () => {
     );
   });
 
+  it("calls app-keys decrypt endpoint when keySource is 'platform'", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ provider: "anthropic", key: "sk-ant-platform-key" }),
+      })
+    );
+
+    const key = await fetchAnthropicKey("platform", { appId: "my-app", orgId: "org-1" });
+
+    expect(key).toBe("sk-ant-platform-key");
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:4000/internal/app-keys/anthropic/decrypt?appId=my-app",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          "x-api-key": "test-key-svc-key",
+          "x-caller-service": "workflow",
+          "x-caller-method": "POST",
+          "x-caller-path": "/workflows/generate",
+        }),
+      })
+    );
+  });
+
   it("calls byok keys decrypt endpoint when keySource is 'byok'", async () => {
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
## Summary
- Add `"platform"` to the `KeySourceSchema` Zod enum alongside `"app"` and `"byok"`
- `"platform"` resolves identically to `"app"` (via the app-keys decrypt endpoint)
- Fixes `POST /workflows/generate` returning 400 when callers send `keySource: "platform"`

## Test plan
- [x] Unit test: `fetchAnthropicKey` calls app-keys endpoint for `"platform"`
- [x] Integration test: `POST /workflows/generate` accepts `keySource: "platform"` and returns 200
- [x] All 230 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)