### PR TITLE
feat: add style support (human/brand) to workflow generation

### DIFF
--- a/drizzle/0010_add_style_columns.sql
+++ b/drizzle/0010_add_style_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "human_id" text;
+--> statement-breakpoint
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "style_name" text;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_workflows_style" ON "workflows" ("app_id", "style_name");

--- a/openapi.json
+++ b/openapi.json
@@ -82,6 +82,11 @@
             "type": "string",
             "nullable": true
           },
+          "humanId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Human ID if this workflow was generated in a human expert's style."
+          },
           "campaignId": {
             "type": "string",
             "nullable": true
@@ -89,6 +94,11 @@
           "subrequestId": {
             "type": "string",
             "nullable": true
+          },
+          "styleName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Base style name used for versioned naming (e.g. 'hormozi'). Null for non-styled workflows."
           },
           "name": {
             "type": "string",
@@ -145,8 +155,10 @@
           "appId",
           "orgId",
           "brandId",
+          "humanId",
           "campaignId",
           "subrequestId",
+          "styleName",
           "name",
           "displayName",
           "description",
@@ -766,6 +778,40 @@
         },
         "description": "Optional hints to guide generation."
       },
+      "WorkflowStyleType": {
+        "type": "string",
+        "enum": [
+          "human",
+          "brand"
+        ],
+        "description": "Style source type. \"human\" for an industry expert, \"brand\" for a company/organization."
+      },
+      "WorkflowStyle": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/WorkflowStyleType"
+          },
+          "humanId": {
+            "type": "string",
+            "description": "Human ID from human-service. Required when type is 'human'."
+          },
+          "brandId": {
+            "type": "string",
+            "description": "Brand ID from brand-service. Required when type is 'brand'."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Display name of the human or brand (e.g. 'Hormozi', 'My Brand'). Used to build the signatureName (e.g. 'hormozi-v1')."
+          }
+        },
+        "required": [
+          "type",
+          "name"
+        ],
+        "description": "Optional style configuration. When provided, the workflow is generated in the style of the specified human or brand, and the signatureName uses the style name with auto-versioning (e.g. 'hormozi-v1')."
+      },
       "GenerateWorkflowRequest": {
         "type": "object",
         "properties": {
@@ -789,6 +835,9 @@
           },
           "hints": {
             "$ref": "#/components/schemas/GenerateWorkflowHints"
+          },
+          "style": {
+            "$ref": "#/components/schemas/WorkflowStyle"
           }
         },
         "required": [
@@ -1024,6 +1073,14 @@
             },
             "required": false,
             "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "humanId",
             "in": "query"
           },
           {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -15,8 +15,10 @@ export const workflows = pgTable(
     appId: text("app_id").notNull(),
     orgId: text("org_id").notNull(),
     brandId: text("brand_id"),
+    humanId: text("human_id"),
     campaignId: text("campaign_id"),
     subrequestId: text("subrequest_id"),
+    styleName: text("style_name"),
     name: text("name").notNull(),
     displayName: text("display_name"),
     description: text("description"),
@@ -41,6 +43,7 @@ export const workflows = pgTable(
       .on(table.appId, table.signature),
     uniqueIndex("idx_workflows_app_signature_name_unique")
       .on(table.appId, table.signatureName),
+    index("idx_workflows_style").on(table.appId, table.styleName),
   ]
 );
 

--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -111,10 +111,11 @@ export const AGENTIC_TOOLS = [
 export interface BuildSystemPromptOptions {
   filterServices?: string[];
   agenticMode?: boolean;
+  styleDirective?: string;
 }
 
 export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
-  const { filterServices, agenticMode } = options ?? {};
+  const { filterServices, agenticMode, styleDirective } = options ?? {};
 
   const nodeTypes = Object.entries(NODE_TYPE_REGISTRY)
     .map(([type, path]) => {
@@ -312,7 +313,7 @@ Campaign service orchestrates workflow execution with budget constraints. Key co
 }
 \`\`\`
 
-Generate a single workflow DAG that fulfills the user's description. Use the create_workflow tool to return the result.`;
+${styleDirective ? `## Style Directive\n\n${styleDirective}\n\n` : ""}Generate a single workflow DAG that fulfills the user's description. Use the create_workflow tool to return the result.`;
 }
 
 export function buildRetryUserMessage(

--- a/src/lib/workflow-generator.ts
+++ b/src/lib/workflow-generator.ts
@@ -18,6 +18,12 @@ export interface GenerateWorkflowInput {
     nodeTypes?: string[];
     expectedInputs?: string[];
   };
+  style?: {
+    type: "human" | "brand";
+    name: string;
+    humanId?: string;
+    brandId?: string;
+  };
 }
 
 export interface GenerateWorkflowResult {
@@ -74,9 +80,14 @@ export async function generateWorkflow(
     process.env.API_REGISTRY_SERVICE_URL && process.env.API_REGISTRY_SERVICE_API_KEY,
   );
 
+  const styleDirective = input.style
+    ? `This workflow MUST be created in the style of ${input.style.name}. Adopt their methodology, tone, and strategic patterns.`
+    : undefined;
+
   const systemPrompt = buildSystemPrompt({
     filterServices: input.hints?.services,
     agenticMode,
+    styleDirective,
   });
 
   const tools = agenticMode ? AGENTIC_TOOLS : [DAG_GENERATION_TOOL];
@@ -90,6 +101,9 @@ export async function generateWorkflow(
   }
   if (input.hints?.expectedInputs?.length) {
     userMessage += `\nExpected flow_input fields: ${input.hints.expectedInputs.join(", ")}`;
+  }
+  if (input.style) {
+    userMessage += `\n\nStyle: Generate this workflow in the style of "${input.style.name}".`;
   }
 
   const messages: Anthropic.Messages.MessageParam[] = [


### PR DESCRIPTION
## Summary
- Add `style` parameter to `POST /workflows/generate` with `type: "human" | "brand"`, `humanId`/`brandId`, and `name`
- Style-based signatureName replaces random word with versioned name (e.g., `hormozi-v1`, `hormozi-v2`) — versions auto-increment per `(appId, styleName)`
- LLM receives a style directive in the system prompt to generate workflows matching the expert/brand methodology
- New DB columns: `human_id`, `style_name` with composite index
- Signature-based deduplication unchanged: same DAG = update, different DAG = new version

## Test plan
- [x] Unit tests: style directive included in prompt when style provided, excluded when not
- [x] Unit tests: style appended to user message
- [x] Integration tests: human style → `signatureName = "hormozi-v1"`
- [x] Integration tests: brand style → `signatureName = "my-brand-v1"`
- [x] Integration tests: validation — human without humanId → 400, brand without brandId → 400
- [x] Integration tests: backward compat — no style → old random word naming
- [x] All 254 tests pass, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)