### PR TITLE
feat: agentic workflow generation with live API registry and Opus 4.6

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,14 @@ WORKFLOW_SERVICE_API_KEY=xxx
 WORKFLOW_SERVICE_URL=https://workflow.mcpfactory.org
 PORT=3000
 
+# API Registry (for agentic workflow generation — LLM browses live OpenAPI specs)
+API_REGISTRY_SERVICE_URL=https://api-registry.mcpfactory.org
+API_REGISTRY_SERVICE_API_KEY=xxx
+
+# Key service (for resolving Anthropic API key during generation)
+KEY_SERVICE_URL=https://key.mcpfactory.org
+KEY_SERVICE_API_KEY=xxx
+
 # Runs service (for cost data in GET /workflows/best)
 RUNS_SERVICE_URL=https://runs.mcpfactory.org
 RUNS_SERVICE_API_KEY=xxx

--- a/src/lib/api-registry-client.ts
+++ b/src/lib/api-registry-client.ts
@@ -1,0 +1,76 @@
+export interface LlmServiceSummary {
+  service: string;
+  baseUrl: string;
+  title?: string;
+  description?: string;
+  error?: string;
+  endpoints: Array<{
+    method: string;
+    path: string;
+    summary: string;
+    params?: Array<{ name: string; in: string; required: boolean; type?: string }>;
+    bodyFields?: string[];
+  }>;
+}
+
+export interface LlmContextResponse {
+  _description: string;
+  _usage: string;
+  services: LlmServiceSummary[];
+}
+
+function getApiRegistryConfig(): { baseUrl: string; apiKey: string } {
+  const baseUrl = process.env.API_REGISTRY_SERVICE_URL;
+  const apiKey = process.env.API_REGISTRY_SERVICE_API_KEY;
+
+  if (!baseUrl || !apiKey) {
+    throw new Error(
+      "API_REGISTRY_SERVICE_URL and API_REGISTRY_SERVICE_API_KEY must be set"
+    );
+  }
+
+  return { baseUrl: baseUrl.replace(/\/$/, ""), apiKey };
+}
+
+/** GET /llm-context — compact summary of all services and endpoints for LLM consumption */
+export async function fetchLlmContext(): Promise<LlmContextResponse> {
+  const { baseUrl, apiKey } = getApiRegistryConfig();
+
+  const res = await fetch(`${baseUrl}/llm-context`, {
+    method: "GET",
+    headers: { "x-api-key": apiKey },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `api-registry error: GET /llm-context -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  return res.json() as Promise<LlmContextResponse>;
+}
+
+/** GET /openapi/:service — full OpenAPI spec for one service */
+export async function fetchServiceSpec(
+  serviceName: string,
+): Promise<Record<string, unknown>> {
+  const { baseUrl, apiKey } = getApiRegistryConfig();
+
+  const res = await fetch(
+    `${baseUrl}/openapi/${encodeURIComponent(serviceName)}`,
+    {
+      method: "GET",
+      headers: { "x-api-key": apiKey },
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `api-registry error: GET /openapi/${serviceName} -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  return res.json() as Promise<Record<string, unknown>>;
+}


### PR DESCRIPTION
## Summary
- Upgrade workflow generator model from Claude Sonnet 4 to **Claude Opus 4.6** (`claude-opus-4-6`)
- Make generation **agentic**: LLM now browses the live API registry (`list_services`, `get_service_endpoints`) to verify real OpenAPI specs before generating DAGs — no more guessing endpoint paths or request bodies
- Add **campaign execution model** context to system prompt (budget constraints, per-minute re-triggering, chassis pattern)
- Graceful **fallback** to static service catalog when `API_REGISTRY_SERVICE_URL` is not configured

## Files changed
- `src/lib/api-registry-client.ts` — NEW: HTTP client for api-registry (`fetchLlmContext`, `fetchServiceSpec`)
- `src/lib/workflow-generator.ts` — Multi-turn agentic loop with tool resolution, model upgrade
- `src/lib/prompt-templates.ts` — New tool definitions, agentic mode system prompt, campaign execution model
- `tests/unit/workflow-generator.test.ts` — 29 tests covering fallback + agentic modes
- `.env.example` — Added `API_REGISTRY_SERVICE_URL` and `API_REGISTRY_SERVICE_API_KEY`

## Test plan
- [x] All 244 tests pass (`npm test`)
- [x] TypeScript compiles (`npm run build`)
- [ ] Deploy with `API_REGISTRY_SERVICE_URL` set — verify multi-turn tool calls in logs
- [ ] Deploy without `API_REGISTRY_SERVICE_URL` — verify fallback to static catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)