### PR TITLE
chore: rename mcpfactory to distribute

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,21 +6,21 @@ WINDMILL_SERVER_WORKSPACE=prod
 # This service
 WORKFLOW_SERVICE_DATABASE_URL=postgresql://...
 WORKFLOW_SERVICE_API_KEY=xxx
-WORKFLOW_SERVICE_URL=https://workflow.mcpfactory.org
+WORKFLOW_SERVICE_URL=https://workflow.distribute.org
 PORT=3000
 
 # API Registry (for agentic workflow generation — LLM browses live OpenAPI specs)
-API_REGISTRY_SERVICE_URL=https://api-registry.mcpfactory.org
+API_REGISTRY_SERVICE_URL=https://api-registry.distribute.org
 API_REGISTRY_SERVICE_API_KEY=xxx
 
 # Key service (for resolving Anthropic API key during generation)
-KEY_SERVICE_URL=https://key.mcpfactory.org
+KEY_SERVICE_URL=https://key.distribute.org
 KEY_SERVICE_API_KEY=xxx
 
 # Runs service (for cost data in GET /workflows/best)
-RUNS_SERVICE_URL=https://runs.mcpfactory.org
+RUNS_SERVICE_URL=https://runs.distribute.org
 RUNS_SERVICE_API_KEY=xxx
 
 # Email gateway service (for email engagement stats in GET /workflows/best)
-EMAIL_GATEWAY_SERVICE_URL=https://email-gateway.mcpfactory.org
+EMAIL_GATEWAY_SERVICE_URL=https://email-gateway.distribute.org
 EMAIL_GATEWAY_SERVICE_API_KEY=xxx

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://windmill.mcpfactory.org"
+      "url": "https://windmill.distribute.org"
     }
   ],
   "components": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@mcpfactory/workflow-service",
