### PR TITLE
feat: auto-inject identity headers in http-call

### DIFF
--- a/scripts/nodes/http-call.ts
+++ b/scripts/nodes/http-call.ts
@@ -14,6 +14,9 @@ export async function main(
   serviceEnvs?: Record<string, string>,
   headers?: Record<string, string>,
   validateResponse?: { field: string; equals: unknown },
+  orgId?: string,
+  userId?: string,
+  runId?: string,
 ) {
   // Convert service name to env var prefix: "transactional-email" → "TRANSACTIONAL_EMAIL"
   const envPrefix = service.toUpperCase().replace(/-/g, "_");
@@ -38,14 +41,17 @@ export async function main(
     url += `?${params}`;
   }
 
-  // Build request — merge caller-supplied headers with defaults
+  // Build request — identity headers + caller-supplied headers, then resolved x-api-key wins
   const reqHeaders: Record<string, string> = {
     "Content-Type": "application/json",
-    ...headers,
   };
-  if (apiKey) {
-    reqHeaders["x-api-key"] = apiKey;
-  }
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+  // Caller-supplied headers can override identity headers
+  if (headers) Object.assign(reqHeaders, headers);
+  // Resolved x-api-key always takes precedence
+  if (apiKey) reqHeaders["x-api-key"] = apiKey;
 
   const options: RequestInit = { method, headers: reqHeaders };
 

--- a/src/lib/dag-to-openflow.ts
+++ b/src/lib/dag-to-openflow.ts
@@ -70,6 +70,7 @@ export function dagToOpenFlow(dag: DAG, name: string): OpenFlow {
   const schemaProperties: Record<string, { type: string; description?: string }> = {
     orgId: { type: "string", description: "Organization identifier" },
     userId: { type: "string", description: "User identifier" },
+    runId: { type: "string", description: "Runs-service run ID for this execution" },
     serviceEnvs: { type: "object", description: "Service URLs and API keys injected by workflow-service" },
   };
   for (const node of dag.nodes) {
@@ -357,12 +358,15 @@ function nodeToModule(node: DAGNode, dag: DAG): FlowModule | null {
     node.inputMapping,
   );
 
-  // Auto-inject orgId, userId, and serviceEnvs from flow_input unless explicitly mapped
+  // Auto-inject orgId, userId, runId, and serviceEnvs from flow_input unless explicitly mapped
   if (!inputTransforms.orgId) {
     inputTransforms.orgId = { type: "javascript", expr: "flow_input.orgId" };
   }
   if (!inputTransforms.userId) {
     inputTransforms.userId = { type: "javascript", expr: "flow_input.userId" };
+  }
+  if (!inputTransforms.runId) {
+    inputTransforms.runId = { type: "javascript", expr: "flow_input.runId" };
   }
   if (!inputTransforms.serviceEnvs) {
     inputTransforms.serviceEnvs = { type: "javascript", expr: "flow_input.serviceEnvs" };
@@ -398,12 +402,15 @@ function buildFailureModule(node: DAGNode): FlowModule | null {
 
   const inputTransforms = buildInputTransforms(node.config, node.inputMapping);
 
-  // Auto-inject orgId, userId, and serviceEnvs from flow_input unless explicitly mapped
+  // Auto-inject orgId, userId, runId, and serviceEnvs from flow_input unless explicitly mapped
   if (!inputTransforms.orgId) {
     inputTransforms.orgId = { type: "javascript", expr: "flow_input.orgId" };
   }
   if (!inputTransforms.userId) {
     inputTransforms.userId = { type: "javascript", expr: "flow_input.userId" };
+  }
+  if (!inputTransforms.runId) {
+    inputTransforms.runId = { type: "javascript", expr: "flow_input.runId" };
   }
   if (!inputTransforms.serviceEnvs) {
     inputTransforms.serviceEnvs = { type: "javascript", expr: "flow_input.serviceEnvs" };

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -182,7 +182,7 @@ describe("dagToOpenFlow", () => {
     }
   });
 
-  it("auto-injects orgId, userId, and serviceEnvs input_transforms into script modules", () => {
+  it("auto-injects orgId, userId, runId, and serviceEnvs input_transforms into script modules", () => {
     const result = dagToOpenFlow(VALID_LINEAR_DAG, "OrgId UserId Inject");
 
     for (const mod of result.value.modules) {
@@ -198,6 +198,10 @@ describe("dagToOpenFlow", () => {
         expect(transforms.userId).toEqual({
           type: "javascript",
           expr: "flow_input.userId",
+        });
+        expect(transforms.runId).toEqual({
+          type: "javascript",
+          expr: "flow_input.runId",
         });
         expect(transforms.serviceEnvs).toEqual({
           type: "javascript",
@@ -231,13 +235,14 @@ describe("dagToOpenFlow", () => {
     }
   });
 
-  it("declares orgId, userId, and serviceEnvs in OpenFlow schema properties", () => {
+  it("declares orgId, userId, runId, and serviceEnvs in OpenFlow schema properties", () => {
     const result = dagToOpenFlow(VALID_LINEAR_DAG, "Schema Test");
 
     expect(result.schema).toBeDefined();
     const props = (result.schema as Record<string, unknown>).properties as Record<string, unknown>;
     expect(props.orgId).toEqual({ type: "string", description: "Organization identifier" });
     expect(props.userId).toEqual({ type: "string", description: "User identifier" });
+    expect(props.runId).toEqual({ type: "string", description: "Runs-service run ID for this execution" });
     expect(props.serviceEnvs).toEqual({ type: "object", description: "Service URLs and API keys injected by workflow-service" });
   });
 

--- a/tests/unit/http-call.test.ts
+++ b/tests/unit/http-call.test.ts
@@ -39,6 +39,27 @@ describe("http-call script", () => {
     expect(options.headers["x-api-key"]).toBe("lead-key-123");
   });
 
+  it("auto-injects identity headers (x-org-id, x-user-id, x-run-id) when params provided", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    await main(
+      "lead", "POST", "/buffer/next",
+      { foo: "bar" },
+      undefined,
+      serviceEnvs,
+      undefined,
+      undefined,
+      "org-uuid-1",
+      "user-uuid-2",
+      "run-uuid-3",
+    );
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers["x-org-id"]).toBe("org-uuid-1");
+    expect(options.headers["x-user-id"]).toBe("user-uuid-2");
+    expect(options.headers["x-run-id"]).toBe("run-uuid-3");
+  });
+
   it("merges custom headers with defaults", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ found: true }));
 


### PR DESCRIPTION
## Summary
- `http-call.ts` now auto-injects `x-org-id`, `x-user-id`, `x-run-id` headers on every downstream service call (from `orgId`, `userId`, `runId` params)
- `dag-to-openflow.ts` auto-injects `runId` from `flow_input` into every module (same pattern as `orgId`/`userId`/`serviceEnvs`)
- `runId` added to Windmill OpenFlow schema properties so it's passed through as a flow input

## Test plan
- [x] Updated dag-to-openflow tests to verify `runId` auto-injection
- [x] Updated http-call tests to verify identity headers are sent
- [x] All 262 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)