### PR TITLE
feat: remove appId/keySource, require identity headers, add parentRunId

### DIFF
--- a/drizzle/0011_remove_appid_add_userid.sql
+++ b/drizzle/0011_remove_appid_add_userid.sql
@@ -1,0 +1,22 @@
+-- Remove app_id from workflows, replace appId-based indexes with orgId-based
+-- Add user_id and parent_run_id to workflow_runs
+
+-- Drop appId-based indexes
+DROP INDEX IF EXISTS "idx_workflows_app";
+DROP INDEX IF EXISTS "idx_workflows_app_name_unique";
+DROP INDEX IF EXISTS "idx_workflows_app_signature_unique";
+DROP INDEX IF EXISTS "idx_workflows_app_signature_name_unique";
+DROP INDEX IF EXISTS "idx_workflows_style";
+
+-- Drop app_id column
+ALTER TABLE "workflows" DROP COLUMN IF EXISTS "app_id";
+
+-- Add orgId-based replacement indexes
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_workflows_org_name_unique" ON "workflows" ("org_id", "name");
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_workflows_org_signature_unique" ON "workflows" ("org_id", "signature");
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_workflows_org_signature_name_unique" ON "workflows" ("org_id", "signature_name");
+CREATE INDEX IF NOT EXISTS "idx_workflows_org_style" ON "workflows" ("org_id", "style_name");
+
+-- Add user_id and parent_run_id to workflow_runs
+ALTER TABLE "workflow_runs" ADD COLUMN IF NOT EXISTS "user_id" text;
+ALTER TABLE "workflow_runs" ADD COLUMN IF NOT EXISTS "parent_run_id" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1771929906410,
       "tag": "0010_add_style_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1772016306410,
+      "tag": "0011_remove_appid_add_userid",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -68,11 +68,7 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Workflow UUID. Not needed for execution — use name + appId instead."
-          },
-          "appId": {
-            "type": "string",
-            "description": "Application identifier."
+            "description": "Workflow UUID."
           },
           "orgId": {
             "type": "string",
@@ -102,7 +98,7 @@
           },
           "name": {
             "type": "string",
-            "description": "Workflow name. Use this with appId to execute via /workflows/by-name/{name}/execute."
+            "description": "Workflow name. Use this with orgId to execute via /workflows/by-name/{name}/execute."
           },
           "displayName": {
             "type": "string",
@@ -152,7 +148,6 @@
         },
         "required": [
           "id",
-          "appId",
           "orgId",
           "brandId",
           "humanId",
@@ -279,11 +274,6 @@
       "CreateWorkflowRequest": {
         "type": "object",
         "properties": {
-          "appId": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Application identifier. Workflows are scoped to appId."
-          },
           "orgId": {
             "type": "string",
             "minLength": 1,
@@ -304,7 +294,7 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "description": "Workflow name. Must be unique within the appId. Used to execute by name later."
+            "description": "Workflow name. Must be unique within the orgId. Used to execute by name later."
           },
           "description": {
             "type": "string",
@@ -324,7 +314,6 @@
           }
         },
         "required": [
-          "appId",
           "orgId",
           "name",
           "category",
@@ -454,10 +443,20 @@
             "type": "string",
             "nullable": true
           },
+          "userId": {
+            "type": "string",
+            "nullable": true,
+            "description": "User ID from the execution context."
+          },
           "runId": {
             "type": "string",
             "nullable": true,
             "description": "External run ID (if provided at execution time)."
+          },
+          "parentRunId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Parent run ID (if linked to a parent execution)."
           },
           "windmillJobId": {
             "type": "string",
@@ -502,7 +501,9 @@
           "orgId",
           "campaignId",
           "subrequestId",
+          "userId",
           "runId",
+          "parentRunId",
           "windmillJobId",
           "windmillWorkspace",
           "status",
@@ -515,10 +516,6 @@
       "ExecuteWorkflowRequest": {
         "type": "object",
         "properties": {
-          "appId": {
-            "type": "string",
-            "description": "App ID override. If not provided, falls back to the workflow's stored appId."
-          },
           "inputs": {
             "type": "object",
             "additionalProperties": {
@@ -529,6 +526,10 @@
           "runId": {
             "type": "string",
             "description": "Optional external run ID for cost tracking via runs-service."
+          },
+          "parentRunId": {
+            "type": "string",
+            "description": "Optional parent run ID to link this execution to a parent run."
           }
         }
       },
@@ -672,15 +673,10 @@
       "DeployWorkflowsRequest": {
         "type": "object",
         "properties": {
-          "appId": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Your application identifier. Workflows are scoped to (appId + signature). Use the same appId when executing. This is idempotent — deploying the same DAG updates the existing workflow."
-          },
           "orgId": {
             "type": "string",
             "minLength": 1,
-            "description": "Organization ID that owns these workflows. If omitted, falls back to appId for backward compatibility."
+            "description": "Organization ID that owns these workflows. Workflows are scoped to (orgId + signature). This is idempotent — deploying the same DAG updates the existing workflow."
           },
           "workflows": {
             "type": "array",
@@ -692,7 +688,7 @@
           }
         },
         "required": [
-          "appId",
+          "orgId",
           "workflows"
         ]
       },
@@ -741,15 +737,6 @@
           "audienceType",
           "generatedDescription"
         ]
-      },
-      "KeySource": {
-        "type": "string",
-        "enum": [
-          "app",
-          "byok",
-          "platform"
-        ],
-        "description": "Required. Where to resolve the Anthropic API key: \"app\", \"platform\", or \"byok\"."
       },
       "GenerateWorkflowHints": {
         "type": "object",
@@ -815,18 +802,10 @@
       "GenerateWorkflowRequest": {
         "type": "object",
         "properties": {
-          "appId": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Application identifier. The generated workflow will be deployed under this appId."
-          },
           "orgId": {
             "type": "string",
             "minLength": 1,
-            "description": "Organization ID."
-          },
-          "keySource": {
-            "$ref": "#/components/schemas/KeySource"
+            "description": "Organization ID. The generated workflow will be deployed under this orgId."
           },
           "description": {
             "type": "string",
@@ -841,9 +820,7 @@
           }
         },
         "required": [
-          "appId",
           "orgId",
-          "keySource",
           "description"
         ]
       },
@@ -948,14 +925,10 @@
       "ExecuteByNameRequest": {
         "type": "object",
         "properties": {
-          "appId": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Must match the appId used during deploy."
-          },
           "orgId": {
             "type": "string",
-            "description": "Organization ID for this execution (overrides workflow's orgId if set)."
+            "minLength": 1,
+            "description": "Organization ID. Must match the orgId used during deploy."
           },
           "inputs": {
             "type": "object",
@@ -967,10 +940,14 @@
           "runId": {
             "type": "string",
             "description": "Optional external run ID for cost tracking via runs-service."
+          },
+          "parentRunId": {
+            "type": "string",
+            "description": "Optional parent run ID to link this execution to a parent run."
           }
         },
         "required": [
-          "appId"
+          "orgId"
         ]
       }
     },