+  "name": "@distribute/workflow-service",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@mcpfactory/workflow-service",
+      "name": "@distribute/workflow-service",
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mcpfactory/workflow-service",
+  "name": "@distribute/workflow-service",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -102,7 +102,7 @@ const document = generator.generateDocument({
   },
   servers: [
     {
-      url: process.env.SERVICE_URL ?? "https://windmill.mcpfactory.org",
+      url: process.env.SERVICE_URL ?? "https://windmill.distribute.org",
     },
   ],
 });

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -223,7 +223,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "mcpfactory",
+        appId: "distribute",
         workflows: [
           {
             ...DEPLOY_ITEM,
@@ -251,7 +251,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "mcpfactory",
+        appId: "distribute",
         orgId: "org_test_id",
         workflows: [
           {
@@ -266,7 +266,7 @@ describe("PUT /workflows/deploy", () => {
     // Verify the DB row got the correct orgId
     const inserted = mockDbRows[mockDbRows.length - 1];
     expect(inserted.orgId).toBe("org_test_id");
-    expect(inserted.appId).toBe("mcpfactory");
+    expect(inserted.appId).toBe("distribute");
   });
 
   it("falls back to appId when orgId is not provided", async () => {
@@ -274,7 +274,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "mcpfactory",
+        appId: "distribute",
         workflows: [
           {
             ...DEPLOY_ITEM,
@@ -286,7 +286,7 @@ describe("PUT /workflows/deploy", () => {
 
     expect(res.status).toBe(200);
     const inserted = mockDbRows[mockDbRows.length - 1];
-    expect(inserted.orgId).toBe("mcpfactory");
+    expect(inserted.orgId).toBe("distribute");
   });
 
   it("updates orgId on existing workflow when redeployed with orgId", async () => {
@@ -295,8 +295,8 @@ describe("PUT /workflows/deploy", () => {
 
     mockDbRows.push({
       id: "wf-wrong-org",
-      appId: "mcpfactory",
-      orgId: "mcpfactory",
+      appId: "distribute",
+      orgId: "distribute",
       name: "sales-email-cold-outreach-sequoia",
       signatureName: "sequoia",
       signature: sig,
@@ -305,7 +305,7 @@ describe("PUT /workflows/deploy", () => {
       audienceType: "cold-outreach",
       description: "Old",
       dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
-      windmillFlowPath: "f/workflows/mcpfactory/sales_email_cold_outreach_sequoia",
+      windmillFlowPath: "f/workflows/distribute/sales_email_cold_outreach_sequoia",
       windmillWorkspace: "prod",
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -315,7 +315,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "mcpfactory",
+        appId: "distribute",
         orgId: "org_correct_id",
         workflows: [
           {
@@ -339,8 +339,8 @@ describe("PUT /workflows/deploy", () => {
 
     mockDbRows.push({
       id: "wf-existing",
-      appId: "mcpfactory",
-      orgId: "mcpfactory",
+      appId: "distribute",
+      orgId: "distribute",
       name: "sales-email-cold-outreach-sequoia",
       signatureName: "sequoia",
       signature: sig,
@@ -349,7 +349,7 @@ describe("PUT /workflows/deploy", () => {
       audienceType: "cold-outreach",
       description: "Old description",
       dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
-      windmillFlowPath: "f/workflows/mcpfactory/sales_email_cold_outreach_sequoia",
+      windmillFlowPath: "f/workflows/distribute/sales_email_cold_outreach_sequoia",
       windmillWorkspace: "prod",
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -359,7 +359,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "mcpfactory",
+        appId: "distribute",
         workflows: [
           {
             ...DEPLOY_ITEM,
@@ -376,7 +376,7 @@ describe("PUT /workflows/deploy", () => {
 
   it("same DAG produces same signature across deploys", async () => {
     const payload = {
-      appId: "mcpfactory",
+      appId: "distribute",
       workflows: [{ ...DEPLOY_ITEM, dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND }],
     };
 
@@ -397,7 +397,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "mcpfactory",
+        appId: "distribute",
         workflows: [{ ...DEPLOY_ITEM, dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND }],
       });
     expect(res1.body.workflows[0].signature).toBe(sig1);
@@ -408,7 +408,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "mcpfactory",
+        appId: "distribute",
         workflows: [{ ...DEPLOY_ITEM, dag: VALID_LINEAR_DAG }],
       });
     expect(res2.body.workflows[0].signature).toBe(sig2);
@@ -419,7 +419,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "mcpfactory",
+        appId: "distribute",
         workflows: [
           {
             // Missing category, channel, audienceType
@@ -436,7 +436,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "mcpfactory",
+        appId: "distribute",
         workflows: [
           {
             category: "sales",
@@ -455,7 +455,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "mcpfactory",
+        appId: "distribute",
         workflows: [
           {
             category: "sales",
@@ -474,7 +474,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "mcpfactory",
+        appId: "distribute",
         workflows: [
           {
             category: "invalid-category",
@@ -500,7 +500,7 @@ describe("PUT /workflows/deploy", () => {
         .put("/workflows/deploy")
         .set(AUTH)
         .send({
-          appId: "mcpfactory",
+          appId: "distribute",
           workflows: [{ ...dims, dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND }],
         });
 
@@ -513,7 +513,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "mcpfactory",
+        appId: "distribute",
         workflows: [
           { ...DEPLOY_ITEM, dag: VALID_LINEAR_DAG },
           { ...DEPLOY_ITEM, dag: DAG_WITH_UNKNOWN_TYPE },
@@ -527,7 +527,7 @@ describe("PUT /workflows/deploy", () => {
 
   it("requires authentication", async () => {
     const res = await request.put("/workflows/deploy").send({
-      appId: "mcpfactory",
+      appId: "distribute",
       workflows: [{ ...DEPLOY_ITEM, dag: VALID_LINEAR_DAG }],
     });
 
@@ -538,7 +538,7 @@ describe("PUT /workflows/deploy", () => {
     const res = await request
       .put("/workflows/deploy")
       .set(AUTH)
-      .send({ appId: "mcpfactory" }); // missing workflows
+      .send({ appId: "distribute" }); // missing workflows
 
     expect(res.status).toBe(400);
   });


### PR DESCRIPTION
## Summary
- Replace all `mcpfactory` references with `distribute` across the entire repo
- Package name: `@mcpfactory/workflow-service` → `@distribute/workflow-service`
- URLs: `*.mcpfactory.org` → `*.distribute.org` (in .env.example and openapi generation)
- Test fixtures: `appId: "mcpfactory"` → `appId: "distribute"`
- Regenerated `openapi.json` with updated server URL

## Test plan
- [x] All 260 tests pass
- [x] `grep -ri mcpfactory` returns zero results
- [x] `openapi.json` regenerated cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)