### PR TITLE
fix: inject identity headers in all node scripts

### DIFF
--- a/scripts/nodes/app-resolve-discount.ts
+++ b/scripts/nodes/app-resolve-discount.ts
@@ -2,18 +2,25 @@
 export async function main(
   couponId: string,
   serviceEnvs?: Record<string, string>,
+  orgId?: string,
+  userId?: string,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.STRIPE_SERVICE_URL ?? Bun.env.STRIPE_SERVICE_URL;
   const apiKey = serviceEnvs?.STRIPE_SERVICE_API_KEY ?? Bun.env.STRIPE_SERVICE_API_KEY;
   if (!baseUrl) throw new Error("STRIPE_SERVICE_URL is not set");
   if (!apiKey) throw new Error("STRIPE_SERVICE_API_KEY is not set");
 
+  const reqHeaders: Record<string, string> = {};
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+  if (apiKey) reqHeaders["x-api-key"] = apiKey;
+
   const response = await fetch(
     `${baseUrl}/coupons/${couponId}`,
     {
-      headers: {
-        "X-API-Key": apiKey,
-      },
+      headers: reqHeaders,
     }
   );
 

--- a/scripts/nodes/app-resolve-product.ts
+++ b/scripts/nodes/app-resolve-product.ts
@@ -2,18 +2,25 @@
 export async function main(
   productId: string,
   serviceEnvs?: Record<string, string>,
+  orgId?: string,
+  userId?: string,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.STRIPE_SERVICE_URL ?? Bun.env.STRIPE_SERVICE_URL;
   const apiKey = serviceEnvs?.STRIPE_SERVICE_API_KEY ?? Bun.env.STRIPE_SERVICE_API_KEY;
   if (!baseUrl) throw new Error("STRIPE_SERVICE_URL is not set");
   if (!apiKey) throw new Error("STRIPE_SERVICE_API_KEY is not set");
 
+  const reqHeaders: Record<string, string> = {};
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+  if (apiKey) reqHeaders["x-api-key"] = apiKey;
+
   const response = await fetch(
     `${baseUrl}/products/${productId}`,
     {
-      headers: {
-        "X-API-Key": apiKey,
-      },
+      headers: reqHeaders,
     }
   );
 

--- a/scripts/nodes/client-create-user.ts
+++ b/scripts/nodes/client-create-user.ts
@@ -7,20 +7,27 @@ export async function main(
   phone?: string,
   metadata?: Record<string, unknown>,
   serviceEnvs?: Record<string, string>,
+  userId?: string,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.CLIENT_SERVICE_URL ?? Bun.env.CLIENT_SERVICE_URL;
   const apiKey = serviceEnvs?.CLIENT_SERVICE_API_KEY ?? Bun.env.CLIENT_SERVICE_API_KEY;
   if (!baseUrl) throw new Error("CLIENT_SERVICE_URL is not set");
   if (!apiKey) throw new Error("CLIENT_SERVICE_API_KEY is not set");
 
+  const reqHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+  if (apiKey) reqHeaders["x-api-key"] = apiKey;
+
   const response = await fetch(
     `${baseUrl}/anonymous-users`,
     {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-      },
+      headers: reqHeaders,
       body: JSON.stringify({ orgId, email, firstName, lastName, phone, metadata }),
     }
   );

--- a/scripts/nodes/client-get-users.ts
+++ b/scripts/nodes/client-get-users.ts
@@ -4,6 +4,8 @@ export async function main(
   limit?: number,
   offset?: number,
   serviceEnvs?: Record<string, string>,
+  userId?: string,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.CLIENT_SERVICE_URL ?? Bun.env.CLIENT_SERVICE_URL;
   const apiKey = serviceEnvs?.CLIENT_SERVICE_API_KEY ?? Bun.env.CLIENT_SERVICE_API_KEY;
@@ -14,12 +16,16 @@ export async function main(
   if (limit) params.set("limit", String(limit));
   if (offset) params.set("offset", String(offset));
 
+  const reqHeaders: Record<string, string> = {};
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+  if (apiKey) reqHeaders["x-api-key"] = apiKey;
+
   const response = await fetch(
     `${baseUrl}/anonymous-users?${params}`,
     {
-      headers: {
-        "x-api-key": apiKey,
-      },
+      headers: reqHeaders,
     }
   );
 

--- a/scripts/nodes/client-service.ts
+++ b/scripts/nodes/client-service.ts
@@ -7,15 +7,22 @@ export async function main(
     orgId?: string;
   },
   serviceEnvs?: Record<string, string>,
+  orgId?: string,
+  userId?: string,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.CLIENT_SERVICE_URL ?? Bun.env.CLIENT_SERVICE_URL;
   const apiKey = serviceEnvs?.CLIENT_SERVICE_API_KEY ?? Bun.env.CLIENT_SERVICE_API_KEY;
   if (!baseUrl) throw new Error("CLIENT_SERVICE_URL is not set");
   if (!apiKey) throw new Error("CLIENT_SERVICE_API_KEY is not set");
+  const resolvedOrgId = orgId ?? context?.orgId;
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "x-api-key": apiKey,
   };
+  if (resolvedOrgId) headers["x-org-id"] = resolvedOrgId;
+  if (userId) headers["x-user-id"] = userId;
+  if (runId) headers["x-run-id"] = runId;
 
   if (action === "create" || action === "update") {
     const response = await fetch(`${baseUrl}/anonymous-users`, {

--- a/scripts/nodes/client-update-user.ts
+++ b/scripts/nodes/client-update-user.ts
@@ -8,21 +8,26 @@ export async function main(
   orgId?: string | null,
   metadata?: Record<string, unknown> | null,
   serviceEnvs?: Record<string, string>,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.CLIENT_SERVICE_URL ?? Bun.env.CLIENT_SERVICE_URL;
   const apiKey = serviceEnvs?.CLIENT_SERVICE_API_KEY ?? Bun.env.CLIENT_SERVICE_API_KEY;
   if (!baseUrl) throw new Error("CLIENT_SERVICE_URL is not set");
   if (!apiKey) throw new Error("CLIENT_SERVICE_API_KEY is not set");
 
+  const reqHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+  if (apiKey) reqHeaders["x-api-key"] = apiKey;
 
   const response = await fetch(
     `${baseUrl}/anonymous-users/${userId}`,
     {
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-      },
+      headers: reqHeaders,
       body: JSON.stringify({ firstName, lastName, phone, userId: linkedUserId, orgId, metadata }),
     }
   );

--- a/scripts/nodes/stripe-create-checkout.ts
+++ b/scripts/nodes/stripe-create-checkout.ts
@@ -13,20 +13,26 @@ export async function main(
   campaignId?: string,
   runId?: string,
   serviceEnvs?: Record<string, string>,
+  userId?: string,
 ) {
   const baseUrl = serviceEnvs?.STRIPE_SERVICE_URL ?? Bun.env.STRIPE_SERVICE_URL;
   const apiKey = serviceEnvs?.STRIPE_SERVICE_API_KEY ?? Bun.env.STRIPE_SERVICE_API_KEY;
   if (!baseUrl) throw new Error("STRIPE_SERVICE_URL is not set");
   if (!apiKey) throw new Error("STRIPE_SERVICE_API_KEY is not set");
 
+  const reqHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+  if (apiKey) reqHeaders["x-api-key"] = apiKey;
+
   const response = await fetch(
     `${baseUrl}/checkout/create`,
     {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-API-Key": apiKey,
-      },
+      headers: reqHeaders,
       body: JSON.stringify({
         lineItems, successUrl, cancelUrl, mode, customerId, customerEmail,
         metadata, discounts, orgId, brandId, campaignId, runId,

--- a/scripts/nodes/stripe-create-coupon.ts
+++ b/scripts/nodes/stripe-create-coupon.ts
@@ -12,20 +12,27 @@ export async function main(
   redeemBy?: string,
   metadata?: Record<string, string>,
   serviceEnvs?: Record<string, string>,
+  userId?: string,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.STRIPE_SERVICE_URL ?? Bun.env.STRIPE_SERVICE_URL;
   const apiKey = serviceEnvs?.STRIPE_SERVICE_API_KEY ?? Bun.env.STRIPE_SERVICE_API_KEY;
   if (!baseUrl) throw new Error("STRIPE_SERVICE_URL is not set");
   if (!apiKey) throw new Error("STRIPE_SERVICE_API_KEY is not set");
 
+  const reqHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+  if (apiKey) reqHeaders["x-api-key"] = apiKey;
+
   const response = await fetch(
     `${baseUrl}/coupons/create`,
     {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-API-Key": apiKey,
-      },
+      headers: reqHeaders,
       body: JSON.stringify({ orgId, id, name, percentOff, amountOffInCents, currency, duration, durationInMonths, maxRedemptions, redeemBy, metadata }),
     }
   );

--- a/scripts/nodes/stripe-create-price.ts
+++ b/scripts/nodes/stripe-create-price.ts
@@ -7,20 +7,27 @@ export async function main(
   recurring?: { interval: "day" | "week" | "month" | "year"; intervalCount?: number },
   metadata?: Record<string, string>,
   serviceEnvs?: Record<string, string>,
+  userId?: string,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.STRIPE_SERVICE_URL ?? Bun.env.STRIPE_SERVICE_URL;
   const apiKey = serviceEnvs?.STRIPE_SERVICE_API_KEY ?? Bun.env.STRIPE_SERVICE_API_KEY;
   if (!baseUrl) throw new Error("STRIPE_SERVICE_URL is not set");
   if (!apiKey) throw new Error("STRIPE_SERVICE_API_KEY is not set");
 
+  const reqHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+  if (apiKey) reqHeaders["x-api-key"] = apiKey;
+
   const response = await fetch(
     `${baseUrl}/prices/create`,
     {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-API-Key": apiKey,
-      },
+      headers: reqHeaders,
       body: JSON.stringify({ orgId, productId, unitAmountInCents, currency, recurring, metadata }),
     }
   );

--- a/scripts/nodes/stripe-create-product.ts
+++ b/scripts/nodes/stripe-create-product.ts
@@ -6,20 +6,27 @@ export async function main(
   id?: string,
   metadata?: Record<string, string>,
   serviceEnvs?: Record<string, string>,
+  userId?: string,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.STRIPE_SERVICE_URL ?? Bun.env.STRIPE_SERVICE_URL;
   const apiKey = serviceEnvs?.STRIPE_SERVICE_API_KEY ?? Bun.env.STRIPE_SERVICE_API_KEY;
   if (!baseUrl) throw new Error("STRIPE_SERVICE_URL is not set");
   if (!apiKey) throw new Error("STRIPE_SERVICE_API_KEY is not set");
 
+  const reqHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+  if (apiKey) reqHeaders["x-api-key"] = apiKey;
+
   const response = await fetch(
     `${baseUrl}/products/create`,
     {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-API-Key": apiKey,
-      },
+      headers: reqHeaders,
       body: JSON.stringify({ orgId, name, description, id, metadata }),
     }
   );

--- a/scripts/nodes/stripe-get-coupon.ts
+++ b/scripts/nodes/stripe-get-coupon.ts
@@ -3,6 +3,8 @@ export async function main(
   orgId: string,
   couponId: string,
   serviceEnvs?: Record<string, string>,
+  userId?: string,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.STRIPE_SERVICE_URL ?? Bun.env.STRIPE_SERVICE_URL;
   const apiKey = serviceEnvs?.STRIPE_SERVICE_API_KEY ?? Bun.env.STRIPE_SERVICE_API_KEY;
@@ -12,12 +14,16 @@ export async function main(
   const url = new URL(`${baseUrl}/coupons/${couponId}`);
   url.searchParams.set("orgId", orgId);
 
+  const reqHeaders: Record<string, string> = {};
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+  if (apiKey) reqHeaders["x-api-key"] = apiKey;
+
   const response = await fetch(
     url.toString(),
     {
-      headers: {
-        "X-API-Key": apiKey,
-      },
+      headers: reqHeaders,
     }
   );
 

--- a/scripts/nodes/stripe-get-prices-by-product.ts
+++ b/scripts/nodes/stripe-get-prices-by-product.ts
@@ -3,6 +3,8 @@ export async function main(
   orgId: string,
   productId: string,
   serviceEnvs?: Record<string, string>,
+  userId?: string,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.STRIPE_SERVICE_URL ?? Bun.env.STRIPE_SERVICE_URL;
   const apiKey = serviceEnvs?.STRIPE_SERVICE_API_KEY ?? Bun.env.STRIPE_SERVICE_API_KEY;
@@ -12,12 +14,16 @@ export async function main(
   const url = new URL(`${baseUrl}/prices/by-product/${productId}`);
   url.searchParams.set("orgId", orgId);
 
+  const reqHeaders: Record<string, string> = {};
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+  if (apiKey) reqHeaders["x-api-key"] = apiKey;
+
   const response = await fetch(
     url.toString(),
     {
-      headers: {
-        "X-API-Key": apiKey,
-      },
+      headers: reqHeaders,
     }
   );
 

--- a/scripts/nodes/stripe-get-product.ts
+++ b/scripts/nodes/stripe-get-product.ts
@@ -3,6 +3,8 @@ export async function main(
   orgId: string,
   productId: string,
   serviceEnvs?: Record<string, string>,
+  userId?: string,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.STRIPE_SERVICE_URL ?? Bun.env.STRIPE_SERVICE_URL;
   const apiKey = serviceEnvs?.STRIPE_SERVICE_API_KEY ?? Bun.env.STRIPE_SERVICE_API_KEY;
@@ -12,12 +14,16 @@ export async function main(
   const url = new URL(`${baseUrl}/products/${productId}`);
   url.searchParams.set("orgId", orgId);
 
+  const reqHeaders: Record<string, string> = {};
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+  if (apiKey) reqHeaders["x-api-key"] = apiKey;
+
   const response = await fetch(
     url.toString(),
     {
-      headers: {
-        "X-API-Key": apiKey,
-      },
+      headers: reqHeaders,
     }
   );
 

--- a/scripts/nodes/stripe-get-stats.ts
+++ b/scripts/nodes/stripe-get-stats.ts
@@ -5,20 +5,27 @@ export async function main(
   brandId?: string,
   campaignId?: string,
   serviceEnvs?: Record<string, string>,
+  userId?: string,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.STRIPE_SERVICE_URL ?? Bun.env.STRIPE_SERVICE_URL;
   const apiKey = serviceEnvs?.STRIPE_SERVICE_API_KEY ?? Bun.env.STRIPE_SERVICE_API_KEY;
   if (!baseUrl) throw new Error("STRIPE_SERVICE_URL is not set");
   if (!apiKey) throw new Error("STRIPE_SERVICE_API_KEY is not set");
 
+  const reqHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+  if (apiKey) reqHeaders["x-api-key"] = apiKey;
+
   const response = await fetch(
     `${baseUrl}/stats`,
     {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-API-Key": apiKey,
-      },
+      headers: reqHeaders,
       body: JSON.stringify({ runIds, orgId, brandId, campaignId }),
     }
   );

--- a/scripts/nodes/transactional-email-get-stats.ts
+++ b/scripts/nodes/transactional-email-get-stats.ts
@@ -4,20 +4,26 @@ export async function main(
   userId?: string,
   eventType?: string,
   serviceEnvs?: Record<string, string>,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.["TRANSACTIONAL_EMAIL_SERVICE_URL"] ?? Bun.env.TRANSACTIONAL_EMAIL_SERVICE_URL;
   const apiKey = serviceEnvs?.["TRANSACTIONAL_EMAIL_SERVICE_API_KEY"] ?? Bun.env.TRANSACTIONAL_EMAIL_SERVICE_API_KEY;
   if (!baseUrl) throw new Error("TRANSACTIONAL_EMAIL_SERVICE_URL is not set");
   if (!apiKey) throw new Error("TRANSACTIONAL_EMAIL_SERVICE_API_KEY is not set");
 
+  const reqHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": apiKey,
+  };
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+
   const response = await fetch(
     `${baseUrl}/stats`,
     {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-      },
+      headers: reqHeaders,
       body: JSON.stringify({ orgId, userId, eventType }),
     }
   );

--- a/scripts/nodes/transactional-email-send.ts
+++ b/scripts/nodes/transactional-email-send.ts
@@ -9,20 +9,26 @@ export async function main(
   orgId?: string,
   metadata?: Record<string, unknown>,
   serviceEnvs?: Record<string, string>,
+  runId?: string,
 ) {
   const baseUrl = serviceEnvs?.["TRANSACTIONAL_EMAIL_SERVICE_URL"] ?? Bun.env.TRANSACTIONAL_EMAIL_SERVICE_URL;
   const apiKey = serviceEnvs?.["TRANSACTIONAL_EMAIL_SERVICE_API_KEY"] ?? Bun.env.TRANSACTIONAL_EMAIL_SERVICE_API_KEY;
   if (!baseUrl) throw new Error("TRANSACTIONAL_EMAIL_SERVICE_URL is not set");
   if (!apiKey) throw new Error("TRANSACTIONAL_EMAIL_SERVICE_API_KEY is not set");
 
+  const reqHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": apiKey,
+  };
+  if (orgId) reqHeaders["x-org-id"] = orgId;
+  if (userId) reqHeaders["x-user-id"] = userId;
+  if (runId) reqHeaders["x-run-id"] = runId;
+
   const response = await fetch(
     `${baseUrl}/send`,
     {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-      },
+      headers: reqHeaders,
       body: JSON.stringify({ eventType, recipientEmail, brandId, campaignId, productId, userId, orgId, metadata }),
     }
   );

--- a/tests/unit/node-identity-headers.test.ts
+++ b/tests/unit/node-identity-headers.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock Bun.env globally (script runs in Bun but we test in Node)
+const mockEnv: Record<string, string> = {};
+vi.stubGlobal("Bun", { env: mockEnv });
+
+// Capture fetch calls
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("node scripts inject identity headers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(mockEnv)) delete mockEnv[key];
+  });
+
+  const emailEnvs: Record<string, string> = {
+    TRANSACTIONAL_EMAIL_SERVICE_URL: "https://email.example.com",
+    TRANSACTIONAL_EMAIL_SERVICE_API_KEY: "email-key-123",
+  };
+
+  const stripeEnvs: Record<string, string> = {
+    STRIPE_SERVICE_URL: "https://stripe.example.com",
+    STRIPE_SERVICE_API_KEY: "stripe-key-123",
+  };
+
+  const clientEnvs: Record<string, string> = {
+    CLIENT_SERVICE_URL: "https://client.example.com",
+    CLIENT_SERVICE_API_KEY: "client-key-123",
+  };
+
+  describe("transactional-email-send", () => {
+    it("sends x-org-id, x-user-id, x-run-id as HTTP headers", async () => {
+      const { main } = await import("../../scripts/nodes/transactional-email-send.js");
+      mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      await main(
+        "contact_welcome",       // eventType
+        "test@example.com",      // recipientEmail
+        undefined,               // brandId
+        undefined,               // campaignId
+        undefined,               // productId
+        "user-uuid-1",           // userId
+        "org-uuid-1",            // orgId
+        undefined,               // metadata
+        emailEnvs,               // serviceEnvs
+        "run-uuid-1",            // runId
+      );
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://email.example.com/send");
+      expect(options.headers["x-org-id"]).toBe("org-uuid-1");
+      expect(options.headers["x-user-id"]).toBe("user-uuid-1");
+      expect(options.headers["x-run-id"]).toBe("run-uuid-1");
+      expect(options.headers["x-api-key"]).toBe("email-key-123");
+    });
+
+    it("omits identity headers when params are undefined", async () => {
+      const { main } = await import("../../scripts/nodes/transactional-email-send.js");
+      mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      await main("contact_welcome", "test@example.com", undefined, undefined, undefined, undefined, undefined, undefined, emailEnvs);
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.headers["x-org-id"]).toBeUndefined();
+      expect(options.headers["x-user-id"]).toBeUndefined();
+      expect(options.headers["x-run-id"]).toBeUndefined();
+      expect(options.headers["x-api-key"]).toBe("email-key-123");
+    });
+  });
+
+  describe("transactional-email-get-stats", () => {
+    it("sends x-org-id, x-user-id, x-run-id as HTTP headers", async () => {
+      const { main } = await import("../../scripts/nodes/transactional-email-get-stats.js");
+      mockFetch.mockResolvedValueOnce(jsonResponse({ sent: 10 }));
+
+      await main(
+        "org-uuid-1",   // orgId
+        "user-uuid-1",  // userId
+        "welcome",      // eventType
+        emailEnvs,      // serviceEnvs
+        "run-uuid-1",   // runId
+      );
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.headers["x-org-id"]).toBe("org-uuid-1");
+      expect(options.headers["x-user-id"]).toBe("user-uuid-1");
+      expect(options.headers["x-run-id"]).toBe("run-uuid-1");
+    });
+  });
+
+  describe("stripe-create-product", () => {
+    it("sends identity headers", async () => {
+      const { main } = await import("../../scripts/nodes/stripe-create-product.js");
+      mockFetch.mockResolvedValueOnce(jsonResponse({ productId: "prod_1" }));
+
+      await main(
+        "org-uuid-1",    // orgId
+        "Test Product",  // name
+        undefined,       // description
+        undefined,       // id
+        undefined,       // metadata
+        stripeEnvs,      // serviceEnvs
+        "user-uuid-1",   // userId
+        "run-uuid-1",    // runId
+      );
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.headers["x-org-id"]).toBe("org-uuid-1");
+      expect(options.headers["x-user-id"]).toBe("user-uuid-1");
+      expect(options.headers["x-run-id"]).toBe("run-uuid-1");
+      expect(options.headers["x-api-key"]).toBe("stripe-key-123");
+    });
+  });
+
+  describe("client-create-user", () => {
+    it("sends identity headers", async () => {
+      const { main } = await import("../../scripts/nodes/client-create-user.js");
+      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "u-1" }));
+
+      await main(
+        "org-uuid-1",         // orgId
+        "test@example.com",   // email
+        undefined,            // firstName
+        undefined,            // lastName
+        undefined,            // phone
+        undefined,            // metadata
+        clientEnvs,           // serviceEnvs
+        "user-uuid-1",        // userId
+        "run-uuid-1",         // runId
+      );
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.headers["x-org-id"]).toBe("org-uuid-1");
+      expect(options.headers["x-user-id"]).toBe("user-uuid-1");
+      expect(options.headers["x-run-id"]).toBe("run-uuid-1");
+      expect(options.headers["x-api-key"]).toBe("client-key-123");
+    });
+  });
+
+  describe("app-resolve-product", () => {
+    it("sends identity headers", async () => {
+      const { main } = await import("../../scripts/nodes/app-resolve-product.js");
+      mockFetch.mockResolvedValueOnce(jsonResponse({ productId: "prod_1", name: "Test" }));
+
+      await main(
+        "prod_1",        // productId
+        stripeEnvs,      // serviceEnvs
+        "org-uuid-1",    // orgId
+        "user-uuid-1",   // userId
+        "run-uuid-1",    // runId
+      );
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.headers["x-org-id"]).toBe("org-uuid-1");
+      expect(options.headers["x-user-id"]).toBe("user-uuid-1");
+      expect(options.headers["x-run-id"]).toBe("run-uuid-1");
+      expect(options.headers["x-api-key"]).toBe("stripe-key-123");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- All 16 specialized node scripts (email, stripe, client, app-resolve) were only sending `orgId`/`userId` in the request **body** but not as HTTP **headers**
- Since commit b5651e3 all backend services require `x-org-id` and `x-user-id` headers, causing `400 "Missing required header: x-org-id"` errors — most visibly on transactional email sends
- Added `x-org-id`, `x-user-id`, `x-run-id` header injection to all 16 node scripts, matching the pattern already used by `http-call.ts`

## Test plan
- [x] Added `tests/unit/node-identity-headers.test.ts` with 6 regression tests covering email-send, email-get-stats, stripe-create-product, client-create-user, app-resolve-product
- [x] All 197 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)