### PR TITLE
fix: route platform keySource to /internal/platform-keys endpoint

### DIFF
--- a/src/lib/key-service-client.ts
+++ b/src/lib/key-service-client.ts
@@ -56,9 +56,11 @@ export async function fetchAnthropicKey(
   };
 
   const path =
-    keySource === "app" || keySource === "platform"
-      ? `/internal/app-keys/anthropic/decrypt?appId=${encodeURIComponent(opts.appId)}`
-      : `/internal/keys/anthropic/decrypt?orgId=${encodeURIComponent(opts.orgId)}`;
+    keySource === "platform"
+      ? `/internal/platform-keys/anthropic/decrypt`
+      : keySource === "app"
+        ? `/internal/app-keys/anthropic/decrypt?appId=${encodeURIComponent(opts.appId)}`
+        : `/internal/keys/anthropic/decrypt?orgId=${encodeURIComponent(opts.orgId)}`;
 
   const res = await fetch(`${baseUrl}${path}`, {
     method: "GET",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -274,7 +274,8 @@ export const KeySourceSchema = z
   .enum(["app", "byok", "platform"])
   .describe(
     "Where to resolve the Anthropic API key. " +
-    '"app" or "platform" fetches the key registered for the appId via /internal/app-keys/anthropic/decrypt. ' +
+    '"app" fetches the per-app key via /internal/app-keys/anthropic/decrypt. ' +
+    '"platform" fetches the global platform key via /internal/platform-keys/anthropic/decrypt. ' +
     '"byok" fetches the user\'s own key via /internal/keys/anthropic/decrypt.'
   )
   .openapi("KeySource");

--- a/tests/unit/key-service-client.test.ts
+++ b/tests/unit/key-service-client.test.ts
@@ -140,7 +140,7 @@ describe("fetchAnthropicKey", () => {
     );
   });
 
-  it("calls app-keys decrypt endpoint when keySource is 'platform'", async () => {
+  it("calls platform-keys decrypt endpoint when keySource is 'platform'", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -153,7 +153,7 @@ describe("fetchAnthropicKey", () => {
 
     expect(key).toBe("sk-ant-platform-key");
     expect(fetch).toHaveBeenCalledWith(
-      "http://localhost:4000/internal/app-keys/anthropic/decrypt?appId=my-app",
+      "http://localhost:4000/internal/platform-keys/anthropic/decrypt",
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({


### PR DESCRIPTION
## Summary
- Fix `keySource: "platform"` to call `/internal/platform-keys/anthropic/decrypt` (global, no appId/orgId) instead of incorrectly routing to `/internal/app-keys/...`
- Update schema description to document the three distinct key resolution paths
- Fix unit test to assert the correct platform-keys endpoint

## Test plan
- [x] Unit test: `fetchAnthropicKey("platform", ...)` calls `/internal/platform-keys/anthropic/decrypt` with no query params
- [x] Integration test: `POST /workflows/generate` with `keySource: "platform"` returns 200
- [x] All 230 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)