### PR TITLE
feat: fix run tracking — x-run-id header + runs-service integration

### DIFF
--- a/drizzle/0012_drop_parent_run_id.sql
+++ b/drizzle/0012_drop_parent_run_id.sql
@@ -1,0 +1,3 @@
+-- Drop parent_run_id from workflow_runs.
+-- Parent-child run relationships are tracked in runs-service, not here.
+ALTER TABLE "workflow_runs" DROP COLUMN IF EXISTS "parent_run_id";

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1772016306410,
       "tag": "0011_remove_appid_add_userid",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1772102706410,
+      "tag": "0012_drop_parent_run_id",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -451,12 +451,7 @@
           "runId": {
             "type": "string",
             "nullable": true,
-            "description": "External run ID (if provided at execution time)."
-          },
-          "parentRunId": {
-            "type": "string",
-            "nullable": true,
-            "description": "Parent run ID (if linked to a parent execution)."
+            "description": "Runs-service run ID for this execution (auto-created)."
           },
           "windmillJobId": {
             "type": "string",
@@ -503,7 +498,6 @@
           "subrequestId",
           "userId",
           "runId",
-          "parentRunId",
           "windmillJobId",
           "windmillWorkspace",
           "status",
@@ -522,14 +516,6 @@
               "nullable": true
             },
             "description": "Runtime inputs for the workflow. Accessible in nodes via $ref:flow_input.fieldName."
-          },
-          "runId": {
-            "type": "string",
-            "description": "Optional external run ID for cost tracking via runs-service."
-          },
-          "parentRunId": {
-            "type": "string",
-            "description": "Optional parent run ID to link this execution to a parent run."
           }
         }
       },
@@ -936,14 +922,6 @@
               "nullable": true
             },
             "description": "Runtime inputs for the workflow. Accessible in nodes via $ref:flow_input.fieldName."
