### PR TITLE
fix: sync Drizzle migration journal (0004-0010)

### DIFF
--- a/drizzle/0005_add_signature_unique_constraints.sql
+++ b/drizzle/0005_add_signature_unique_constraints.sql
@@ -1,7 +1,5 @@
 CREATE UNIQUE INDEX IF NOT EXISTS "idx_workflows_app_signature_unique"
-  ON "workflows" ("app_id", "signature")
-  WHERE status != 'deleted';
+  ON "workflows" ("app_id", "signature");
 --> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "idx_workflows_app_signature_name_unique"
-  ON "workflows" ("app_id", "signature_name")
-  WHERE status != 'deleted';
+  ON "workflows" ("app_id", "signature_name");

--- a/drizzle/0009_drop_status_column.sql
+++ b/drizzle/0009_drop_status_column.sql
@@ -6,7 +6,7 @@ DROP INDEX IF EXISTS "idx_workflows_app_signature_unique";
 --> statement-breakpoint
 DROP INDEX IF EXISTS "idx_workflows_app_signature_name_unique";
 --> statement-breakpoint
-ALTER TABLE "workflows" DROP COLUMN "status";
+ALTER TABLE "workflows" DROP COLUMN IF EXISTS "status";
 --> statement-breakpoint
 CREATE UNIQUE INDEX "idx_workflows_app_name_unique" ON "workflows" ("app_id", "name");
 --> statement-breakpoint

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,55 @@
       "when": 1771325106410,
       "tag": "0003_add_channel_audience_type",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1771411506410,
+      "tag": "0004_add_signature",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1771497906410,
+      "tag": "0005_add_signature_unique_constraints",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1771584306410,
+      "tag": "0006_signature_not_null",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1771670706410,
+      "tag": "0007_dimensions_not_null",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1771757106410,
+      "tag": "0008_appid_not_null",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1771843506410,
+      "tag": "0009_drop_status_column",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1771929906410,
+      "tag": "0010_add_style_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/unit/migration-journal.test.ts
+++ b/tests/unit/migration-journal.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync } from "fs";
+import { resolve } from "path";
+
+const DRIZZLE_DIR = resolve(process.cwd(), "drizzle");
+const JOURNAL_PATH = resolve(DRIZZLE_DIR, "meta/_journal.json");
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+describe("Drizzle migration journal", () => {
+  const journal: Journal = JSON.parse(readFileSync(JOURNAL_PATH, "utf-8"));
+
+  it("has sequential idx values starting at 0", () => {
+    journal.entries.forEach((entry, i) => {
+      expect(entry.idx).toBe(i);
+    });
+  });
+
+  it("every journal entry has a matching SQL file", () => {
+    for (const entry of journal.entries) {
+      const sqlPath = resolve(DRIZZLE_DIR, `${entry.tag}.sql`);
+      expect(existsSync(sqlPath), `Missing SQL file for ${entry.tag}`).toBe(true);
+    }
+  });
+
+  it("every SQL file in drizzle/ has a journal entry", () => {
+    const { readdirSync } = require("fs");
+    const sqlFiles: string[] = readdirSync(DRIZZLE_DIR)
+      .filter((f: string) => f.endsWith(".sql"))
+      .map((f: string) => f.replace(".sql", ""));
+
+    const journalTags = new Set(journal.entries.map((e) => e.tag));
+
+    for (const file of sqlFiles) {
+      expect(journalTags.has(file), `SQL file ${file}.sql not in journal`).toBe(true);
+    }
+  });
+
+  it("migration 0009 uses DROP COLUMN IF EXISTS for idempotency", () => {
+    const sql = readFileSync(resolve(DRIZZLE_DIR, "0009_drop_status_column.sql"), "utf-8");
+    expect(sql).toContain("DROP COLUMN IF EXISTS");
+    expect(sql).not.toMatch(/DROP COLUMN "status"/);
+  });
+
+  it("migration 0005 does not reference the dropped status column", () => {
+    const sql = readFileSync(
+      resolve(DRIZZLE_DIR, "0005_add_signature_unique_constraints.sql"),
+      "utf-8",
+    );
+    expect(sql).not.toContain("status");
+  });
+
+  it("includes style columns migration (0010)", () => {
+    const entry = journal.entries.find((e) => e.tag === "0010_add_style_columns");
+    expect(entry).toBeDefined();
+
+    const sql = readFileSync(resolve(DRIZZLE_DIR, "0010_add_style_columns.sql"), "utf-8");
+    expect(sql).toContain("human_id");
+    expect(sql).toContain("style_name");
+  });
+});


### PR DESCRIPTION
## Summary
- Migration journal (`_journal.json`) only tracked 4 of 11 migrations — migrations 0004-0010 were applied manually to prod DB but never registered in Drizzle's journal
- This caused the startup `migrate()` to skip them, meaning any fresh DB (or CI) would be missing `signature`, `signature_name`, `human_id`, `style_name` columns → 500 errors on `GET /workflows`
- Made migration 0009 idempotent (`DROP COLUMN IF EXISTS "status"`) and removed stale `WHERE status != 'deleted'` from 0005

## Test plan
- [x] All 260 tests pass (18 test files)
- [x] New migration journal consistency tests verify every SQL file has a journal entry and vice versa
- [x] Verified in Neon prod (old-pond-00882067) that all columns exist and data is queryable

🤖 Generated with [Claude Code](https://claude.com/claude-code)