@@ -1058,14 +1035,6 @@
             },
             "required": false,
             "name": "orgId",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "appId",
             "in": "query"
           },
           {
@@ -1620,7 +1589,7 @@
     "/workflows/deploy": {
       "put": {
         "summary": "Deploy (upsert) workflows by DAG signature",
-        "description": "Idempotent: creates new workflows or updates existing ones matched by (appId + DAG signature). The workflow name is auto-generated as {category}-{channel}-{audienceType}-{signatureName}. signatureName is a human-readable word auto-assigned to each unique DAG. After deploying, execute workflows via POST /workflows/by-name/{name}/execute.",
+        "description": "Idempotent: creates new workflows or updates existing ones matched by (orgId + DAG signature). The workflow name is auto-generated as {category}-{channel}-{audienceType}-{signatureName}. signatureName is a human-readable word auto-assigned to each unique DAG. After deploying, execute workflows via POST /workflows/by-name/{name}/execute.",
         "tags": [
           "Workflows"
         ],
@@ -1735,12 +1704,11 @@
           {
             "schema": {
               "type": "string",
-              "minLength": 1,
-              "description": "Application identifier. When omitted, searches across all apps."
+              "description": "Organization ID. When omitted, searches across all orgs."
             },
             "required": false,
-            "description": "Application identifier. When omitted, searches across all apps.",
-            "name": "appId",
+            "description": "Organization ID. When omitted, searches across all orgs.",
+            "name": "orgId",
             "in": "query"
           },
           {

--- a/scripts/nodes/client-create-user.ts
+++ b/scripts/nodes/client-create-user.ts
@@ -1,11 +1,10 @@
 // Windmill node script — calls client POST /anonymous-users
 export async function main(
-  appId: string,
+  orgId: string,
   email: string,
   firstName?: string,
   lastName?: string,
   phone?: string,
-  orgId?: string,
   metadata?: Record<string, unknown>,
   serviceEnvs?: Record<string, string>,
 ) {
@@ -22,7 +21,7 @@ export async function main(
         "Content-Type": "application/json",
         "x-api-key": apiKey,
       },
-      body: JSON.stringify({ appId, email, firstName, lastName, phone, orgId, metadata }),
+      body: JSON.stringify({ orgId, email, firstName, lastName, phone, metadata }),
     }
   );
 

--- a/scripts/nodes/client-get-users.ts
+++ b/scripts/nodes/client-get-users.ts
@@ -1,6 +1,6 @@
-// Windmill node script — calls client GET /anonymous-users?appId=...
+// Windmill node script — calls client GET /anonymous-users?orgId=...
 export async function main(
-  appId: string,
+  orgId: string,
   limit?: number,
   offset?: number,
   serviceEnvs?: Record<string, string>,
@@ -10,7 +10,7 @@ export async function main(
   if (!baseUrl) throw new Error("CLIENT_SERVICE_URL is not set");
   if (!apiKey) throw new Error("CLIENT_SERVICE_API_KEY is not set");
 
-  const params = new URLSearchParams({ appId });
+  const params = new URLSearchParams({ orgId });
   if (limit) params.set("limit", String(limit));
   if (offset) params.set("offset", String(offset));
 

--- a/scripts/nodes/stripe-create-checkout.ts
+++ b/scripts/nodes/stripe-create-checkout.ts
@@ -12,7 +12,6 @@ export async function main(
   brandId?: string,
   campaignId?: string,
   runId?: string,
-  appId?: string,
   serviceEnvs?: Record<string, string>,
 ) {
   const baseUrl = serviceEnvs?.STRIPE_SERVICE_URL ?? Bun.env.STRIPE_SERVICE_URL;
@@ -30,7 +29,7 @@ export async function main(
       },
       body: JSON.stringify({
         lineItems, successUrl, cancelUrl, mode, customerId, customerEmail,
-        metadata, discounts, orgId, brandId, campaignId, runId, appId,
+        metadata, discounts, orgId, brandId, campaignId, runId,
       }),
     }
   );

--- a/scripts/nodes/stripe-create-coupon.ts
+++ b/scripts/nodes/stripe-create-coupon.ts
@@ -1,6 +1,6 @@
 // Windmill node script — calls stripe POST /coupons/create
 export async function main(
-  appId: string,
+  orgId: string,
   id?: string,
   name?: string,
   percentOff?: number,
@@ -26,7 +26,7 @@ export async function main(
         "Content-Type": "application/json",
         "X-API-Key": apiKey,
       },
-      body: JSON.stringify({ appId, id, name, percentOff, amountOffInCents, currency, duration, durationInMonths, maxRedemptions, redeemBy, metadata }),
+      body: JSON.stringify({ orgId, id, name, percentOff, amountOffInCents, currency, duration, durationInMonths, maxRedemptions, redeemBy, metadata }),
     }
   );
 

--- a/scripts/nodes/stripe-create-price.ts
+++ b/scripts/nodes/stripe-create-price.ts
@@ -1,6 +1,6 @@
 // Windmill node script — calls stripe POST /prices/create
 export async function main(
-  appId: string,
+  orgId: string,
   productId: string,
   unitAmountInCents: number,
   currency?: string,
@@ -21,7 +21,7 @@ export async function main(
         "Content-Type": "application/json",
         "X-API-Key": apiKey,
       },
-      body: JSON.stringify({ appId, productId, unitAmountInCents, currency, recurring, metadata }),
+      body: JSON.stringify({ orgId, productId, unitAmountInCents, currency, recurring, metadata }),
     }
   );
 

--- a/scripts/nodes/stripe-create-product.ts
+++ b/scripts/nodes/stripe-create-product.ts
@@ -1,6 +1,6 @@
 // Windmill node script — calls stripe POST /products/create
 export async function main(
-  appId: string,
+  orgId: string,
   name: string,
   description?: string,
   id?: string,
@@ -20,7 +20,7 @@ export async function main(
         "Content-Type": "application/json",
         "X-API-Key": apiKey,
       },
-      body: JSON.stringify({ appId, name, description, id, metadata }),
+      body: JSON.stringify({ orgId, name, description, id, metadata }),
     }
   );
 

--- a/scripts/nodes/stripe-get-coupon.ts
+++ b/scripts/nodes/stripe-get-coupon.ts
@@ -1,6 +1,6 @@
 // Windmill node script — calls stripe GET /coupons/:couponId
 export async function main(
-  appId: string,
+  orgId: string,
   couponId: string,
   serviceEnvs?: Record<string, string>,
 ) {
@@ -10,7 +10,7 @@ export async function main(
   if (!apiKey) throw new Error("STRIPE_SERVICE_API_KEY is not set");
 
   const url = new URL(`${baseUrl}/coupons/${couponId}`);
-  url.searchParams.set("appId", appId);
+  url.searchParams.set("orgId", orgId);
 
   const response = await fetch(
     url.toString(),

--- a/scripts/nodes/stripe-get-prices-by-product.ts
+++ b/scripts/nodes/stripe-get-prices-by-product.ts
@@ -1,6 +1,6 @@
 // Windmill node script — calls stripe GET /prices/by-product/:productId
 export async function main(
-  appId: string,
+  orgId: string,
   productId: string,
   serviceEnvs?: Record<string, string>,
 ) {
@@ -10,7 +10,7 @@ export async function main(
   if (!apiKey) throw new Error("STRIPE_SERVICE_API_KEY is not set");
 
   const url = new URL(`${baseUrl}/prices/by-product/${productId}`);
-  url.searchParams.set("appId", appId);
+  url.searchParams.set("orgId", orgId);
 
   const response = await fetch(
     url.toString(),

--- a/scripts/nodes/stripe-get-product.ts
+++ b/scripts/nodes/stripe-get-product.ts
@@ -1,6 +1,6 @@
 // Windmill node script — calls stripe GET /products/:productId
 export async function main(
-  appId: string,
+  orgId: string,
   productId: string,
   serviceEnvs?: Record<string, string>,
 ) {
@@ -10,7 +10,7 @@ export async function main(
   if (!apiKey) throw new Error("STRIPE_SERVICE_API_KEY is not set");
 
   const url = new URL(`${baseUrl}/products/${productId}`);
-  url.searchParams.set("appId", appId);
+  url.searchParams.set("orgId", orgId);
 
   const response = await fetch(
     url.toString(),

--- a/scripts/nodes/stripe-get-stats.ts
+++ b/scripts/nodes/stripe-get-stats.ts
@@ -3,7 +3,6 @@ export async function main(
   runIds?: string[],
   orgId?: string,
   brandId?: string,
-  appId?: string,
   campaignId?: string,
   serviceEnvs?: Record<string, string>,
 ) {
@@ -20,7 +19,7 @@ export async function main(
         "Content-Type": "application/json",
         "X-API-Key": apiKey,
       },
-      body: JSON.stringify({ runIds, orgId, brandId, appId, campaignId }),
+      body: JSON.stringify({ runIds, orgId, brandId, campaignId }),
     }
   );
 

--- a/scripts/nodes/transactional-email-get-stats.ts
+++ b/scripts/nodes/transactional-email-get-stats.ts
@@ -1,6 +1,5 @@
 // Windmill node script — calls transactional-email POST /stats
 export async function main(
-  appId?: string,
   orgId?: string,
   userId?: string,
   eventType?: string,
@@ -19,7 +18,7 @@ export async function main(
         "Content-Type": "application/json",
         "x-api-key": apiKey,
       },
-      body: JSON.stringify({ appId, orgId, userId, eventType }),
+      body: JSON.stringify({ orgId, userId, eventType }),
     }
   );
 

--- a/scripts/nodes/transactional-email-send.ts
+++ b/scripts/nodes/transactional-email-send.ts
@@ -1,6 +1,5 @@
 // Windmill node script — calls transactional-email POST /send
 export async function main(
-  appId: string,
   eventType: string,
   recipientEmail?: string,
   brandId?: string,
@@ -24,7 +23,7 @@ export async function main(
         "Content-Type": "application/json",
         "x-api-key": apiKey,
       },
-      body: JSON.stringify({ appId, eventType, recipientEmail, brandId, campaignId, productId, userId, orgId, metadata }),
+      body: JSON.stringify({ eventType, recipientEmail, brandId, campaignId, productId, userId, orgId, metadata }),
     }
   );
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -12,7 +12,6 @@ export const workflows = pgTable(
   "workflows",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    appId: text("app_id").notNull(),
     orgId: text("org_id").notNull(),
     brandId: text("brand_id"),
     humanId: text("human_id"),
@@ -34,16 +33,15 @@ export const workflows = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
   },
   (table) => [
-    index("idx_workflows_app").on(table.appId),
     index("idx_workflows_org").on(table.orgId),
     index("idx_workflows_campaign").on(table.campaignId),
-    uniqueIndex("idx_workflows_app_name_unique")
-      .on(table.appId, table.name),
-    uniqueIndex("idx_workflows_app_signature_unique")
-      .on(table.appId, table.signature),
-    uniqueIndex("idx_workflows_app_signature_name_unique")
-      .on(table.appId, table.signatureName),
-    index("idx_workflows_style").on(table.appId, table.styleName),
+    uniqueIndex("idx_workflows_org_name_unique")
+      .on(table.orgId, table.name),
+    uniqueIndex("idx_workflows_org_signature_unique")
+      .on(table.orgId, table.signature),
+    uniqueIndex("idx_workflows_org_signature_name_unique")
+      .on(table.orgId, table.signatureName),
+    index("idx_workflows_org_style").on(table.orgId, table.styleName),
   ]
 );
 
@@ -53,9 +51,11 @@ export const workflowRuns = pgTable(
     id: uuid("id").primaryKey().defaultRandom(),
     workflowId: uuid("workflow_id").references(() => workflows.id),
     orgId: text("org_id").notNull(),
+    userId: text("user_id"),
     campaignId: text("campaign_id"),
     subrequestId: text("subrequest_id"),
     runId: text("run_id"),
+    parentRunId: text("parent_run_id"),
     windmillJobId: text("windmill_job_id"),
     windmillWorkspace: text("windmill_workspace").notNull().default("prod"),
     status: text("status").notNull().default("queued"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { db } from "./db/index.js";
 import { workflowRuns } from "./db/schema.js";
 import { getWindmillClient } from "./lib/windmill-client.js";
 import { JobPoller } from "./lib/job-poller.js";
+import { requireIdentity } from "./middleware/auth.js";
 import healthRoutes from "./routes/health.js";
 import workflowsRoutes from "./routes/workflows.js";
 import workflowRunsRoutes from "./routes/workflow-runs.js";
@@ -16,11 +17,14 @@ const PORT = process.env.PORT ?? 3000;
 app.use(cors());
 app.use(express.json());
 
-// Routes
+// Public routes (no identity required)
 app.use(healthRoutes);
+app.use(openapiRoutes);
+
+// Identity-gated routes
+app.use(requireIdentity);
 app.use(workflowsRoutes);
 app.use(workflowRunsRoutes);
-app.use(openapiRoutes);
 
 // 404 fallback
 app.use((_req, res) => {

--- a/src/lib/dag-to-openflow.ts
+++ b/src/lib/dag-to-openflow.ts
@@ -68,7 +68,8 @@ export function dagToOpenFlow(dag: DAG, name: string): OpenFlow {
 
   // Collect all flow_input fields referenced by any node so Windmill accepts them
   const schemaProperties: Record<string, { type: string; description?: string }> = {
-    appId: { type: "string", description: "Application identifier" },
+    orgId: { type: "string", description: "Organization identifier" },
+    userId: { type: "string", description: "User identifier" },
     serviceEnvs: { type: "object", description: "Service URLs and API keys injected by workflow-service" },
   };
   for (const node of dag.nodes) {
@@ -356,9 +357,12 @@ function nodeToModule(node: DAGNode, dag: DAG): FlowModule | null {
     node.inputMapping,
   );
 
-  // Auto-inject appId and serviceEnvs from flow_input unless explicitly mapped
-  if (!inputTransforms.appId) {
-    inputTransforms.appId = { type: "javascript", expr: "flow_input.appId" };
+  // Auto-inject orgId, userId, and serviceEnvs from flow_input unless explicitly mapped
+  if (!inputTransforms.orgId) {
+    inputTransforms.orgId = { type: "javascript", expr: "flow_input.orgId" };
+  }
+  if (!inputTransforms.userId) {
+    inputTransforms.userId = { type: "javascript", expr: "flow_input.userId" };
   }
   if (!inputTransforms.serviceEnvs) {
     inputTransforms.serviceEnvs = { type: "javascript", expr: "flow_input.serviceEnvs" };
@@ -394,9 +398,12 @@ function buildFailureModule(node: DAGNode): FlowModule | null {
 
   const inputTransforms = buildInputTransforms(node.config, node.inputMapping);
 
-  // Auto-inject appId and serviceEnvs from flow_input unless explicitly mapped
-  if (!inputTransforms.appId) {
-    inputTransforms.appId = { type: "javascript", expr: "flow_input.appId" };
+  // Auto-inject orgId, userId, and serviceEnvs from flow_input unless explicitly mapped
+  if (!inputTransforms.orgId) {
+    inputTransforms.orgId = { type: "javascript", expr: "flow_input.orgId" };
+  }
+  if (!inputTransforms.userId) {
+    inputTransforms.userId = { type: "javascript", expr: "flow_input.userId" };
   }
   if (!inputTransforms.serviceEnvs) {
     inputTransforms.serviceEnvs = { type: "javascript", expr: "flow_input.serviceEnvs" };

--- a/src/lib/key-service-client.ts
+++ b/src/lib/key-service-client.ts
@@ -5,6 +5,11 @@ export interface ProviderRequirementsResponse {
   providers: string[];
 }
 
+export interface KeyDecryptResponse {
+  key: string;
+  keySource: "platform" | "org";
+}
+
 function getKeyServiceConfig(): { baseUrl: string; apiKey: string } {
   const baseUrl = process.env.KEY_SERVICE_URL;
   const apiKey = process.env.KEY_SERVICE_API_KEY;
@@ -44,9 +49,8 @@ export async function fetchProviderRequirements(
 }
 
 export async function fetchAnthropicKey(
-  keySource: "app" | "byok" | "platform",
-  opts: { appId: string; orgId: string },
-): Promise<string> {
+  opts: { orgId: string; userId: string },
+): Promise<KeyDecryptResponse> {
   const { baseUrl, apiKey } = getKeyServiceConfig();
 
   const callerHeaders = {
@@ -55,12 +59,11 @@ export async function fetchAnthropicKey(
     "x-caller-path": "/workflows/generate",
   };
 
-  const path =
-    keySource === "platform"
-      ? `/internal/platform-keys/anthropic/decrypt`
-      : keySource === "app"
-        ? `/internal/app-keys/anthropic/decrypt?appId=${encodeURIComponent(opts.appId)}`
-        : `/internal/keys/anthropic/decrypt?orgId=${encodeURIComponent(opts.orgId)}`;
+  const params = new URLSearchParams({
+    orgId: opts.orgId,
+    userId: opts.userId,
+  });
+  const path = `/keys/anthropic/decrypt?${params}`;
 
   const res = await fetch(`${baseUrl}${path}`, {
     method: "GET",
@@ -73,10 +76,10 @@ export async function fetchAnthropicKey(
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `key-service error: GET ${path.split("?")[0]} -> ${res.status} ${res.statusText}: ${text}`
+      `key-service error: GET /keys/anthropic/decrypt -> ${res.status} ${res.statusText}: ${text}`
     );
   }
 
-  const body = (await res.json()) as { provider: string; key: string };
-  return body.key;
+  const body = (await res.json()) as KeyDecryptResponse;
+  return body;
 }

--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -223,7 +223,7 @@ Campaign service orchestrates workflow execution with budget constraints. Key co
 4. Set retries: 0 for non-idempotent operations (email sends, SMS, queue consumes)
 5. Use onError for workflows that need cleanup on failure (e.g. mark run as failed via end-run)
 6. Use "condition" nodes for branching, not skipIf (skipIf only skips one step)
-7. The http.call node auto-injects appId and serviceEnvs from flow_input — no need to map them
+7. The http.call node auto-injects orgId, userId, and serviceEnvs from flow_input — no need to map them
 8. Campaign workflows should use the chassis pattern: gate-check → start-run → ... → end-run, with onError → end-run-error
 
 ## Example: Cold Email Outreach with Branching
@@ -247,7 +247,7 @@ Campaign service orchestrates workflow execution with budget constraints. Key co
       "id": "fetch-lead",
       "type": "http.call",
       "config": { "service": "lead", "method": "POST", "path": "/buffer/next" },
-      "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId", "body.appId": "$ref:start-run.output.appId" },
+      "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId", "body.orgId": "$ref:start-run.output.orgId" },
       "retries": 0
     },
     { "id": "check-lead", "type": "condition" },

--- a/src/lib/service-catalog.ts
+++ b/src/lib/service-catalog.ts
@@ -47,8 +47,8 @@ export const SERVICE_CATALOG: ServiceInfo[] = [
   },
   {
     name: "key",
-    description: "API key management: per-app BYOK secrets (Stripe keys, etc.)",
-    keyEndpoints: ["POST /internal/app-keys", "GET /internal/app-keys/:provider/decrypt"],
+    description: "API key management: resolve external API keys by org/user",
+    keyEndpoints: ["GET /keys/:provider/decrypt"],
   },
   {
     name: "client",

--- a/src/lib/signature-words.ts
+++ b/src/lib/signature-words.ts
@@ -115,7 +115,7 @@ const UNIQUE_WORDS = [...new Set(WORDS)];
  * words are exhausted.
  *
  * @param signature - The SHA-256 hex hash of the DAG
- * @param usedNames - Set of signatureNames already taken in this (appId) scope
+ * @param usedNames - Set of signatureNames already taken in this (orgId) scope
  * @returns A unique signatureName
  */
 export function pickSignatureName(

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -12,3 +12,23 @@ export function requireApiKey(
   }
   next();
 }
+
+export function requireIdentity(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const orgId = req.headers["x-org-id"] as string | undefined;
+  const userId = req.headers["x-user-id"] as string | undefined;
+
+  if (!orgId || !userId) {
+    res.status(400).json({
+      error: "x-org-id and x-user-id headers are required",
+    });
+    return;
+  }
+
+  res.locals.orgId = orgId;
+  res.locals.userId = userId;
+  next();
+}

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -26,20 +26,20 @@ router.post(
     try {
       const body = ExecuteByNameSchema.parse(req.body);
 
-      // Look up workflow by (appId + name)
+      // Look up workflow by (orgId + name)
       const [workflow] = await db
         .select()
         .from(workflows)
         .where(
           and(
-            eq(workflows.appId, body.appId),
+            eq(workflows.orgId, body.orgId),
             eq(workflows.name, req.params.name),
           )
         );
 
       if (!workflow) {
         res.status(404).json({
-          error: `Workflow "${req.params.name}" not found for app "${body.appId}"`,
+          error: `Workflow "${req.params.name}" not found for org "${body.orgId}"`,
         });
         return;
       }
@@ -51,12 +51,13 @@ router.post(
         return;
       }
 
-      // Run in Windmill — inject appId so nodes can access it via flow_input.appId
+      // Run in Windmill — inject orgId and userId so nodes can access them via flow_input
+      const userId = res.locals.userId as string;
       let windmillJobId: string | null = null;
       const client = getWindmillClient();
       if (client) {
         try {
-          const flowInputs = { ...body.inputs, appId: body.appId, serviceEnvs: collectServiceEnvs() };
+          const flowInputs = { ...body.inputs, orgId: body.orgId, userId, serviceEnvs: collectServiceEnvs() };
           windmillJobId = await client.runFlow(
             workflow.windmillFlowPath,
             flowInputs
@@ -74,12 +75,13 @@ router.post(
       }
 
       // Create workflow run in DB
-      // Use provided orgId (user context) or fall back to workflow's orgId
       const [run] = await db
         .insert(workflowRuns)
         .values({
           workflowId: workflow.id,
-          orgId: body.orgId ?? workflow.orgId,
+          orgId: body.orgId,
+          userId,
+          parentRunId: body.parentRunId,
           campaignId: workflow.campaignId,
           subrequestId: workflow.subrequestId,
           runId: body.runId,
@@ -124,13 +126,13 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
       return;
     }
 
-    // Run in Windmill — inject appId so nodes can access it via flow_input.appId
+    // Run in Windmill — inject orgId and userId so nodes can access them via flow_input
+    const executeUserId = res.locals.userId as string;
     let windmillJobId: string | null = null;
     const client = getWindmillClient();
     if (client) {
       try {
-        const appId = body.appId ?? workflow.appId;
-        const flowInputs = { ...body.inputs, ...(appId ? { appId } : {}), serviceEnvs: collectServiceEnvs() };
+        const flowInputs = { ...body.inputs, orgId: workflow.orgId, userId: executeUserId, serviceEnvs: collectServiceEnvs() };
         windmillJobId = await client.runFlow(
           workflow.windmillFlowPath,
           flowInputs
@@ -150,6 +152,8 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
       .values({
         workflowId: workflow.id,
         orgId: workflow.orgId,
+        userId: executeUserId,
+        parentRunId: body.parentRunId,
         campaignId: workflow.campaignId,
         subrequestId: workflow.subrequestId,
         runId: body.runId,

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -45,11 +45,10 @@ function generateFlowPath(scope: string, name: string): string {
 router.post("/workflows/generate", requireApiKey, async (req, res) => {
   try {
     const body = GenerateWorkflowSchema.parse(req.body);
+    const orgId = body.orgId;
+    const userId = res.locals.userId as string;
 
-    const anthropicApiKey = await fetchAnthropicKey(body.keySource, {
-      appId: body.appId,
-      orgId: body.orgId,
-    });
+    const { key: anthropicApiKey } = await fetchAnthropicKey({ orgId, userId });
 
     const generated = await generateWorkflow(
       { description: body.description, hints: body.hints, style: body.style },
@@ -62,7 +61,7 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
     const existingWorkflows = await db
       .select({ signatureName: workflows.signatureName })
       .from(workflows)
-      .where(eq(workflows.appId, body.appId));
+      .where(eq(workflows.orgId, orgId));
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
 
     const [existing] = await db
@@ -70,7 +69,7 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
       .from(workflows)
       .where(
         and(
-          eq(workflows.appId, body.appId),
+          eq(workflows.orgId, orgId),
           eq(workflows.signature, signature),
         )
       );
@@ -140,13 +139,13 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
           .replace(/[^a-z0-9]+/g, "-")
           .replace(/^-|-$/g, "");
 
-        // Count existing workflows with same (appId, styleName) for versioning
+        // Count existing workflows with same (orgId, styleName) for versioning
         const sameStyle = await db
           .select({ id: workflows.id })
           .from(workflows)
           .where(
             and(
-              eq(workflows.appId, body.appId),
+              eq(workflows.orgId, orgId),
               eq(workflows.styleName, styleName),
             )
           );
@@ -168,7 +167,7 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
 
       const name = `${generated.category}-${generated.channel}-${generated.audienceType}-${signatureName}`;
       const openFlow = dagToOpenFlow(dag, name);
-      const flowPath = generateFlowPath(body.appId, name);
+      const flowPath = generateFlowPath(orgId, name);
       const client = getWindmillClient();
 
       if (client) {
@@ -188,8 +187,7 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
       const [created] = await db
         .insert(workflows)
         .values({
-          appId: body.appId,
-          orgId: body.orgId,
+          orgId,
           name,
           displayName,
           description: generated.description,
@@ -292,7 +290,7 @@ router.post("/workflows", requireApiKey, async (req, res) => {
     const existingWorkflows = await db
       .select({ signatureName: workflows.signatureName })
       .from(workflows)
-      .where(eq(workflows.appId, body.appId));
+      .where(eq(workflows.orgId, body.orgId));
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
     const signatureName = pickSignatureName(signature, usedNames);
 
@@ -300,7 +298,6 @@ router.post("/workflows", requireApiKey, async (req, res) => {
     const [workflow] = await db
       .insert(workflows)
       .values({
-        appId: body.appId,
         orgId: body.orgId,
         brandId: body.brandId,
         campaignId: body.campaignId,
@@ -328,10 +325,11 @@ router.post("/workflows", requireApiKey, async (req, res) => {
   }
 });
 
-// PUT /workflows/deploy — Batch upsert workflows by (appId + signature)
+// PUT /workflows/deploy — Batch upsert workflows by (orgId + signature)
 router.put("/workflows/deploy", requireApiKey, async (req, res) => {
   try {
     const body = DeployWorkflowsSchema.parse(req.body);
+    const orgId = body.orgId;
 
     // Validate ALL DAGs first — reject if any are invalid
     const dagErrors: { index: number; errors: unknown[] }[] = [];
@@ -346,27 +344,26 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
       return;
     }
 
-    // Fetch all existing signatureNames for this appId to avoid collisions
+    // Fetch all existing signatureNames for this orgId to avoid collisions
     const existingWorkflows = await db
       .select({ signatureName: workflows.signatureName })
       .from(workflows)
-      .where(eq(workflows.appId, body.appId));
+      .where(eq(workflows.orgId, orgId));
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
 
-    const orgId = body.orgId ?? body.appId;
     const results: { id: string; name: string; category: string; channel: string; audienceType: string; signature: string; signatureName: string; action: "created" | "updated" }[] = [];
 
     for (const wf of body.workflows) {
       const dag = wf.dag as DAG;
       const signature = computeDAGSignature(wf.dag);
 
-      // Check if workflow already exists for this (appId, signature)
+      // Check if workflow already exists for this (orgId, signature)
       const [existing] = await db
         .select()
         .from(workflows)
         .where(
           and(
-            eq(workflows.appId, body.appId),
+            eq(workflows.orgId, orgId),
             eq(workflows.signature, signature),
           )
         );
@@ -420,7 +417,7 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
 
         const name = `${wf.category}-${wf.channel}-${wf.audienceType}-${signatureName}`;
         const openFlow = dagToOpenFlow(dag, name);
-        const flowPath = generateFlowPath(body.appId, name);
+        const flowPath = generateFlowPath(orgId, name);
         const client = getWindmillClient();
 
         if (client) {
@@ -440,7 +437,6 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
         const [created] = await db
           .insert(workflows)
           .values({
-            appId: body.appId,
             orgId,
             name,
             displayName: name,
@@ -487,11 +483,11 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
       res.status(400).json({ error: "Validation error", details: query.error });
       return;
     }
-    const { appId, category, channel, audienceType, objective } = query.data;
+    const { orgId, category, channel, audienceType, objective } = query.data;
 
     // 1. Get all workflows matching the dimensions (all filters optional)
     const conditions: ReturnType<typeof eq>[] = [];
-    if (appId) conditions.push(eq(workflows.appId, appId));
+    if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (category) conditions.push(eq(workflows.category, category));
     if (channel) conditions.push(eq(workflows.channel, channel));
     if (audienceType) conditions.push(eq(workflows.audienceType, audienceType));
@@ -634,15 +630,12 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
 // GET /workflows — List workflows
 router.get("/workflows", requireApiKey, async (req, res) => {
   try {
-    const { orgId, appId, brandId, humanId, campaignId, category, channel, audienceType } = req.query;
+    const { orgId, brandId, humanId, campaignId, category, channel, audienceType } = req.query;
 
     const conditions: ReturnType<typeof eq>[] = [];
 
     if (orgId && typeof orgId === "string") {
       conditions.push(eq(workflows.orgId, orgId));
-    }
-    if (appId && typeof appId === "string") {
-      conditions.push(eq(workflows.appId, appId));
     }
     if (brandId && typeof brandId === "string") {
       conditions.push(eq(workflows.brandId, brandId));

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -108,12 +108,11 @@ export const WorkflowAudienceTypeSchema = z
 
 export const CreateWorkflowSchema = z
   .object({
-    appId: z.string().min(1).describe("Application identifier. Workflows are scoped to appId."),
     orgId: z.string().min(1).describe("Organization ID that owns this workflow."),
     brandId: z.string().optional().describe("Optional brand ID for scoping."),
     campaignId: z.string().optional().describe("Optional campaign ID for scoping."),
     subrequestId: z.string().optional().describe("Optional subrequest ID for cost tracking."),
-    name: z.string().min(1).describe("Workflow name. Must be unique within the appId. Used to execute by name later."),
+    name: z.string().min(1).describe("Workflow name. Must be unique within the orgId. Used to execute by name later."),
     description: z.string().optional().describe("Human-readable description of what this workflow does."),
     category: WorkflowCategorySchema.describe("Workflow category."),
     channel: WorkflowChannelSchema.describe("Workflow distribution channel."),
@@ -132,15 +131,14 @@ export const UpdateWorkflowSchema = z
 
 export const WorkflowResponseSchema = z
   .object({
-    id: z.string().uuid().describe("Workflow UUID. Not needed for execution — use name + appId instead."),
-    appId: z.string().describe("Application identifier."),
+    id: z.string().uuid().describe("Workflow UUID."),
     orgId: z.string().describe("Organization ID."),
     brandId: z.string().nullable(),
     humanId: z.string().nullable().describe("Human ID if this workflow was generated in a human expert's style."),
     campaignId: z.string().nullable(),
     subrequestId: z.string().nullable(),
     styleName: z.string().nullable().describe("Base style name used for versioned naming (e.g. 'hormozi'). Null for non-styled workflows."),
-    name: z.string().describe("Workflow name. Use this with appId to execute via /workflows/by-name/{name}/execute."),
+    name: z.string().describe("Workflow name. Use this with orgId to execute via /workflows/by-name/{name}/execute."),
     displayName: z.string().nullable().describe("Human-readable display name. Falls back to name if not set."),
     description: z.string().nullable(),
     category: WorkflowCategorySchema.describe("Workflow category."),
@@ -169,13 +167,11 @@ export const ValidationResultSchema = z
 
 export const ExecuteWorkflowSchema = z
   .object({
-    appId: z.string().optional().describe(
-      "App ID override. If not provided, falls back to the workflow's stored appId."
-    ),
     inputs: z.record(z.unknown()).optional().describe(
       "Runtime inputs for the workflow. Accessible in nodes via $ref:flow_input.fieldName."
     ),
     runId: z.string().optional().describe("Optional external run ID for cost tracking via runs-service."),
+    parentRunId: z.string().optional().describe("Optional parent run ID to link this execution to a parent run."),
   })
   .openapi("ExecuteWorkflowRequest");
 
@@ -186,7 +182,9 @@ export const WorkflowRunResponseSchema = z
     orgId: z.string(),
     campaignId: z.string().nullable(),
     subrequestId: z.string().nullable(),
+    userId: z.string().nullable().describe("User ID from the execution context."),
     runId: z.string().nullable().describe("External run ID (if provided at execution time)."),
+    parentRunId: z.string().nullable().describe("Parent run ID (if linked to a parent execution)."),
     windmillJobId: z.string().nullable().describe("Internal Windmill job ID (managed automatically)."),
     windmillWorkspace: z.string(),
     status: z.string().describe("Run status: queued, running, completed, failed, or cancelled."),
@@ -213,12 +211,9 @@ export const DeployWorkflowItemSchema = z
 
 export const DeployWorkflowsSchema = z
   .object({
-    appId: z.string().min(1).describe(
-      "Your application identifier. Workflows are scoped to (appId + signature). " +
-      "Use the same appId when executing. This is idempotent — deploying the same DAG updates the existing workflow."
-    ),
-    orgId: z.string().min(1).optional().describe(
-      "Organization ID that owns these workflows. If omitted, falls back to appId for backward compatibility."
+    orgId: z.string().min(1).describe(
+      "Organization ID that owns these workflows. Workflows are scoped to (orgId + signature). " +
+      "This is idempotent — deploying the same DAG updates the existing workflow."
     ),
     workflows: z.array(DeployWorkflowItemSchema).min(1).describe("The workflows to deploy."),
   })
@@ -247,12 +242,12 @@ export const DeployWorkflowsResponseSchema = z
 
 export const ExecuteByNameSchema = z
   .object({
-    appId: z.string().min(1).describe("Must match the appId used during deploy."),
-    orgId: z.string().optional().describe("Organization ID for this execution (overrides workflow's orgId if set)."),
+    orgId: z.string().min(1).describe("Organization ID. Must match the orgId used during deploy."),
     inputs: z.record(z.unknown()).optional().describe(
       "Runtime inputs for the workflow. Accessible in nodes via $ref:flow_input.fieldName."
     ),
     runId: z.string().optional().describe("Optional external run ID for cost tracking via runs-service."),
+    parentRunId: z.string().optional().describe("Optional parent run ID to link this execution to a parent run."),
   })
   .openapi("ExecuteByNameRequest");
 
@@ -305,23 +300,9 @@ export const GenerateWorkflowHintsSchema = z
   })
   .openapi("GenerateWorkflowHints");
 
-export const KeySourceSchema = z
-  .enum(["app", "byok", "platform"])
-  .describe(
-    "Where to resolve the Anthropic API key. " +
-    '"app" fetches the per-app key via /internal/app-keys/anthropic/decrypt. ' +
-    '"platform" fetches the global platform key via /internal/platform-keys/anthropic/decrypt. ' +
-    '"byok" fetches the user\'s own key via /internal/keys/anthropic/decrypt.'
-  )
-  .openapi("KeySource");
-
 export const GenerateWorkflowSchema = z
   .object({
-    appId: z.string().min(1).describe("Application identifier. The generated workflow will be deployed under this appId."),
-    orgId: z.string().min(1).describe("Organization ID."),
-    keySource: KeySourceSchema.describe(
-      'Required. Where to resolve the Anthropic API key: "app", "platform", or "byok".'
-    ),
+    orgId: z.string().min(1).describe("Organization ID. The generated workflow will be deployed under this orgId."),
     description: z.string().min(10).describe(
       "Natural language description of the desired workflow. Be specific about the steps, services, and data flow."
     ),
@@ -361,7 +342,7 @@ export const BestWorkflowObjectiveSchema = z
 
 export const BestWorkflowQuerySchema = z
   .object({
-    appId: z.string().min(1).optional().describe("Application identifier. When omitted, searches across all apps."),
+    orgId: z.string().optional().describe("Organization ID. When omitted, searches across all orgs."),
     category: WorkflowCategorySchema.optional().describe("Filter workflows by category."),
     channel: WorkflowChannelSchema.optional().describe("Filter workflows by channel."),
     audienceType: WorkflowAudienceTypeSchema.optional().describe("Filter workflows by audience type."),
@@ -484,7 +465,6 @@ registry.registerPath({
   request: {
     query: z.object({
       orgId: z.string().optional(),
-      appId: z.string().optional(),
       brandId: z.string().optional(),
       humanId: z.string().optional(),
       campaignId: z.string().optional(),
@@ -755,7 +735,7 @@ registry.registerPath({
   path: "/workflows/deploy",
   summary: "Deploy (upsert) workflows by DAG signature",
   description:
-    "Idempotent: creates new workflows or updates existing ones matched by (appId + DAG signature). " +
+    "Idempotent: creates new workflows or updates existing ones matched by (orgId + DAG signature). " +
     "The workflow name is auto-generated as {category}-{channel}-{audienceType}-{signatureName}. " +
     "signatureName is a human-readable word auto-assigned to each unique DAG. " +
     "After deploying, execute workflows via POST /workflows/by-name/{name}/execute.",

--- a/src/workflows/polarity/discount-expiry-followup.ts
+++ b/src/workflows/polarity/discount-expiry-followup.ts
@@ -22,7 +22,7 @@ export const discountExpiryFollowup: DAG = {
       type: "client-service",
       config: {
         action: "list",
-        appId: "polaritycourse",
+        orgId: "polaritycourse",
       },
     },
     {
@@ -37,7 +37,7 @@ export const discountExpiryFollowup: DAG = {
       id: "send-followup",
       type: "transactional-email.send",
       config: {
-        appId: "polaritycourse",
+        orgId: "polaritycourse",
         eventType: "webinar-discount-expiring",
       },
       inputMapping: {

--- a/src/workflows/polarity/payment-confirmation.ts
+++ b/src/workflows/polarity/payment-confirmation.ts
@@ -27,7 +27,7 @@ export const paymentConfirmation: DAG = {
       id: "send-confirmation",
       type: "transactional-email.send",
       config: {
-        appId: "polaritycourse",
+        orgId: "polaritycourse",
         eventType: "course-purchase-confirmation",
       },
       inputMapping: {

--- a/src/workflows/polarity/post-registration-welcome.ts
+++ b/src/workflows/polarity/post-registration-welcome.ts
@@ -15,7 +15,7 @@ export const postRegistrationWelcome: DAG = {
       id: "send-welcome",
       type: "transactional-email.send",
       config: {
-        appId: "polaritycourse",
+        orgId: "polaritycourse",
         eventType: "webinar-registration-welcome",
       },
       inputMapping: {

--- a/src/workflows/polarity/post-webinar-offer.ts
+++ b/src/workflows/polarity/post-webinar-offer.ts
@@ -17,7 +17,7 @@ export const postWebinarOffer: DAG = {
       type: "client-service",
       config: {
         action: "list",
-        appId: "polaritycourse",
+        orgId: "polaritycourse",
       },
     },
     {
@@ -32,7 +32,7 @@ export const postWebinarOffer: DAG = {
       id: "send-offer",
       type: "transactional-email.send",
       config: {
-        appId: "polaritycourse",
+        orgId: "polaritycourse",
         eventType: "webinar-post-offer",
       },
       inputMapping: {

--- a/src/workflows/polarity/reminder-sequence.ts
+++ b/src/workflows/polarity/reminder-sequence.ts
@@ -17,7 +17,7 @@ export const reminderSequence: DAG = {
       type: "client-service",
       config: {
         action: "list",
-        appId: "polaritycourse",
+        orgId: "polaritycourse",
       },
     },
     {
@@ -32,7 +32,7 @@ export const reminderSequence: DAG = {
       id: "send-reminder",
       type: "transactional-email.send",
       config: {
-        appId: "polaritycourse",
+        orgId: "polaritycourse",
       },
       inputMapping: {
         recipientEmail: "$ref:loop-contacts.output.email",

--- a/src/workflows/polarity/sms-reminder.ts
+++ b/src/workflows/polarity/sms-reminder.ts
@@ -20,7 +20,7 @@ export const smsReminder: DAG = {
       type: "client-service",
       config: {
         action: "list",
-        appId: "polaritycourse",
+        orgId: "polaritycourse",
       },
     },
     {

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -158,12 +158,12 @@ export const DAG_WITH_CLIENT_NODES: DAG = {
     {
       id: "create-user",
       type: "client.createUser",
-      config: { appId: "test-app", email: "test@example.com" },
+      config: { orgId: "test-app", email: "test@example.com" },
     },
     {
       id: "list-users",
       type: "client.getUsers",
-      config: { appId: "test-app" },
+      config: { orgId: "test-app" },
     },
     {
       id: "update-user",
@@ -185,7 +185,7 @@ export const DAG_WITH_TRANSACTIONAL_EMAIL_SEND: DAG = {
     {
       id: "send-email",
       type: "transactional-email.send",
-      config: { appId: "test-app", eventType: "welcome" },
+      config: { orgId: "test-app", eventType: "welcome" },
     },
   ],
   edges: [],
@@ -196,12 +196,12 @@ export const DAG_WITH_MIXED_DOT_NOTATION: DAG = {
     {
       id: "create-user",
       type: "client.createUser",
-      config: { appId: "test-app", email: "user@example.com" },
+      config: { orgId: "test-app", email: "user@example.com" },
     },
     {
       id: "send-welcome",
       type: "transactional-email.send",
-      config: { appId: "test-app", eventType: "welcome" },
+      config: { orgId: "test-app", eventType: "welcome" },
       inputMapping: {
         recipientEmail: "$ref:create-user.output.user.email",
       },
@@ -260,7 +260,7 @@ export const DAG_WITH_RETRIES_ZERO: DAG = {
     {
       id: "send-email",
       type: "transactional-email.send",
-      config: { appId: "test-app", eventType: "welcome" },
+      config: { orgId: "test-app", eventType: "welcome" },
       retries: 0,
     },
   ],
@@ -370,7 +370,7 @@ export const DAG_WITH_DOT_NOTATION_AND_STATIC_BASE: DAG = {
       },
       inputMapping: {
         "body.to": "$ref:start-run.output.lead.data.email",
-        "body.appId": "$ref:start-run.output.appId",
+        "body.orgId": "$ref:start-run.output.orgId",
         "body.subject": "$ref:email-generate.output.subject",
         "body.metadata.emailGenerationId": "$ref:email-generate.output.id",
       },
@@ -499,7 +499,7 @@ export const POLARITY_WELCOME_DAG: DAG = {
       id: "send-welcome",
       type: "transactional-email.send",
       config: {
-        appId: "polaritycourse",
+        orgId: "polaritycourse",
         eventType: "webinar-registration-welcome",
       },
       inputMapping: {

--- a/tests/integration/best-workflow.test.ts
+++ b/tests/integration/best-workflow.test.ts
@@ -92,10 +92,11 @@ import supertest from "supertest";
 import app from "../../src/index.js";
 
 const request = supertest(app);
-const AUTH = { "x-api-key": "test-api-key" };
+const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1" };
+const AUTH = { "x-api-key": "test-api-key", ...IDENTITY };
 
 const BASE_QUERY = {
-  appId: "app1",
+  orgId: "org1",
   category: "sales",
   channel: "email",
   audienceType: "cold-outreach",
@@ -105,7 +106,6 @@ const BASE_QUERY = {
 function makeWorkflow(overrides: Record<string, unknown> = {}) {
   return {
     id: "wf-" + Math.random().toString(36).slice(2, 10),
-    appId: "app1",
     orgId: "org1",
     name: "sales-email-cold-outreach-alpha",
     displayName: null,
@@ -297,6 +297,7 @@ describe("GET /workflows/best", () => {
   it("requires authentication", async () => {
     const res = await request
       .get("/workflows/best")
+      .set(IDENTITY)
       .query(BASE_QUERY);
 
     expect(res.status).toBe(401);

--- a/tests/integration/generate-workflow.test.ts
+++ b/tests/integration/generate-workflow.test.ts
@@ -76,7 +76,7 @@ vi.mock("../../src/lib/workflow-generator.js", () => {
 });
 
 // Mock fetchAnthropicKey from key-service-client
-const mockFetchAnthropicKey = vi.fn().mockResolvedValue("resolved-anthropic-key");
+const mockFetchAnthropicKey = vi.fn().mockResolvedValue({ key: "resolved-anthropic-key", keySource: "platform" });
 vi.mock("../../src/lib/key-service-client.js", () => ({
   fetchProviderRequirements: vi.fn().mockResolvedValue({ requirements: [], providers: [] }),
   fetchAnthropicKey: (...args: unknown[]) => mockFetchAnthropicKey(...args),
@@ -86,14 +86,15 @@ import supertest from "supertest";
 import app from "../../src/index.js";
 
 const request = supertest(app);
-const AUTH = { "x-api-key": "test-api-key" };
+const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1" };
+const AUTH = { "x-api-key": "test-api-key", ...IDENTITY };
 
 describe("POST /workflows/generate", () => {
   beforeEach(() => {
     mockDbRows.length = 0;
     mockGenerateWorkflow.mockReset();
     mockFetchAnthropicKey.mockReset();
-    mockFetchAnthropicKey.mockResolvedValue("resolved-anthropic-key");
+    mockFetchAnthropicKey.mockResolvedValue({ key: "resolved-anthropic-key", keySource: "platform" });
   });
 
   it("generates and deploys a workflow from description", async () => {
@@ -109,9 +110,7 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        appId: "test-app",
         orgId: "org-1",
-        keySource: "app",
         description: "I want a cold email outreach workflow that finds leads and sends emails",
       });
 
@@ -125,7 +124,7 @@ describe("POST /workflows/generate", () => {
     expect(res.body.category).toBe("sales");
     expect(res.body.channel).toBe("email");
     expect(res.body.audienceType).toBe("cold-outreach");
-    expect(mockFetchAnthropicKey).toHaveBeenCalledWith("app", { appId: "test-app", orgId: "org-1" });
+    expect(mockFetchAnthropicKey).toHaveBeenCalledWith({ orgId: "org-1", userId: "user-1" });
     expect(mockGenerateWorkflow).toHaveBeenCalledWith(
       { description: "I want a cold email outreach workflow that finds leads and sends emails", hints: undefined, style: undefined },
       "resolved-anthropic-key",
@@ -144,9 +143,7 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        appId: "test-app",
         orgId: "org-1",
-        keySource: "app",
         description: "A workflow that does something impossible with bad types",
       });
 
@@ -156,11 +153,13 @@ describe("POST /workflows/generate", () => {
   });
 
   it("requires authentication", async () => {
-    const res = await request.post("/workflows/generate").send({
-      appId: "test-app",
-      orgId: "org-1",
-      description: "test workflow description here",
-    });
+    const res = await request
+      .post("/workflows/generate")
+      .set(IDENTITY)
+      .send({
+        orgId: "org-1",
+        description: "test workflow description here",
+      });
 
     expect(res.status).toBe(401);
   });
@@ -169,7 +168,7 @@ describe("POST /workflows/generate", () => {
     const res = await request
       .post("/workflows/generate")
       .set(AUTH)
-      .send({ appId: "test-app", orgId: "org-1", keySource: "app" });
+      .send({ orgId: "org-1" });
 
     expect(res.status).toBe(400);
   });
@@ -178,50 +177,9 @@ describe("POST /workflows/generate", () => {
     const res = await request
       .post("/workflows/generate")
       .set(AUTH)
-      .send({ appId: "test-app", orgId: "org-1", keySource: "app", description: "hi" });
+      .send({ orgId: "org-1", description: "hi" });
 
     expect(res.status).toBe(400);
-  });
-
-  it("validates keySource is required", async () => {
-    const res = await request
-      .post("/workflows/generate")
-      .set(AUTH)
-      .send({ appId: "test-app", orgId: "org-1", description: "A workflow that does things" });
-
-    expect(res.status).toBe(400);
-  });
-
-  it("validates keySource enum values", async () => {
-    const res = await request
-      .post("/workflows/generate")
-      .set(AUTH)
-      .send({ appId: "test-app", orgId: "org-1", keySource: "invalid", description: "A workflow that does things" });
-
-    expect(res.status).toBe(400);
-  });
-
-  it("accepts keySource 'platform' and resolves via app-keys", async () => {
-    mockGenerateWorkflow.mockResolvedValueOnce({
-      dag: VALID_LINEAR_DAG,
-      category: "sales",
-      channel: "email",
-      audienceType: "cold-outreach",
-      description: "Test",
-    });
-
-    const res = await request
-      .post("/workflows/generate")
-      .set(AUTH)
-      .send({
-        appId: "test-app",
-        orgId: "org-1",
-        keySource: "platform",
-        description: "A workflow that does things with platform key",
-      });
-
-    expect(res.status).toBe(200);
-    expect(mockFetchAnthropicKey).toHaveBeenCalledWith("platform", { appId: "test-app", orgId: "org-1" });
   });
 
   it("passes hints through to generator", async () => {
@@ -237,14 +195,12 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        appId: "test-app",
         orgId: "org-1",
-        keySource: "byok",
         description: "Cold email outreach with lead search",
         hints: { services: ["lead", "email-gateway"] },
       });
 
-    expect(mockFetchAnthropicKey).toHaveBeenCalledWith("byok", { appId: "test-app", orgId: "org-1" });
+    expect(mockFetchAnthropicKey).toHaveBeenCalledWith({ orgId: "org-1", userId: "user-1" });
     expect(mockGenerateWorkflow).toHaveBeenCalledWith(
       { description: "Cold email outreach with lead search", hints: { services: ["lead", "email-gateway"] }, style: undefined },
       "resolved-anthropic-key",
@@ -260,9 +216,7 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        appId: "test-app",
         orgId: "org-1",
-        keySource: "app",
         description: "Some workflow description for testing errors",
       });
 
@@ -272,16 +226,14 @@ describe("POST /workflows/generate", () => {
 
   it("returns 502 when key-service returns an error", async () => {
     mockFetchAnthropicKey.mockRejectedValueOnce(
-      new Error("key-service error: GET /internal/app-keys/anthropic/decrypt -> 404 Not Found: key not configured"),
+      new Error("key-service error: GET /keys/anthropic/decrypt -> 404 Not Found: key not configured"),
     );
 
     const res = await request
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        appId: "test-app",
         orgId: "org-1",
-        keySource: "app",
         description: "Some workflow description for testing key-service errors",
       });
 
@@ -304,9 +256,7 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        appId: "test-app",
         orgId: "org-1",
-        keySource: "app",
         description: "Cold email outreach in the style of Alex Hormozi",
         style: { type: "human", humanId: "human-123", name: "Hormozi" },
       });
@@ -337,9 +287,7 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        appId: "test-app",
         orgId: "org-1",
-        keySource: "app",
         description: "Cold email outreach in my brand style with good copy",
         style: { type: "brand", brandId: "brand-456", name: "My Brand" },
       });
@@ -354,9 +302,7 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        appId: "test-app",
         orgId: "org-1",
-        keySource: "app",
         description: "Cold email outreach in expert style",
         style: { type: "human", name: "Hormozi" },
       });
@@ -369,9 +315,7 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        appId: "test-app",
         orgId: "org-1",
-        keySource: "app",
         description: "Cold email outreach in brand style long description",
         style: { type: "brand", name: "My Brand" },
       });
@@ -392,9 +336,7 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        appId: "test-app",
         orgId: "org-1",
-        keySource: "app",
         description: "Standard cold email outreach without any style preference",
       });
 
@@ -414,9 +356,7 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        appId: "test-app",
         orgId: "org-1",
-        keySource: "app",
         description: "Some workflow description for testing missing config",
       });
 

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -78,7 +78,8 @@ import supertest from "supertest";
 import app from "../../src/index.js";
 
 const request = supertest(app);
-const AUTH = { "x-api-key": "test-api-key" };
+const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1" };
+const AUTH = { "x-api-key": "test-api-key", ...IDENTITY };
 
 describe("POST /workflows/:id/execute", () => {
   beforeEach(() => {
@@ -108,54 +109,9 @@ describe("POST /workflows/:id/execute", () => {
     expect(mockRunFlow).toHaveBeenCalled();
   });
 
-  it("accepts appId in request body and forwards it to Windmill", async () => {
+  it("forwards orgId and userId into Windmill flow inputs", async () => {
     mockWorkflows.push({
       id: "wf-1",
-      appId: null,
-      orgId: "org-1",
-      name: "Test Flow",
-      windmillFlowPath: "f/workflows/org_1/test_flow",
-      windmillWorkspace: "prod",
-      dag: VALID_LINEAR_DAG,
-    });
-
-    await request
-      .post("/workflows/wf-1/execute")
-      .set(AUTH)
-      .send({ appId: "kevinlourd-com", inputs: { email: "user@test.com" } });
-
-    expect(mockRunFlow).toHaveBeenCalledWith(
-      "f/workflows/org_1/test_flow",
-      expect.objectContaining({ appId: "kevinlourd-com", email: "user@test.com" }),
-    );
-  });
-
-  it("prefers body appId over workflow appId", async () => {
-    mockWorkflows.push({
-      id: "wf-1",
-      appId: "old-app-id",
-      orgId: "org-1",
-      name: "Test Flow",
-      windmillFlowPath: "f/workflows/org_1/test_flow",
-      windmillWorkspace: "prod",
-      dag: VALID_LINEAR_DAG,
-    });
-
-    await request
-      .post("/workflows/wf-1/execute")
-      .set(AUTH)
-      .send({ appId: "new-app-id", inputs: {} });
-
-    expect(mockRunFlow).toHaveBeenCalledWith(
-      "f/workflows/org_1/test_flow",
-      expect.objectContaining({ appId: "new-app-id" }),
-    );
-  });
-
-  it("forwards workflow appId into Windmill flow inputs", async () => {
-    mockWorkflows.push({
-      id: "wf-1",
-      appId: "kevinlourd-com",
       orgId: "org-1",
       name: "Test Flow",
       windmillFlowPath: "f/workflows/org_1/test_flow",
@@ -170,13 +126,34 @@ describe("POST /workflows/:id/execute", () => {
 
     expect(mockRunFlow).toHaveBeenCalledWith(
       "f/workflows/org_1/test_flow",
-      expect.objectContaining({ appId: "kevinlourd-com", email: "user@test.com" }),
+      expect.objectContaining({ orgId: "org-1", userId: "user-1", email: "user@test.com" }),
     );
+  });
+
+  it("stores userId and parentRunId in DB", async () => {
+    mockWorkflows.push({
+      id: "wf-1",
+      orgId: "org-1",
+      name: "Test Flow",
+      windmillFlowPath: "f/workflows/org_1/test_flow",
+      windmillWorkspace: "prod",
+      dag: VALID_LINEAR_DAG,
+    });
+
+    const res = await request
+      .post("/workflows/wf-1/execute")
+      .set(AUTH)
+      .send({ inputs: {}, parentRunId: "parent-run-123" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.userId).toBe("user-1");
+    expect(res.body.parentRunId).toBe("parent-run-123");
   });
 
   it("requires authentication", async () => {
     const res = await request
       .post("/workflows/wf-1/execute")
+      .set(IDENTITY)
       .send({ inputs: {} });
 
     expect(res.status).toBe(401);
@@ -190,13 +167,12 @@ describe("POST /workflows/by-name/:name/execute", () => {
     mockRunFlow.mockClear();
   });
 
-  it("executes a workflow by appId + name", async () => {
+  it("executes a workflow by orgId + name", async () => {
     mockWorkflows.push({
       id: "wf-1",
-      appId: "kevinlourd-com",
-      orgId: "kevinlourd-com",
+      orgId: "org-1",
       name: "newsletter-subscribe",
-      windmillFlowPath: "f/workflows/kevinlourd-com/newsletter_subscribe",
+      windmillFlowPath: "f/workflows/org-1/newsletter_subscribe",
       windmillWorkspace: "prod",
       dag: VALID_LINEAR_DAG,
     });
@@ -204,7 +180,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
     const res = await request
       .post("/workflows/by-name/newsletter-subscribe/execute")
       .set(AUTH)
-      .send({ appId: "kevinlourd-com", inputs: { email: "test@example.com" } });
+      .send({ orgId: "org-1", inputs: { email: "test@example.com" } });
 
     expect(res.status).toBe(201);
     expect(res.body.status).toBe("queued");
@@ -212,13 +188,12 @@ describe("POST /workflows/by-name/:name/execute", () => {
     expect(mockRunFlow).toHaveBeenCalled();
   });
 
-  it("forwards appId into Windmill flow inputs", async () => {
+  it("forwards orgId and userId into Windmill flow inputs", async () => {
     mockWorkflows.push({
       id: "wf-1",
-      appId: "kevinlourd-com",
-      orgId: "kevinlourd-com",
+      orgId: "org-1",
       name: "create-user-flow",
-      windmillFlowPath: "f/workflows/kevinlourd_com/create_user_flow",
+      windmillFlowPath: "f/workflows/org_1/create_user_flow",
       windmillWorkspace: "prod",
       dag: VALID_LINEAR_DAG,
     });
@@ -226,83 +201,58 @@ describe("POST /workflows/by-name/:name/execute", () => {
     await request
       .post("/workflows/by-name/create-user-flow/execute")
       .set(AUTH)
-      .send({ appId: "kevinlourd-com", inputs: { email: "user@test.com" } });
+      .send({ orgId: "org-1", inputs: { email: "user@test.com" } });
 
     expect(mockRunFlow).toHaveBeenCalledWith(
-      "f/workflows/kevinlourd_com/create_user_flow",
-      expect.objectContaining({ appId: "kevinlourd-com", email: "user@test.com" }),
+      "f/workflows/org_1/create_user_flow",
+      expect.objectContaining({ orgId: "org-1", userId: "user-1", email: "user@test.com" }),
     );
   });
 
-  it("includes appId in flow inputs even without other inputs", async () => {
+  it("stores userId and parentRunId in DB", async () => {
     mockWorkflows.push({
       id: "wf-1",
-      appId: "kevinlourd-com",
-      orgId: "kevinlourd-com",
+      orgId: "org-1",
       name: "simple-flow",
-      windmillFlowPath: "f/workflows/kevinlourd_com/simple_flow",
+      windmillFlowPath: "f/workflows/org_1/simple_flow",
       windmillWorkspace: "prod",
       dag: VALID_LINEAR_DAG,
     });
 
-    await request
+    const res = await request
       .post("/workflows/by-name/simple-flow/execute")
       .set(AUTH)
-      .send({ appId: "kevinlourd-com" });
+      .send({ orgId: "org-1", parentRunId: "parent-123" });
 
-    expect(mockRunFlow).toHaveBeenCalledWith(
-      "f/workflows/kevinlourd_com/simple_flow",
-      expect.objectContaining({ appId: "kevinlourd-com" }),
-    );
+    expect(res.status).toBe(201);
+    expect(res.body.userId).toBe("user-1");
+    expect(res.body.parentRunId).toBe("parent-123");
   });
 
   it("returns 404 for unknown workflow name", async () => {
     const res = await request
       .post("/workflows/by-name/nonexistent/execute")
       .set(AUTH)
-      .send({ appId: "kevinlourd-com" });
+      .send({ orgId: "org-1" });
 
     expect(res.status).toBe(404);
     expect(res.body.error).toContain("nonexistent");
   });
 
-  it("requires appId in body", async () => {
+  it("requires orgId in body", async () => {
     const res = await request
       .post("/workflows/by-name/test-flow/execute")
       .set(AUTH)
-      .send({ inputs: {} }); // missing appId
+      .send({ inputs: {} }); // missing orgId
 
     expect(res.status).toBe(400);
-  });
-
-  it("accepts optional orgId for user context", async () => {
-    mockWorkflows.push({
-      id: "wf-1",
-      appId: "kevinlourd-com",
-      orgId: "kevinlourd-com",
-      name: "newsletter-subscribe",
-      windmillFlowPath: "f/workflows/kevinlourd-com/newsletter_subscribe",
-      windmillWorkspace: "prod",
-      dag: VALID_LINEAR_DAG,
-    });
-
-    const res = await request
-      .post("/workflows/by-name/newsletter-subscribe/execute")
-      .set(AUTH)
-      .send({
-        appId: "kevinlourd-com",
-        orgId: "user-org-123",
-        inputs: { email: "test@example.com" },
-      });
-
-    expect(res.status).toBe(201);
-    expect(res.body.orgId).toBe("user-org-123");
   });
 
   it("requires authentication", async () => {
     const res = await request
       .post("/workflows/by-name/test-flow/execute")
-      .send({ appId: "kevinlourd-com" });
+      .set(IDENTITY)
+      .send({ orgId: "org-1" });
 
     expect(res.status).toBe(401);
   });
@@ -453,7 +403,9 @@ describe("GET /workflow-runs/:id/debug", () => {
   });
 
   it("requires authentication", async () => {
-    const res = await request.get("/workflow-runs/run-1/debug");
+    const res = await request
+      .get("/workflow-runs/run-1/debug")
+      .set(IDENTITY);
     expect(res.status).toBe(401);
   });
 });

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -75,7 +75,8 @@ import supertest from "supertest";
 import app from "../../src/index.js";
 
 const request = supertest(app);
-const AUTH = { "x-api-key": "test-api-key" };
+const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1" };
+const AUTH = { "x-api-key": "test-api-key", ...IDENTITY };
 
 describe("POST /workflows", () => {
   beforeEach(() => {
@@ -87,7 +88,6 @@ describe("POST /workflows", () => {
       .post("/workflows")
       .set(AUTH)
       .send({
-        appId: "test-app",
         orgId: "org-1",
         name: "Test Flow",
         category: "sales",
@@ -98,7 +98,6 @@ describe("POST /workflows", () => {
 
     expect(res.status).toBe(201);
     expect(res.body.name).toBe("Test Flow");
-    expect(res.body.appId).toBe("test-app");
     expect(res.body.orgId).toBe("org-1");
     expect(res.body.category).toBe("sales");
     expect(res.body.channel).toBe("email");
@@ -113,7 +112,6 @@ describe("POST /workflows", () => {
       .post("/workflows")
       .set(AUTH)
       .send({
-        appId: "test-app",
         orgId: "org-1",
         name: "Bad Flow",
         category: "sales",
@@ -128,11 +126,14 @@ describe("POST /workflows", () => {
   });
 
   it("requires authentication", async () => {
-    const res = await request.post("/workflows").send({
-      orgId: "org-1",
-      name: "No Auth",
-      dag: VALID_LINEAR_DAG,
-    });
+    const res = await request
+      .post("/workflows")
+      .set(IDENTITY)
+      .send({
+        orgId: "org-1",
+        name: "No Auth",
+        dag: VALID_LINEAR_DAG,
+      });
 
     expect(res.status).toBe(401);
   });
@@ -191,7 +192,6 @@ describe("GET /workflows", () => {
     mockDbRows.push({
       id: "wf-1",
       orgId: "org-1",
-      appId: "my-app",
       name: "sales-email-cold-outreach-sequoia",
       displayName: "Sales Flow",
       category: "sales",
@@ -232,7 +232,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "distribute",
+        orgId: "org-deploy",
         workflows: [
           {
             ...DEPLOY_ITEM,
@@ -255,91 +255,24 @@ describe("PUT /workflows/deploy", () => {
     expect(wf.name).toBe(`sales-email-cold-outreach-${wf.signatureName}`);
   });
 
-  it("uses orgId from body instead of falling back to appId", async () => {
+  it("stores orgId from body in DB", async () => {
     const res = await request
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "distribute",
         orgId: "org_test_id",
         workflows: [
           {
             ...DEPLOY_ITEM,
-            description: "Workflow with real orgId",
+            description: "Workflow with orgId",
             dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
-          },
-        ],
-      });
-
-    expect(res.status).toBe(200);
-    // Verify the DB row got the correct orgId
-    const inserted = mockDbRows[mockDbRows.length - 1];
-    expect(inserted.orgId).toBe("org_test_id");
-    expect(inserted.appId).toBe("distribute");
-  });
-
-  it("falls back to appId when orgId is not provided", async () => {
-    const res = await request
-      .put("/workflows/deploy")
-      .set(AUTH)
-      .send({
-        appId: "distribute",
-        workflows: [
-          {
-            ...DEPLOY_ITEM,
-            description: "Workflow without orgId",
-            dag: VALID_LINEAR_DAG,
           },
         ],
       });
 
     expect(res.status).toBe(200);
     const inserted = mockDbRows[mockDbRows.length - 1];
-    expect(inserted.orgId).toBe("distribute");
-  });
-
-  it("updates orgId on existing workflow when redeployed with orgId", async () => {
-    const { computeDAGSignature } = await import("../../src/lib/dag-signature.js");
-    const sig = computeDAGSignature(DAG_WITH_TRANSACTIONAL_EMAIL_SEND);
-
-    mockDbRows.push({
-      id: "wf-wrong-org",
-      appId: "distribute",
-      orgId: "distribute",
-      name: "sales-email-cold-outreach-sequoia",
-      signatureName: "sequoia",
-      signature: sig,
-      category: "sales",
-      channel: "email",
-      audienceType: "cold-outreach",
-      description: "Old",
-      dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
-      windmillFlowPath: "f/workflows/distribute/sales_email_cold_outreach_sequoia",
-      windmillWorkspace: "prod",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
-
-    const res = await request
-      .put("/workflows/deploy")
-      .set(AUTH)
-      .send({
-        appId: "distribute",
-        orgId: "org_correct_id",
-        workflows: [
-          {
-            ...DEPLOY_ITEM,
-            description: "Fixed orgId",
-            dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
-          },
-        ],
-      });
-
-    expect(res.status).toBe(200);
-    expect(res.body.workflows[0].action).toBe("updated");
-    // The mock DB row should have been updated with the correct orgId
-    const row = mockDbRows[mockDbRows.length - 1];
-    expect(row.orgId).toBe("org_correct_id");
+    expect(inserted.orgId).toBe("org_test_id");
   });
 
   it("updates existing workflow when same DAG is redeployed (idempotent)", async () => {
@@ -348,8 +281,7 @@ describe("PUT /workflows/deploy", () => {
 
     mockDbRows.push({
       id: "wf-existing",
-      appId: "distribute",
-      orgId: "distribute",
+      orgId: "org-deploy",
       name: "sales-email-cold-outreach-sequoia",
       signatureName: "sequoia",
       signature: sig,
@@ -368,7 +300,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "distribute",
+        orgId: "org-deploy",
         workflows: [
           {
             ...DEPLOY_ITEM,
@@ -385,7 +317,7 @@ describe("PUT /workflows/deploy", () => {
 
   it("same DAG produces same signature across deploys", async () => {
     const payload = {
-      appId: "distribute",
+      orgId: "org-deploy",
       workflows: [{ ...DEPLOY_ITEM, dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND }],
     };
 
@@ -406,7 +338,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "distribute",
+        orgId: "org-deploy",
         workflows: [{ ...DEPLOY_ITEM, dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND }],
       });
     expect(res1.body.workflows[0].signature).toBe(sig1);
@@ -417,7 +349,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "distribute",
+        orgId: "org-deploy",
         workflows: [{ ...DEPLOY_ITEM, dag: VALID_LINEAR_DAG }],
       });
     expect(res2.body.workflows[0].signature).toBe(sig2);
@@ -428,7 +360,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "distribute",
+        orgId: "org-deploy",
         workflows: [
           {
             // Missing category, channel, audienceType
@@ -445,7 +377,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "distribute",
+        orgId: "org-deploy",
         workflows: [
           {
             category: "sales",
@@ -464,7 +396,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "distribute",
+        orgId: "org-deploy",
         workflows: [
           {
             category: "sales",
@@ -483,7 +415,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "distribute",
+        orgId: "org-deploy",
         workflows: [
           {
             category: "invalid-category",
@@ -509,7 +441,7 @@ describe("PUT /workflows/deploy", () => {
         .put("/workflows/deploy")
         .set(AUTH)
         .send({
-          appId: "distribute",
+          orgId: "org-deploy",
           workflows: [{ ...dims, dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND }],
         });
 
@@ -522,7 +454,7 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        appId: "distribute",
+        orgId: "org-deploy",
         workflows: [
           { ...DEPLOY_ITEM, dag: VALID_LINEAR_DAG },
           { ...DEPLOY_ITEM, dag: DAG_WITH_UNKNOWN_TYPE },
@@ -535,10 +467,13 @@ describe("PUT /workflows/deploy", () => {
   });
 
   it("requires authentication", async () => {
-    const res = await request.put("/workflows/deploy").send({
-      appId: "distribute",
-      workflows: [{ ...DEPLOY_ITEM, dag: VALID_LINEAR_DAG }],
-    });
+    const res = await request
+      .put("/workflows/deploy")
+      .set(IDENTITY)
+      .send({
+        orgId: "org-deploy",
+        workflows: [{ ...DEPLOY_ITEM, dag: VALID_LINEAR_DAG }],
+      });
 
     expect(res.status).toBe(401);
   });
@@ -547,7 +482,7 @@ describe("PUT /workflows/deploy", () => {
     const res = await request
       .put("/workflows/deploy")
       .set(AUTH)
-      .send({ appId: "distribute" }); // missing workflows
+      .send({ orgId: "org-deploy" }); // missing workflows
 
     expect(res.status).toBe(400);
   });
@@ -563,7 +498,6 @@ describe("GET /workflows/:id/required-providers", () => {
     mockDbRows.push({
       id: "wf-http",
       orgId: "org-1",
-      appId: "test-app",
       name: "HTTP Flow",
       dag: DAG_WITH_HTTP_CALL_CHAIN,
       createdAt: new Date(),
@@ -595,7 +529,6 @@ describe("GET /workflows/:id/required-providers", () => {
     mockDbRows.push({
       id: "wf-legacy",
       orgId: "org-1",
-      appId: "test-app",
       name: "Legacy Flow",
       dag: VALID_LINEAR_DAG,
       createdAt: new Date(),
@@ -626,7 +559,6 @@ describe("GET /workflows/:id/required-providers", () => {
     mockDbRows.push({
       id: "wf-http",
       orgId: "org-1",
-      appId: "test-app",
       name: "HTTP Flow",
       dag: DAG_WITH_HTTP_CALL,
       createdAt: new Date(),
@@ -651,7 +583,6 @@ describe("GET /workflows/:id/required-providers", () => {
     mockDbRows.push({
       id: "wf-http",
       orgId: "org-1",
-      appId: "test-app",
       name: "HTTP Flow",
       dag: DAG_WITH_HTTP_CALL,
       createdAt: new Date(),
@@ -672,7 +603,9 @@ describe("GET /workflows/:id/required-providers", () => {
   });
 
   it("requires authentication", async () => {
-    const res = await request.get("/workflows/wf-1/required-providers");
+    const res = await request
+      .get("/workflows/wf-1/required-providers")
+      .set(IDENTITY);
     expect(res.status).toBe(401);
   });
 });

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -126,7 +126,7 @@ describe("dagToOpenFlow", () => {
         string,
         { type: string; value?: unknown; expr?: string }
       >;
-      expect(transforms.appId).toEqual({
+      expect(transforms.orgId).toEqual({
         type: "static",
         value: "polaritycourse",
       });
@@ -182,8 +182,8 @@ describe("dagToOpenFlow", () => {
     }
   });
 
-  it("auto-injects appId and serviceEnvs input_transforms into script modules", () => {
-    const result = dagToOpenFlow(VALID_LINEAR_DAG, "AppId Inject");
+  it("auto-injects orgId, userId, and serviceEnvs input_transforms into script modules", () => {
+    const result = dagToOpenFlow(VALID_LINEAR_DAG, "OrgId UserId Inject");
 
     for (const mod of result.value.modules) {
       if (mod.value.type === "script") {
@@ -191,9 +191,13 @@ describe("dagToOpenFlow", () => {
           string,
           { type: string; expr?: string; value?: unknown }
         >;
-        expect(transforms.appId).toEqual({
+        expect(transforms.orgId).toEqual({
           type: "javascript",
-          expr: "flow_input.appId",
+          expr: "flow_input.orgId",
+        });
+        expect(transforms.userId).toEqual({
+          type: "javascript",
+          expr: "flow_input.userId",
         });
         expect(transforms.serviceEnvs).toEqual({
           type: "javascript",
@@ -203,8 +207,8 @@ describe("dagToOpenFlow", () => {
     }
   });
 
-  it("does not override explicit appId in node config", () => {
-    const result = dagToOpenFlow(POLARITY_WELCOME_DAG, "Explicit AppId");
+  it("does not override explicit orgId in node config but auto-injects userId", () => {
+    const result = dagToOpenFlow(POLARITY_WELCOME_DAG, "Explicit OrgId");
 
     const mod = result.value.modules[0];
     expect(mod.value.type).toBe("script");
@@ -215,19 +219,25 @@ describe("dagToOpenFlow", () => {
         { type: string; expr?: string; value?: unknown }
       >;
       // Should keep the static config value, not override with flow_input
-      expect(transforms.appId).toEqual({
+      expect(transforms.orgId).toEqual({
         type: "static",
         value: "polaritycourse",
+      });
+      // Should still auto-inject userId
+      expect(transforms.userId).toEqual({
+        type: "javascript",
+        expr: "flow_input.userId",
       });
     }
   });
 
-  it("declares appId and serviceEnvs in OpenFlow schema properties", () => {
+  it("declares orgId, userId, and serviceEnvs in OpenFlow schema properties", () => {
     const result = dagToOpenFlow(VALID_LINEAR_DAG, "Schema Test");
 
     expect(result.schema).toBeDefined();
     const props = (result.schema as Record<string, unknown>).properties as Record<string, unknown>;
-    expect(props.appId).toEqual({ type: "string", description: "Application identifier" });
+    expect(props.orgId).toEqual({ type: "string", description: "Organization identifier" });
+    expect(props.userId).toEqual({ type: "string", description: "User identifier" });
     expect(props.serviceEnvs).toEqual({ type: "object", description: "Service URLs and API keys injected by workflow-service" });
   });
 
@@ -296,10 +306,14 @@ describe("dagToOpenFlow", () => {
         type: "javascript",
         expr: "error.message",
       });
-      // Should auto-inject appId and serviceEnvs
-      expect(transforms.appId).toEqual({
+      // Should auto-inject orgId, userId and serviceEnvs
+      expect(transforms.orgId).toEqual({
         type: "javascript",
-        expr: "flow_input.appId",
+        expr: "flow_input.orgId",
+      });
+      expect(transforms.userId).toEqual({
+        type: "javascript",
+        expr: "flow_input.userId",
       });
       expect(transforms.serviceEnvs).toEqual({
         type: "javascript",
@@ -317,9 +331,9 @@ describe("dagToOpenFlow", () => {
     const result = dagToOpenFlow(DAG_WITH_FLOW_INPUT_REFS, "Flow Input Schema");
 
     const props = (result.schema as Record<string, unknown>).properties as Record<string, unknown>;
-    expect(props.appId).toEqual({ type: "string", description: "Application identifier" });
+    expect(props.orgId).toEqual({ type: "string", description: "Organization identifier" });
+    expect(props.userId).toEqual({ type: "string", description: "User identifier" });
     expect(props.campaignId).toEqual({ type: "string" });
-    expect(props.orgId).toEqual({ type: "string" });
   });
 
   it("declares flow_input fields from all nodes including onError handler", () => {
@@ -544,7 +558,7 @@ describe("dagToOpenFlow", () => {
       expect(expr).toContain('"broadcast"');
       // Dynamic fields should be present (deep paths use optional chaining)
       expect(expr).toContain("results.start_run?.lead?.data?.email");
-      expect(expr).toContain("results.start_run?.appId");
+      expect(expr).toContain("results.start_run?.orgId");
       // Nested metadata should merge static source with dynamic emailGenerationId
       expect(expr).toContain('"source"');
       expect(expr).toContain("results.email_generate?.id");

--- a/tests/unit/key-service-client.test.ts
+++ b/tests/unit/key-service-client.test.ts
@@ -114,20 +114,20 @@ describe("fetchAnthropicKey", () => {
     vi.restoreAllMocks();
   });
 
-  it("calls app-keys decrypt endpoint when keySource is 'app'", async () => {
+  it("calls GET /keys/anthropic/decrypt with orgId and userId", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ provider: "anthropic", key: "sk-ant-app-key" }),
+        json: () => Promise.resolve({ key: "sk-ant-key", keySource: "platform" }),
       })
     );
 
-    const key = await fetchAnthropicKey("app", { appId: "my-app", orgId: "org-1" });
+    const result = await fetchAnthropicKey({ orgId: "org-1", userId: "user-1" });
 
-    expect(key).toBe("sk-ant-app-key");
+    expect(result).toEqual({ key: "sk-ant-key", keySource: "platform" });
     expect(fetch).toHaveBeenCalledWith(
-      "http://localhost:4000/internal/app-keys/anthropic/decrypt?appId=my-app",
+      "http://localhost:4000/keys/anthropic/decrypt?orgId=org-1&userId=user-1",
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
@@ -140,54 +140,19 @@ describe("fetchAnthropicKey", () => {
     );
   });
 
-  it("calls platform-keys decrypt endpoint when keySource is 'platform'", async () => {
+  it("returns keySource 'org' when user has own key", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ provider: "anthropic", key: "sk-ant-platform-key" }),
+        json: () => Promise.resolve({ key: "sk-ant-org-key", keySource: "org" }),
       })
     );
 
-    const key = await fetchAnthropicKey("platform", { appId: "my-app", orgId: "org-1" });
+    const result = await fetchAnthropicKey({ orgId: "org-1", userId: "user-1" });
 
-    expect(key).toBe("sk-ant-platform-key");
-    expect(fetch).toHaveBeenCalledWith(
-      "http://localhost:4000/internal/platform-keys/anthropic/decrypt",
-      expect.objectContaining({
-        method: "GET",
-        headers: expect.objectContaining({
-          "x-api-key": "test-key-svc-key",
-          "x-caller-service": "workflow",
-          "x-caller-method": "POST",
-          "x-caller-path": "/workflows/generate",
-        }),
-      })
-    );
-  });
-
-  it("calls byok keys decrypt endpoint when keySource is 'byok'", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ provider: "anthropic", key: "sk-ant-byok-key" }),
-      })
-    );
-
-    const key = await fetchAnthropicKey("byok", { appId: "my-app", orgId: "org-1" });
-
-    expect(key).toBe("sk-ant-byok-key");
-    expect(fetch).toHaveBeenCalledWith(
-      "http://localhost:4000/internal/keys/anthropic/decrypt?orgId=org-1",
-      expect.objectContaining({
-        method: "GET",
-        headers: expect.objectContaining({
-          "x-api-key": "test-key-svc-key",
-          "x-caller-service": "workflow",
-        }),
-      })
-    );
+    expect(result.key).toBe("sk-ant-org-key");
+    expect(result.keySource).toBe("org");
   });
 
   it("throws on non-2xx response", async () => {
@@ -202,30 +167,30 @@ describe("fetchAnthropicKey", () => {
     );
 
     await expect(
-      fetchAnthropicKey("app", { appId: "my-app", orgId: "org-1" })
+      fetchAnthropicKey({ orgId: "org-1", userId: "user-1" })
     ).rejects.toThrow("key-service error:");
   });
 
   it("throws if KEY_SERVICE_URL is not set", async () => {
     delete process.env.KEY_SERVICE_URL;
     await expect(
-      fetchAnthropicKey("app", { appId: "my-app", orgId: "org-1" })
+      fetchAnthropicKey({ orgId: "org-1", userId: "user-1" })
     ).rejects.toThrow("KEY_SERVICE_URL and KEY_SERVICE_API_KEY must be set");
   });
 
-  it("encodes appId and orgId in query params", async () => {
+  it("encodes orgId and userId in query params", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ provider: "anthropic", key: "sk-key" }),
+        json: () => Promise.resolve({ key: "sk-key", keySource: "platform" }),
       })
     );
 
-    await fetchAnthropicKey("app", { appId: "app with spaces", orgId: "org-1" });
+    await fetchAnthropicKey({ orgId: "org with spaces", userId: "user-1" });
 
     expect(fetch).toHaveBeenCalledWith(
-      "http://localhost:4000/internal/app-keys/anthropic/decrypt?appId=app%20with%20spaces",
+      "http://localhost:4000/keys/anthropic/decrypt?orgId=org+with+spaces&userId=user-1",
       expect.anything()
     );
   });

--- a/tests/unit/polarity-workflows.test.ts
+++ b/tests/unit/polarity-workflows.test.ts
@@ -31,8 +31,8 @@ describe("Polarity workflows", () => {
       expect(wf.dag.edges).toHaveLength(0);
     });
 
-    it("uses polaritycourse appId", () => {
-      expect(wf.dag.nodes[0].config?.appId).toBe("polaritycourse");
+    it("uses polaritycourse orgId", () => {
+      expect(wf.dag.nodes[0].config?.orgId).toBe("polaritycourse");
     });
 
     it("maps email from flow_input", () => {


### PR DESCRIPTION
## Summary

Breaking changes to align with columbia (api-service) v2 contract:

- **Remove appId** from all schemas, DB columns, routes, node scripts, and Windmill flow inputs. All scoping now uses orgId exclusively.
- **Remove keySource** from generate endpoint. Key resolution now uses a single endpoint: `GET /keys/:provider/decrypt?orgId=&userId=`
- **Require identity headers** (`x-org-id`, `x-user-id`) on all endpoints except `/health` and `/openapi.json`
- **Add parentRunId** to execute endpoints and `workflow_runs` table for execution chain tracking
- **Add userId** to `workflow_runs` table
- **Replace appId-based DB indexes** with orgId-based equivalents (migration 0011)
- **Update all 12 node scripts** to use orgId instead of appId in request bodies/query params
- **Auto-inject orgId/userId** (instead of appId) into Windmill flow inputs

## Files Changed (40)

| Area | Files |
|------|-------|
| Migration | `drizzle/0011_remove_appid_add_userid.sql`, `drizzle/meta/_journal.json` |
| Schema | `src/db/schema.ts`, `src/schemas.ts` |
| Middleware | `src/middleware/auth.ts`, `src/index.ts` |
| Routes | `src/routes/workflows.ts`, `src/routes/workflow-runs.ts` |
| Key Service | `src/lib/key-service-client.ts` |
| DAG Engine | `src/lib/dag-to-openflow.ts`, `src/lib/prompt-templates.ts` |
| Node Scripts | 12 scripts in `scripts/nodes/` |
| Workflows | 6 polarity workflow definitions |
| Tests | 8 test files updated |
| OpenAPI | `openapi.json` regenerated |

## Test plan

- [x] `npm test` — 253 tests pass across 18 test files
- [x] `npx tsc --noEmit` — compiles without errors
- [x] `npm run generate:openapi` — spec regenerated
- [x] Zero remaining `appId` references in `src/` and `tests/`
- [ ] Run migration 0011 on prod DB
- [ ] Coordinate deploy with columbia (api-service) v2 breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)