-          },
-          "runId": {
-            "type": "string",
-            "description": "Optional external run ID for cost tracking via runs-service."
-          },
-          "parentRunId": {
-            "type": "string",
-            "description": "Optional parent run ID to link this execution to a parent run."
           }
         },
         "required": [

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -55,7 +55,7 @@ export const workflowRuns = pgTable(
     campaignId: text("campaign_id"),
     subrequestId: text("subrequest_id"),
     runId: text("run_id"),
-    parentRunId: text("parent_run_id"),
+
     windmillJobId: text("windmill_job_id"),
     windmillWorkspace: text("windmill_workspace").notNull().default("prod"),
     status: text("status").notNull().default("queued"),

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -1,0 +1,60 @@
+// --- Runs-service client ---
+// Creates child runs in runs-service to track execution costs.
+
+function getRunsServiceConfig(): { baseUrl: string; apiKey: string } {
+  const baseUrl = process.env.RUNS_SERVICE_URL;
+  const apiKey = process.env.RUNS_SERVICE_API_KEY;
+  if (!baseUrl || !apiKey) {
+    throw new Error(
+      "RUNS_SERVICE_URL and RUNS_SERVICE_API_KEY must be set to create runs"
+    );
+  }
+  return { baseUrl: baseUrl.replace(/\/$/, ""), apiKey };
+}
+
+export interface CreateRunResult {
+  runId: string;
+}
+
+/**
+ * Create a child run in runs-service.
+ *
+ * @param opts.parentRunId - The caller's run ID (from x-run-id header)
+ * @param opts.orgId - Organization ID
+ * @param opts.userId - User ID
+ * @returns The newly created run's ID
+ */
+export async function createRun(opts: {
+  parentRunId: string;
+  orgId: string;
+  userId: string;
+}): Promise<CreateRunResult> {
+  const { baseUrl, apiKey } = getRunsServiceConfig();
+
+  const res = await fetch(`${baseUrl}/runs/start`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "x-org-id": opts.orgId,
+      "x-user-id": opts.userId,
+      "x-run-id": opts.parentRunId,
+    },
+    body: JSON.stringify({
+      parentRunId: opts.parentRunId,
+      service: "workflow",
+      orgId: opts.orgId,
+      userId: opts.userId,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `runs-service error: POST /runs/start -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  const body = (await res.json()) as { runId: string };
+  return { runId: body.runId };
+}

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -20,15 +20,17 @@ export function requireIdentity(
 ): void {
   const orgId = req.headers["x-org-id"] as string | undefined;
   const userId = req.headers["x-user-id"] as string | undefined;
+  const runId = req.headers["x-run-id"] as string | undefined;
 
-  if (!orgId || !userId) {
+  if (!orgId || !userId || !runId) {
     res.status(400).json({
-      error: "x-org-id and x-user-id headers are required",
+      error: "x-org-id, x-user-id, and x-run-id headers are required",
     });
     return;
   }
 
   res.locals.orgId = orgId;
   res.locals.userId = userId;
+  res.locals.runId = runId;
   next();
 }

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -5,6 +5,7 @@ import { workflows, workflowRuns } from "../db/schema.js";
 import { requireApiKey } from "../middleware/auth.js";
 import { getWindmillClient } from "../lib/windmill-client.js";
 import { collectServiceEnvs } from "../lib/service-envs.js";
+import { createRun } from "../lib/runs-client.js";
 import { ExecuteWorkflowSchema, ExecuteByNameSchema } from "../schemas.js";
 
 const router = Router();
@@ -51,13 +52,30 @@ router.post(
         return;
       }
 
-      // Run in Windmill — inject orgId and userId so nodes can access them via flow_input
       const userId = res.locals.userId as string;
+      const callerRunId = res.locals.runId as string;
+
+      // Create a child run in runs-service (links to caller's run via parentRunId)
+      let ownRunId: string | null = null;
+      try {
+        const { runId: newRunId } = await createRun({
+          parentRunId: callerRunId,
+          orgId: body.orgId,
+          userId,
+        });
+        ownRunId = newRunId;
+      } catch (err) {
+        console.error("[workflow-runs] Failed to create run in runs-service:", err);
+        res.status(502).json({ error: "Failed to create run in runs-service" });
+        return;
+      }
+
+      // Run in Windmill — inject orgId, userId, and our own runId so nodes can access them
       let windmillJobId: string | null = null;
       const client = getWindmillClient();
       if (client) {
         try {
-          const flowInputs = { ...body.inputs, orgId: body.orgId, userId, serviceEnvs: collectServiceEnvs() };
+          const flowInputs = { ...body.inputs, orgId: body.orgId, userId, runId: ownRunId, serviceEnvs: collectServiceEnvs() };
           windmillJobId = await client.runFlow(
             workflow.windmillFlowPath,
             flowInputs
@@ -81,10 +99,9 @@ router.post(
           workflowId: workflow.id,
           orgId: body.orgId,
           userId,
-          parentRunId: body.parentRunId,
           campaignId: workflow.campaignId,
           subrequestId: workflow.subrequestId,
-          runId: body.runId,
+          runId: ownRunId,
           windmillJobId,
           windmillWorkspace: workflow.windmillWorkspace,
           status: "queued",
@@ -126,13 +143,30 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
       return;
     }
 
-    // Run in Windmill — inject orgId and userId so nodes can access them via flow_input
     const executeUserId = res.locals.userId as string;
+    const callerRunId = res.locals.runId as string;
+
+    // Create a child run in runs-service (links to caller's run via parentRunId)
+    let ownRunId: string | null = null;
+    try {
+      const { runId: newRunId } = await createRun({
+        parentRunId: callerRunId,
+        orgId: workflow.orgId,
+        userId: executeUserId,
+      });
+      ownRunId = newRunId;
+    } catch (err) {
+      console.error("[workflow-runs] Failed to create run in runs-service:", err);
+      res.status(502).json({ error: "Failed to create run in runs-service" });
+      return;
+    }
+
+    // Run in Windmill — inject orgId, userId, and our own runId so nodes can access them
     let windmillJobId: string | null = null;
     const client = getWindmillClient();
     if (client) {
       try {
-        const flowInputs = { ...body.inputs, orgId: workflow.orgId, userId: executeUserId, serviceEnvs: collectServiceEnvs() };
+        const flowInputs = { ...body.inputs, orgId: workflow.orgId, userId: executeUserId, runId: ownRunId, serviceEnvs: collectServiceEnvs() };
         windmillJobId = await client.runFlow(
           workflow.windmillFlowPath,
           flowInputs
@@ -153,10 +187,9 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
         workflowId: workflow.id,
         orgId: workflow.orgId,
         userId: executeUserId,
-        parentRunId: body.parentRunId,
         campaignId: workflow.campaignId,
         subrequestId: workflow.subrequestId,
-        runId: body.runId,
+        runId: ownRunId,
         windmillJobId,
         windmillWorkspace: workflow.windmillWorkspace,
         status: "queued",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -170,8 +170,6 @@ export const ExecuteWorkflowSchema = z
     inputs: z.record(z.unknown()).optional().describe(
       "Runtime inputs for the workflow. Accessible in nodes via $ref:flow_input.fieldName."
     ),
-    runId: z.string().optional().describe("Optional external run ID for cost tracking via runs-service."),
-    parentRunId: z.string().optional().describe("Optional parent run ID to link this execution to a parent run."),
   })
   .openapi("ExecuteWorkflowRequest");
 
@@ -183,8 +181,7 @@ export const WorkflowRunResponseSchema = z
     campaignId: z.string().nullable(),
     subrequestId: z.string().nullable(),
     userId: z.string().nullable().describe("User ID from the execution context."),
-    runId: z.string().nullable().describe("External run ID (if provided at execution time)."),
-    parentRunId: z.string().nullable().describe("Parent run ID (if linked to a parent execution)."),
+    runId: z.string().nullable().describe("Runs-service run ID for this execution (auto-created)."),
     windmillJobId: z.string().nullable().describe("Internal Windmill job ID (managed automatically)."),
     windmillWorkspace: z.string(),
     status: z.string().describe("Run status: queued, running, completed, failed, or cancelled."),
@@ -246,8 +243,6 @@ export const ExecuteByNameSchema = z
     inputs: z.record(z.unknown()).optional().describe(
       "Runtime inputs for the workflow. Accessible in nodes via $ref:flow_input.fieldName."
     ),
-    runId: z.string().optional().describe("Optional external run ID for cost tracking via runs-service."),
-    parentRunId: z.string().optional().describe("Optional parent run ID to link this execution to a parent run."),
   })
   .openapi("ExecuteByNameRequest");
 

--- a/tests/integration/best-workflow.test.ts
+++ b/tests/integration/best-workflow.test.ts
@@ -92,7 +92,7 @@ import supertest from "supertest";
 import app from "../../src/index.js";
 
 const request = supertest(app);
-const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1" };
+const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-caller-1" };
 const AUTH = { "x-api-key": "test-api-key", ...IDENTITY };
 
 const BASE_QUERY = {

--- a/tests/integration/generate-workflow.test.ts
+++ b/tests/integration/generate-workflow.test.ts
@@ -86,7 +86,7 @@ import supertest from "supertest";
 import app from "../../src/index.js";
 
 const request = supertest(app);
-const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1" };
+const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-caller-1" };
 const AUTH = { "x-api-key": "test-api-key", ...IDENTITY };
 
 describe("POST /workflows/generate", () => {

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -74,11 +74,18 @@ vi.mock("../../src/lib/windmill-client.js", () => ({
   resetWindmillClient: vi.fn(),
 }));
 
+// Mock runs-service client
+const mockCreateRun = vi.fn().mockResolvedValue({ runId: "run-own-123" });
+
+vi.mock("../../src/lib/runs-client.js", () => ({
+  createRun: (...args: unknown[]) => mockCreateRun(...args),
+}));
+
 import supertest from "supertest";
 import app from "../../src/index.js";
 
 const request = supertest(app);
-const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1" };
+const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-caller-1" };
 const AUTH = { "x-api-key": "test-api-key", ...IDENTITY };
 
 describe("POST /workflows/:id/execute", () => {
@@ -86,6 +93,8 @@ describe("POST /workflows/:id/execute", () => {
     mockWorkflows.length = 0;
     mockRuns.length = 0;
     mockRunFlow.mockClear();
+    mockCreateRun.mockClear();
+    mockCreateRun.mockResolvedValue({ runId: "run-own-123" });
   });
 
   it("executes a workflow and returns a run", async () => {
@@ -106,10 +115,33 @@ describe("POST /workflows/:id/execute", () => {
     expect(res.status).toBe(201);
     expect(res.body.status).toBe("queued");
     expect(res.body.windmillJobId).toBe("job-uuid-123");
+    expect(res.body.runId).toBe("run-own-123");
     expect(mockRunFlow).toHaveBeenCalled();
   });
 
-  it("forwards orgId and userId into Windmill flow inputs", async () => {
+  it("creates a child run in runs-service with caller's runId as parentRunId", async () => {
+    mockWorkflows.push({
+      id: "wf-1",
+      orgId: "org-1",
+      name: "Test Flow",
+      windmillFlowPath: "f/workflows/org_1/test_flow",
+      windmillWorkspace: "prod",
+      dag: VALID_LINEAR_DAG,
+    });
+
+    await request
+      .post("/workflows/wf-1/execute")
+      .set(AUTH)
+      .send({ inputs: {} });
+
+    expect(mockCreateRun).toHaveBeenCalledWith({
+      parentRunId: "run-caller-1",
+      orgId: "org-1",
+      userId: "user-1",
+    });
+  });
+
+  it("forwards orgId, userId, and own runId into Windmill flow inputs", async () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "org-1",
@@ -126,11 +158,11 @@ describe("POST /workflows/:id/execute", () => {
 
     expect(mockRunFlow).toHaveBeenCalledWith(
       "f/workflows/org_1/test_flow",
-      expect.objectContaining({ orgId: "org-1", userId: "user-1", email: "user@test.com" }),
+      expect.objectContaining({ orgId: "org-1", userId: "user-1", runId: "run-own-123", email: "user@test.com" }),
     );
   });
 
-  it("stores userId and parentRunId in DB", async () => {
+  it("stores userId in DB", async () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "org-1",
@@ -143,11 +175,33 @@ describe("POST /workflows/:id/execute", () => {
     const res = await request
       .post("/workflows/wf-1/execute")
       .set(AUTH)
-      .send({ inputs: {}, parentRunId: "parent-run-123" });
+      .send({ inputs: {} });
 
     expect(res.status).toBe(201);
     expect(res.body.userId).toBe("user-1");
-    expect(res.body.parentRunId).toBe("parent-run-123");
+  });
+
+  it("returns 502 when runs-service fails", async () => {
+    mockCreateRun.mockRejectedValueOnce(
+      new Error("runs-service error: POST /runs/start -> 500 Internal Server Error: boom")
+    );
+
+    mockWorkflows.push({
+      id: "wf-1",
+      orgId: "org-1",
+      name: "Test Flow",
+      windmillFlowPath: "f/workflows/org_1/test_flow",
+      windmillWorkspace: "prod",
+      dag: VALID_LINEAR_DAG,
+    });
+
+    const res = await request
+      .post("/workflows/wf-1/execute")
+      .set(AUTH)
+      .send({ inputs: {} });
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toContain("runs-service");
   });
 
   it("requires authentication", async () => {
@@ -165,6 +219,8 @@ describe("POST /workflows/by-name/:name/execute", () => {
     mockWorkflows.length = 0;
     mockRuns.length = 0;
     mockRunFlow.mockClear();
+    mockCreateRun.mockClear();
+    mockCreateRun.mockResolvedValue({ runId: "run-own-456" });
   });
 
   it("executes a workflow by orgId + name", async () => {
@@ -185,10 +241,33 @@ describe("POST /workflows/by-name/:name/execute", () => {
     expect(res.status).toBe(201);
     expect(res.body.status).toBe("queued");
     expect(res.body.windmillJobId).toBe("job-uuid-123");
+    expect(res.body.runId).toBe("run-own-456");
     expect(mockRunFlow).toHaveBeenCalled();
   });
 
-  it("forwards orgId and userId into Windmill flow inputs", async () => {
+  it("creates a child run in runs-service with caller's runId as parentRunId", async () => {
+    mockWorkflows.push({
+      id: "wf-1",
+      orgId: "org-1",
+      name: "create-user-flow",
+      windmillFlowPath: "f/workflows/org_1/create_user_flow",
+      windmillWorkspace: "prod",
+      dag: VALID_LINEAR_DAG,
+    });
+
+    await request
+      .post("/workflows/by-name/create-user-flow/execute")
+      .set(AUTH)
+      .send({ orgId: "org-1", inputs: {} });
+
+    expect(mockCreateRun).toHaveBeenCalledWith({
+      parentRunId: "run-caller-1",
+      orgId: "org-1",
+      userId: "user-1",
+    });
+  });
+
+  it("forwards orgId, userId, and own runId into Windmill flow inputs", async () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "org-1",
@@ -205,11 +284,11 @@ describe("POST /workflows/by-name/:name/execute", () => {
 
     expect(mockRunFlow).toHaveBeenCalledWith(
       "f/workflows/org_1/create_user_flow",
-      expect.objectContaining({ orgId: "org-1", userId: "user-1", email: "user@test.com" }),
+      expect.objectContaining({ orgId: "org-1", userId: "user-1", runId: "run-own-456", email: "user@test.com" }),
     );
   });
 
-  it("stores userId and parentRunId in DB", async () => {
+  it("stores userId in DB", async () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "org-1",
@@ -222,11 +301,10 @@ describe("POST /workflows/by-name/:name/execute", () => {
     const res = await request
       .post("/workflows/by-name/simple-flow/execute")
       .set(AUTH)
-      .send({ orgId: "org-1", parentRunId: "parent-123" });
+      .send({ orgId: "org-1" });
 
     expect(res.status).toBe(201);
     expect(res.body.userId).toBe("user-1");
-    expect(res.body.parentRunId).toBe("parent-123");
   });
 
   it("returns 404 for unknown workflow name", async () => {

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -75,7 +75,7 @@ import supertest from "supertest";
 import app from "../../src/index.js";
 
 const request = supertest(app);
-const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1" };
+const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-caller-1" };
 const AUTH = { "x-api-key": "test-api-key", ...IDENTITY };
 
 describe("POST /workflows", () => {

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createRun } from "../../src/lib/runs-client.js";
+
+describe("createRun", () => {
+  const originalUrl = process.env.RUNS_SERVICE_URL;
+  const originalKey = process.env.RUNS_SERVICE_API_KEY;
+
+  beforeEach(() => {
+    process.env.RUNS_SERVICE_URL = "http://localhost:5000";
+    process.env.RUNS_SERVICE_API_KEY = "test-runs-key";
+  });
+
+  afterEach(() => {
+    process.env.RUNS_SERVICE_URL = originalUrl;
+    process.env.RUNS_SERVICE_API_KEY = originalKey;
+    vi.restoreAllMocks();
+  });
+
+  it("calls POST /runs/start with parentRunId, orgId, userId", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ runId: "new-run-123" }),
+      })
+    );
+
+    const result = await createRun({
+      parentRunId: "caller-run-1",
+      orgId: "org-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ runId: "new-run-123" });
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:5000/runs/start",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "x-api-key": "test-runs-key",
+          "x-org-id": "org-1",
+          "x-user-id": "user-1",
+          "x-run-id": "caller-run-1",
+        }),
+        body: JSON.stringify({
+          parentRunId: "caller-run-1",
+          service: "workflow",
+          orgId: "org-1",
+          userId: "user-1",
+        }),
+      })
+    );
+  });
+
+  it("strips trailing slash from RUNS_SERVICE_URL", async () => {
+    process.env.RUNS_SERVICE_URL = "http://localhost:5000/";
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ runId: "new-run-456" }),
+      })
+    );
+
+    await createRun({
+      parentRunId: "caller-run-2",
+      orgId: "org-1",
+      userId: "user-1",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:5000/runs/start",
+      expect.anything()
+    );
+  });
+
+  it("throws on non-2xx response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        text: () => Promise.resolve("boom"),
+      })
+    );
+
+    await expect(
+      createRun({ parentRunId: "caller-run-3", orgId: "org-1", userId: "user-1" })
+    ).rejects.toThrow("runs-service error:");
+  });
+
+  it("throws if RUNS_SERVICE_URL is not set", async () => {
+    delete process.env.RUNS_SERVICE_URL;
+
+    await expect(
+      createRun({ parentRunId: "caller-run-4", orgId: "org-1", userId: "user-1" })
+    ).rejects.toThrow("RUNS_SERVICE_URL and RUNS_SERVICE_API_KEY must be set");
+  });
+
+  it("throws if RUNS_SERVICE_API_KEY is not set", async () => {
+    delete process.env.RUNS_SERVICE_API_KEY;
+
+    await expect(
+      createRun({ parentRunId: "caller-run-5", orgId: "org-1", userId: "user-1" })
+    ).rejects.toThrow("RUNS_SERVICE_URL and RUNS_SERVICE_API_KEY must be set");
+  });
+});


### PR DESCRIPTION
## Summary
- **x-run-id required header**: Added as mandatory alongside x-org-id and x-user-id on all identity-gated endpoints
- **runs-service integration**: Execute endpoints now create a child run in runs-service (POST /runs/start) with parentRunId set to the caller's x-run-id, then pass the new runId to Windmill flow inputs for downstream services
- **Removed parentRunId from API**: Dropped from execute schemas (body) and workflow_runs DB table — runs-service owns the parent-child tree, not workflow-service
- **New runs-client**: src/lib/runs-client.ts with full unit test coverage

## Test plan
- [x] 261 tests pass across 19 test files
- [x] All integration tests send x-run-id header
- [x] Execute endpoints verified to create child run and pass own runId downstream
- [x] 502 response when runs-service is unavailable
- [x] Unit tests for runs-client (POST /runs/start, error handling, env validation)
- [x] TypeScript builds clean, OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)