### PR TITLE
fix: correct provider-requirements path on key-service call

### DIFF
--- a/src/lib/key-service-client.ts
+++ b/src/lib/key-service-client.ts
@@ -28,7 +28,7 @@ export async function fetchProviderRequirements(
 ): Promise<ProviderRequirementsResponse> {
   const { baseUrl, apiKey } = getKeyServiceConfig();
 
-  const url = `${baseUrl}/internal/provider-requirements`;
+  const url = `${baseUrl}/provider-requirements`;
   const res = await fetch(url, {
     method: "POST",
     headers: {
@@ -41,7 +41,7 @@ export async function fetchProviderRequirements(
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `key-service error: POST /internal/provider-requirements -> ${res.status} ${res.statusText}: ${text}`
+      `key-service error: POST /provider-requirements -> ${res.status} ${res.statusText}: ${text}`
     );
   }
 

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -623,7 +623,7 @@ describe("GET /workflows/:id/required-providers", () => {
 
     mockFetchProviderRequirements.mockRejectedValue(
       new Error(
-        "key-service error: POST /internal/provider-requirements -> 500 Internal Server Error: boom"
+        "key-service error: POST /provider-requirements -> 500 Internal Server Error: boom"
       )
     );
 

--- a/tests/unit/key-service-client.test.ts
+++ b/tests/unit/key-service-client.test.ts
@@ -50,7 +50,7 @@ describe("fetchProviderRequirements", () => {
 
     expect(result).toEqual(mockResponse);
     expect(fetch).toHaveBeenCalledWith(
-      "http://localhost:4000/internal/provider-requirements",
+      "http://localhost:4000/provider-requirements",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -75,9 +75,27 @@ describe("fetchProviderRequirements", () => {
     await fetchProviderRequirements([]);
 
     expect(fetch).toHaveBeenCalledWith(
-      "http://localhost:4000/internal/provider-requirements",
+      "http://localhost:4000/provider-requirements",
       expect.anything()
     );
+  });
+
+  it("calls /provider-requirements without /internal prefix (regression)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ requirements: [], providers: [] }),
+      })
+    );
+
+    await fetchProviderRequirements([
+      { service: "apollo", method: "POST", path: "/search" },
+    ]);
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).not.toContain("/internal/");
+    expect(calledUrl.endsWith("/provider-requirements")).toBe(true);
   });
 
   it("throws on non-2xx response from key-service", async () => {


### PR DESCRIPTION
## Summary
- workflow-service was calling `POST /internal/provider-requirements` on key-service, but key-service exposes the endpoint at `POST /provider-requirements` (no `/internal` prefix)
- This caused 404 errors on every `GET /workflows/{id}/required-providers` call, silently breaking the `requiredProviders` feature in api-service's leaderboard
- Added regression test verifying the URL does not contain `/internal/`

## Test plan
- [x] All 281 existing tests pass
- [x] New regression test confirms URL uses `/provider-requirements` without `/internal` prefix
- [ ] After deploy, verify api-service leaderboard shows `requiredProviders` populated instead of empty arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)