### PR TITLE
fix: forward identity headers in all src/lib HTTP clients

### DIFF
--- a/src/lib/api-registry-client.ts
+++ b/src/lib/api-registry-client.ts
@@ -1,3 +1,5 @@
+import type { IdentityHeaders } from "./key-service-client.js";
+
 export interface LlmServiceSummary {
   service: string;
   baseUrl: string;
@@ -33,12 +35,17 @@ function getApiRegistryConfig(): { baseUrl: string; apiKey: string } {
 }
 
 /** GET /llm-context — compact summary of all services and endpoints for LLM consumption */
-export async function fetchLlmContext(): Promise<LlmContextResponse> {
+export async function fetchLlmContext(identity: IdentityHeaders): Promise<LlmContextResponse> {
   const { baseUrl, apiKey } = getApiRegistryConfig();
 
   const res = await fetch(`${baseUrl}/llm-context`, {
     method: "GET",
-    headers: { "x-api-key": apiKey },
+    headers: {
+      "x-api-key": apiKey,
+      "x-org-id": identity.orgId,
+      "x-user-id": identity.userId,
+      "x-run-id": identity.runId,
+    },
   });
 
   if (!res.ok) {
@@ -54,6 +61,7 @@ export async function fetchLlmContext(): Promise<LlmContextResponse> {
 /** GET /openapi/:service — full OpenAPI spec for one service */
 export async function fetchServiceSpec(
   serviceName: string,
+  identity: IdentityHeaders,
 ): Promise<Record<string, unknown>> {
   const { baseUrl, apiKey } = getApiRegistryConfig();
 
@@ -61,7 +69,12 @@ export async function fetchServiceSpec(
     `${baseUrl}/openapi/${encodeURIComponent(serviceName)}`,
     {
       method: "GET",
-      headers: { "x-api-key": apiKey },
+      headers: {
+        "x-api-key": apiKey,
+        "x-org-id": identity.orgId,
+        "x-user-id": identity.userId,
+        "x-run-id": identity.runId,
+      },
     },
   );
 

--- a/src/lib/key-service-client.ts
+++ b/src/lib/key-service-client.ts
@@ -1,5 +1,11 @@
 import type { HttpEndpoint } from "./extract-http-endpoints.js";
 
+export interface IdentityHeaders {
+  orgId: string;
+  userId: string;
+  runId: string;
+}
+
 export interface ProviderRequirementsResponse {
   requirements: unknown[];
   providers: string[];
@@ -24,7 +30,8 @@ function getKeyServiceConfig(): { baseUrl: string; apiKey: string } {
 }
 
 export async function fetchProviderRequirements(
-  endpoints: HttpEndpoint[]
+  endpoints: HttpEndpoint[],
+  identity: IdentityHeaders,
 ): Promise<ProviderRequirementsResponse> {
   const { baseUrl, apiKey } = getKeyServiceConfig();
 
@@ -34,6 +41,9 @@ export async function fetchProviderRequirements(
     headers: {
       "Content-Type": "application/json",
       "x-api-key": apiKey,
+      "x-org-id": identity.orgId,
+      "x-user-id": identity.userId,
+      "x-run-id": identity.runId,
     },
     body: JSON.stringify({ endpoints }),
   });
@@ -49,7 +59,7 @@ export async function fetchProviderRequirements(
 }
 
 export async function fetchAnthropicKey(
-  opts: { orgId: string; userId: string },
+  opts: { orgId: string; userId: string; runId: string },
 ): Promise<KeyDecryptResponse> {
   const { baseUrl, apiKey } = getKeyServiceConfig();
 
@@ -69,6 +79,9 @@ export async function fetchAnthropicKey(
     method: "GET",
     headers: {
       "x-api-key": apiKey,
+      "x-org-id": opts.orgId,
+      "x-user-id": opts.userId,
+      "x-run-id": opts.runId,
       ...callerHeaders,
     },
   });

--- a/src/lib/stats-client.ts
+++ b/src/lib/stats-client.ts
@@ -1,3 +1,5 @@
+import type { IdentityHeaders } from "./key-service-client.js";
+
 // --- Config helpers (same pattern as key-service-client.ts) ---
 
 function getRunsServiceConfig(): { baseUrl: string; apiKey: string } {
@@ -47,7 +49,7 @@ export interface EmailStatsResponse {
 
 // --- Fetch run costs from runs-service ---
 
-export async function fetchRunCosts(runIds: string[]): Promise<RunCost[]> {
+export async function fetchRunCosts(runIds: string[], identity: IdentityHeaders): Promise<RunCost[]> {
   if (runIds.length === 0) return [];
 
   const { baseUrl, apiKey } = getRunsServiceConfig();
@@ -57,7 +59,12 @@ export async function fetchRunCosts(runIds: string[]): Promise<RunCost[]> {
     runIds.map(async (runId) => {
       const res = await fetch(`${baseUrl}/v1/runs/${runId}`, {
         method: "GET",
-        headers: { "x-api-key": apiKey },
+        headers: {
+          "x-api-key": apiKey,
+          "x-org-id": identity.orgId,
+          "x-user-id": identity.userId,
+          "x-run-id": identity.runId,
+        },
       });
       if (!res.ok) {
         console.warn(
@@ -93,7 +100,8 @@ const EMPTY_STATS: EmailStats = {
 };
 
 export async function fetchEmailStats(
-  runIds: string[]
+  runIds: string[],
+  identity: IdentityHeaders,
 ): Promise<EmailStatsResponse> {
   if (runIds.length === 0) {
     return { transactional: { ...EMPTY_STATS }, broadcast: { ...EMPTY_STATS } };
@@ -106,6 +114,9 @@ export async function fetchEmailStats(
     headers: {
       "Content-Type": "application/json",
       "x-api-key": apiKey,
+      "x-org-id": identity.orgId,
+      "x-user-id": identity.userId,
+      "x-run-id": identity.runId,
     },
     body: JSON.stringify({ runIds }),
   });

--- a/src/lib/workflow-generator.ts
+++ b/src/lib/workflow-generator.ts
@@ -10,6 +10,7 @@ import {
   fetchLlmContext,
   fetchServiceSpec,
 } from "./api-registry-client.js";
+import type { IdentityHeaders } from "./key-service-client.js";
 
 export interface GenerateWorkflowInput {
   description: string;
@@ -48,10 +49,11 @@ export function setAnthropicClient(client: Anthropic | null): void {
 async function resolveToolCall(
   toolName: string,
   toolInput: Record<string, unknown>,
+  identity: IdentityHeaders,
 ): Promise<{ content: string; isError?: boolean }> {
   switch (toolName) {
     case "list_services": {
-      const context = await fetchLlmContext();
+      const context = await fetchLlmContext(identity);
       const summary = context.services.map((s) => ({
         name: s.service,
         description: s.description ?? s.title ?? "",
@@ -62,7 +64,7 @@ async function resolveToolCall(
     }
     case "get_service_endpoints": {
       const serviceName = toolInput.service as string;
-      const spec = await fetchServiceSpec(serviceName);
+      const spec = await fetchServiceSpec(serviceName, identity);
       return { content: JSON.stringify(spec, null, 2) };
     }
     default:
@@ -73,6 +75,7 @@ async function resolveToolCall(
 export async function generateWorkflow(
   input: GenerateWorkflowInput,
   anthropicApiKey: string,
+  identity: IdentityHeaders,
 ): Promise<GenerateWorkflowResult> {
   const client = overrideClient ?? new Anthropic({ apiKey: anthropicApiKey });
 
@@ -192,6 +195,7 @@ export async function generateWorkflow(
         const resolved = await resolveToolCall(
           toolBlock.name,
           toolBlock.input as Record<string, unknown>,
+          identity,
         );
         toolResults.push({
           type: "tool_result",

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -47,12 +47,15 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
     const body = GenerateWorkflowSchema.parse(req.body);
     const orgId = body.orgId;
     const userId = res.locals.userId as string;
+    const runId = res.locals.runId as string;
+    const identity = { orgId, userId, runId };
 
-    const { key: anthropicApiKey } = await fetchAnthropicKey({ orgId, userId });
+    const { key: anthropicApiKey } = await fetchAnthropicKey({ orgId, userId, runId });
 
     const generated = await generateWorkflow(
       { description: body.description, hints: body.hints, style: body.style },
       anthropicApiKey,
+      identity,
     );
 
     const dag = generated.dag as DAG;
@@ -493,6 +496,11 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
       return;
     }
     const { orgId, category, channel, audienceType, objective } = query.data;
+    const identity = {
+      orgId: res.locals.orgId as string,
+      userId: res.locals.userId as string,
+      runId: res.locals.runId as string,
+    };
 
     // 1. Get all workflows matching the dimensions (all filters optional)
     const conditions: ReturnType<typeof eq>[] = [];
@@ -541,7 +549,7 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
     }
 
     // 3. Batch fetch costs from runs-service
-    const runCosts = await fetchRunCosts(allRunIds);
+    const runCosts = await fetchRunCosts(allRunIds, identity);
     const costByRunId = new Map(
       runCosts.map((c) => [c.runId, c.totalCostInUsdCents])
     );
@@ -564,7 +572,7 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
         0
       );
 
-      const stats = await fetchEmailStats(runIds);
+      const stats = await fetchEmailStats(runIds, identity);
       const outcomes =
         objective === "replies"
           ? (stats.transactional?.replied ?? 0) + (stats.broadcast?.replied ?? 0)
@@ -702,6 +710,12 @@ router.get("/workflows/:id", requireApiKey, async (req, res) => {
 // GET /workflows/:id/required-providers — Compute required BYOK providers for a workflow
 router.get("/workflows/:id/required-providers", requireApiKey, async (req, res) => {
   try {
+    const identity = {
+      orgId: res.locals.orgId as string,
+      userId: res.locals.userId as string,
+      runId: res.locals.runId as string,
+    };
+
     const [workflow] = await db
       .select()
       .from(workflows)
@@ -720,7 +734,7 @@ router.get("/workflows/:id/required-providers", requireApiKey, async (req, res) 
       return;
     }
 
-    const result = await fetchProviderRequirements(endpoints);
+    const result = await fetchProviderRequirements(endpoints, identity);
 
     res.json({
       endpoints,

--- a/tests/integration/generate-workflow.test.ts
+++ b/tests/integration/generate-workflow.test.ts
@@ -124,10 +124,11 @@ describe("POST /workflows/generate", () => {
     expect(res.body.category).toBe("sales");
     expect(res.body.channel).toBe("email");
     expect(res.body.audienceType).toBe("cold-outreach");
-    expect(mockFetchAnthropicKey).toHaveBeenCalledWith({ orgId: "org-1", userId: "user-1" });
+    expect(mockFetchAnthropicKey).toHaveBeenCalledWith({ orgId: "org-1", userId: "user-1", runId: "run-caller-1" });
     expect(mockGenerateWorkflow).toHaveBeenCalledWith(
       { description: "I want a cold email outreach workflow that finds leads and sends emails", hints: undefined, style: undefined },
       "resolved-anthropic-key",
+      { orgId: "org-1", userId: "user-1", runId: "run-caller-1" },
     );
   });
 
@@ -200,10 +201,11 @@ describe("POST /workflows/generate", () => {
         hints: { services: ["lead", "email-gateway"] },
       });
 
-    expect(mockFetchAnthropicKey).toHaveBeenCalledWith({ orgId: "org-1", userId: "user-1" });
+    expect(mockFetchAnthropicKey).toHaveBeenCalledWith({ orgId: "org-1", userId: "user-1", runId: "run-caller-1" });
     expect(mockGenerateWorkflow).toHaveBeenCalledWith(
       { description: "Cold email outreach with lead search", hints: { services: ["lead", "email-gateway"] }, style: undefined },
       "resolved-anthropic-key",
+      { orgId: "org-1", userId: "user-1", runId: "run-caller-1" },
     );
   });
 
@@ -271,6 +273,7 @@ describe("POST /workflows/generate", () => {
         style: { type: "human", humanId: "human-123", name: "Hormozi" },
       }),
       "resolved-anthropic-key",
+      { orgId: "org-1", userId: "user-1", runId: "run-caller-1" },
     );
   });
 

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -575,10 +575,13 @@ describe("GET /workflows/:id/required-providers", () => {
     expect(res.status).toBe(200);
     expect(res.body.endpoints).toHaveLength(2);
     expect(res.body.providers).toEqual(["client", "transactional-email"]);
-    expect(mockFetchProviderRequirements).toHaveBeenCalledWith([
-      { service: "client", method: "POST", path: "/users" },
-      { service: "transactional-email", method: "POST", path: "/send" },
-    ]);
+    expect(mockFetchProviderRequirements).toHaveBeenCalledWith(
+      [
+        { service: "client", method: "POST", path: "/users" },
+        { service: "transactional-email", method: "POST", path: "/send" },
+      ],
+      { orgId: "org-1", userId: "user-1", runId: "run-caller-1" },
+    );
   });
 
   it("returns empty providers for workflows with no http.call nodes", async () => {

--- a/tests/unit/key-service-client.test.ts
+++ b/tests/unit/key-service-client.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { fetchProviderRequirements, fetchAnthropicKey } from "../../src/lib/key-service-client.js";
+import { fetchProviderRequirements, fetchAnthropicKey, type IdentityHeaders } from "../../src/lib/key-service-client.js";
+
+const TEST_IDENTITY: IdentityHeaders = { orgId: "org-1", userId: "user-1", runId: "run-1" };
 
 describe("fetchProviderRequirements", () => {
   const originalUrl = process.env.KEY_SERVICE_URL;
@@ -18,14 +20,14 @@ describe("fetchProviderRequirements", () => {
 
   it("throws if KEY_SERVICE_URL is not set", async () => {
     delete process.env.KEY_SERVICE_URL;
-    await expect(fetchProviderRequirements([])).rejects.toThrow(
+    await expect(fetchProviderRequirements([], TEST_IDENTITY)).rejects.toThrow(
       "KEY_SERVICE_URL and KEY_SERVICE_API_KEY must be set"
     );
   });
 
   it("throws if KEY_SERVICE_API_KEY is not set", async () => {
     delete process.env.KEY_SERVICE_API_KEY;
-    await expect(fetchProviderRequirements([])).rejects.toThrow(
+    await expect(fetchProviderRequirements([], TEST_IDENTITY)).rejects.toThrow(
       "KEY_SERVICE_URL and KEY_SERVICE_API_KEY must be set"
     );
   });
@@ -46,7 +48,7 @@ describe("fetchProviderRequirements", () => {
 
     const result = await fetchProviderRequirements([
       { service: "apollo", method: "POST", path: "/search" },
-    ]);
+    ], TEST_IDENTITY);
 
     expect(result).toEqual(mockResponse);
     expect(fetch).toHaveBeenCalledWith(
@@ -56,6 +58,9 @@ describe("fetchProviderRequirements", () => {
         headers: expect.objectContaining({
           "Content-Type": "application/json",
           "x-api-key": "test-key-svc-key",
+          "x-org-id": "org-1",
+          "x-user-id": "user-1",
+          "x-run-id": "run-1",
         }),
       })
     );
@@ -72,7 +77,7 @@ describe("fetchProviderRequirements", () => {
       })
     );
 
-    await fetchProviderRequirements([]);
+    await fetchProviderRequirements([], TEST_IDENTITY);
 
     expect(fetch).toHaveBeenCalledWith(
       "http://localhost:4000/provider-requirements",
@@ -91,7 +96,7 @@ describe("fetchProviderRequirements", () => {
 
     await fetchProviderRequirements([
       { service: "apollo", method: "POST", path: "/search" },
-    ]);
+    ], TEST_IDENTITY);
 
     const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(calledUrl).not.toContain("/internal/");
@@ -112,7 +117,7 @@ describe("fetchProviderRequirements", () => {
     await expect(
       fetchProviderRequirements([
         { service: "apollo", method: "POST", path: "/search" },
-      ])
+      ], TEST_IDENTITY)
     ).rejects.toThrow("key-service error:");
   });
 });
@@ -141,7 +146,7 @@ describe("fetchAnthropicKey", () => {
       })
     );
 
-    const result = await fetchAnthropicKey({ orgId: "org-1", userId: "user-1" });
+    const result = await fetchAnthropicKey({ orgId: "org-1", userId: "user-1", runId: "run-1" });
 
     expect(result).toEqual({ key: "sk-ant-key", keySource: "platform" });
     expect(fetch).toHaveBeenCalledWith(
@@ -150,6 +155,9 @@ describe("fetchAnthropicKey", () => {
         method: "GET",
         headers: expect.objectContaining({
           "x-api-key": "test-key-svc-key",
+          "x-org-id": "org-1",
+          "x-user-id": "user-1",
+          "x-run-id": "run-1",
           "x-caller-service": "workflow",
           "x-caller-method": "POST",
           "x-caller-path": "/workflows/generate",
@@ -167,7 +175,7 @@ describe("fetchAnthropicKey", () => {
       })
     );
 
-    const result = await fetchAnthropicKey({ orgId: "org-1", userId: "user-1" });
+    const result = await fetchAnthropicKey({ orgId: "org-1", userId: "user-1", runId: "run-1" });
 
     expect(result.key).toBe("sk-ant-org-key");
     expect(result.keySource).toBe("org");
@@ -185,14 +193,14 @@ describe("fetchAnthropicKey", () => {
     );
 
     await expect(
-      fetchAnthropicKey({ orgId: "org-1", userId: "user-1" })
+      fetchAnthropicKey({ orgId: "org-1", userId: "user-1", runId: "run-1" })
     ).rejects.toThrow("key-service error:");
   });
 
   it("throws if KEY_SERVICE_URL is not set", async () => {
     delete process.env.KEY_SERVICE_URL;
     await expect(
-      fetchAnthropicKey({ orgId: "org-1", userId: "user-1" })
+      fetchAnthropicKey({ orgId: "org-1", userId: "user-1", runId: "run-1" })
     ).rejects.toThrow("KEY_SERVICE_URL and KEY_SERVICE_API_KEY must be set");
   });
 
@@ -205,7 +213,7 @@ describe("fetchAnthropicKey", () => {
       })
     );
 
-    await fetchAnthropicKey({ orgId: "org with spaces", userId: "user-1" });
+    await fetchAnthropicKey({ orgId: "org with spaces", userId: "user-1", runId: "run-1" });
 
     expect(fetch).toHaveBeenCalledWith(
       "http://localhost:4000/keys/anthropic/decrypt?orgId=org+with+spaces&userId=user-1",

--- a/tests/unit/workflow-generator.test.ts
+++ b/tests/unit/workflow-generator.test.ts
@@ -171,6 +171,7 @@ function createMockAgenticResponse(toolCalls: Array<{ name: string; input: unkno
 }
 
 const TEST_API_KEY = "test-anthropic-key";
+const TEST_IDENTITY = { orgId: "org-1", userId: "user-1", runId: "run-1" };
 
 const MOCK_LLM_CONTEXT = {
   _description: "LLM-friendly context",
@@ -238,6 +239,7 @@ describe("generateWorkflow (fallback mode — no api-registry)", () => {
     const result = await generateWorkflow(
       { description: "Search leads and send cold emails" },
       TEST_API_KEY,
+      TEST_IDENTITY,
     );
 
     expect(result.dag).toEqual(VALID_LINEAR_DAG);
@@ -259,6 +261,7 @@ describe("generateWorkflow (fallback mode — no api-registry)", () => {
     const result = await generateWorkflow(
       { description: "Search leads and send cold emails" },
       TEST_API_KEY,
+      TEST_IDENTITY,
     );
 
     expect(result.dag).toEqual(VALID_LINEAR_DAG);
@@ -279,7 +282,7 @@ describe("generateWorkflow (fallback mode — no api-registry)", () => {
     mockCreate.mockResolvedValue(createMockToolResponse(invalidDag));
 
     await expect(
-      generateWorkflow({ description: "Bad workflow" }, TEST_API_KEY),
+      generateWorkflow({ description: "Bad workflow" }, TEST_API_KEY, TEST_IDENTITY),
     ).rejects.toThrow(GenerationValidationError);
 
     // 1 initial + 2 retries = 3 calls
@@ -298,6 +301,7 @@ describe("generateWorkflow (fallback mode — no api-registry)", () => {
         },
       },
       TEST_API_KEY,
+      TEST_IDENTITY,
     );
 
     const call = mockCreate.mock.calls[0][0];
@@ -317,14 +321,14 @@ describe("generateWorkflow (fallback mode — no api-registry)", () => {
     });
 
     await expect(
-      generateWorkflow({ description: "test workflow" }, TEST_API_KEY),
+      generateWorkflow({ description: "test workflow" }, TEST_API_KEY, TEST_IDENTITY),
     ).rejects.toThrow("LLM did not return a tool use response");
   });
 
   it("includes system prompt with DAG schema", async () => {
     mockCreate.mockResolvedValueOnce(createMockToolResponse(VALID_LINEAR_DAG));
 
-    await generateWorkflow({ description: "test workflow" }, TEST_API_KEY);
+    await generateWorkflow({ description: "test workflow" }, TEST_API_KEY, TEST_IDENTITY);
 
     const call = mockCreate.mock.calls[0][0];
     expect(call.system).toContain("DAG Format");
@@ -334,7 +338,7 @@ describe("generateWorkflow (fallback mode — no api-registry)", () => {
   it("uses forced tool_choice in fallback mode", async () => {
     mockCreate.mockResolvedValueOnce(createMockToolResponse(VALID_LINEAR_DAG));
 
-    await generateWorkflow({ description: "test workflow" }, TEST_API_KEY);
+    await generateWorkflow({ description: "test workflow" }, TEST_API_KEY, TEST_IDENTITY);
 
     const call = mockCreate.mock.calls[0][0];
     expect(call.tool_choice).toEqual({ type: "tool", name: "create_workflow" });
@@ -349,6 +353,7 @@ describe("generateWorkflow (fallback mode — no api-registry)", () => {
         style: { type: "human", name: "Hormozi", humanId: "human-123" },
       },
       TEST_API_KEY,
+      TEST_IDENTITY,
     );
 
     const call = mockCreate.mock.calls[0][0];
@@ -365,6 +370,7 @@ describe("generateWorkflow (fallback mode — no api-registry)", () => {
         style: { type: "brand", name: "My Brand", brandId: "brand-456" },
       },
       TEST_API_KEY,
+      TEST_IDENTITY,
     );
 
     const call = mockCreate.mock.calls[0][0];
@@ -378,6 +384,7 @@ describe("generateWorkflow (fallback mode — no api-registry)", () => {
     await generateWorkflow(
       { description: "Cold email outreach" },
       TEST_API_KEY,
+      TEST_IDENTITY,
     );
 
     const call = mockCreate.mock.calls[0][0];
@@ -388,7 +395,7 @@ describe("generateWorkflow (fallback mode — no api-registry)", () => {
   it("only provides create_workflow tool in fallback mode", async () => {
     mockCreate.mockResolvedValueOnce(createMockToolResponse(VALID_LINEAR_DAG));
 
-    await generateWorkflow({ description: "test workflow" }, TEST_API_KEY);
+    await generateWorkflow({ description: "test workflow" }, TEST_API_KEY, TEST_IDENTITY);
 
     const call = mockCreate.mock.calls[0][0];
     expect(call.tools).toHaveLength(1);
@@ -421,7 +428,7 @@ describe("generateWorkflow (agentic mode — with api-registry)", () => {
   it("uses auto tool_choice in agentic mode", async () => {
     mockCreate.mockResolvedValueOnce(createMockToolResponse(VALID_LINEAR_DAG));
 
-    await generateWorkflow({ description: "test workflow" }, TEST_API_KEY);
+    await generateWorkflow({ description: "test workflow" }, TEST_API_KEY, TEST_IDENTITY);
 
     const call = mockCreate.mock.calls[0][0];
     expect(call.tool_choice).toEqual({ type: "auto" });
@@ -430,7 +437,7 @@ describe("generateWorkflow (agentic mode — with api-registry)", () => {
   it("provides all three tools in agentic mode", async () => {
     mockCreate.mockResolvedValueOnce(createMockToolResponse(VALID_LINEAR_DAG));
 
-    await generateWorkflow({ description: "test workflow" }, TEST_API_KEY);
+    await generateWorkflow({ description: "test workflow" }, TEST_API_KEY, TEST_IDENTITY);
 
     const call = mockCreate.mock.calls[0][0];
     expect(call.tools).toHaveLength(3);
@@ -451,6 +458,7 @@ describe("generateWorkflow (agentic mode — with api-registry)", () => {
     const result = await generateWorkflow(
       { description: "Search leads and send cold emails" },
       TEST_API_KEY,
+      TEST_IDENTITY,
     );
 
     expect(result.dag).toEqual(VALID_LINEAR_DAG);
@@ -473,12 +481,13 @@ describe("generateWorkflow (agentic mode — with api-registry)", () => {
     const result = await generateWorkflow(
       { description: "Cold email outreach" },
       TEST_API_KEY,
+      TEST_IDENTITY,
     );
 
     expect(result.dag).toEqual(VALID_LINEAR_DAG);
     expect(mockCreate).toHaveBeenCalledTimes(3);
     expect(mockFetchLlmContext).toHaveBeenCalledTimes(1);
-    expect(mockFetchServiceSpec).toHaveBeenCalledWith("lead");
+    expect(mockFetchServiceSpec).toHaveBeenCalledWith("lead", TEST_IDENTITY);
   });
 
   it("handles multiple tool calls in a single turn", async () => {
@@ -495,12 +504,13 @@ describe("generateWorkflow (agentic mode — with api-registry)", () => {
     const result = await generateWorkflow(
       { description: "Cold email outreach" },
       TEST_API_KEY,
+      TEST_IDENTITY,
     );
 
     expect(result.dag).toEqual(VALID_LINEAR_DAG);
     expect(mockCreate).toHaveBeenCalledTimes(2);
     expect(mockFetchLlmContext).toHaveBeenCalledTimes(1);
-    expect(mockFetchServiceSpec).toHaveBeenCalledWith("lead");
+    expect(mockFetchServiceSpec).toHaveBeenCalledWith("lead", TEST_IDENTITY);
   });
 
   it("passes api-registry error to LLM as tool_result error", async () => {
@@ -516,6 +526,7 @@ describe("generateWorkflow (agentic mode — with api-registry)", () => {
     const result = await generateWorkflow(
       { description: "Cold email outreach" },
       TEST_API_KEY,
+      TEST_IDENTITY,
     );
 
     expect(result.dag).toEqual(VALID_LINEAR_DAG);
@@ -533,7 +544,7 @@ describe("generateWorkflow (agentic mode — with api-registry)", () => {
     );
 
     await expect(
-      generateWorkflow({ description: "Stuck workflow" }, TEST_API_KEY),
+      generateWorkflow({ description: "Stuck workflow" }, TEST_API_KEY, TEST_IDENTITY),
     ).rejects.toThrow("Generation exceeded maximum turns without producing a workflow");
   });
 
@@ -555,6 +566,7 @@ describe("generateWorkflow (agentic mode — with api-registry)", () => {
     const result = await generateWorkflow(
       { description: "Cold email outreach" },
       TEST_API_KEY,
+      TEST_IDENTITY,
     );
 
     expect(result.dag).toEqual(VALID_LINEAR_DAG);
@@ -564,7 +576,7 @@ describe("generateWorkflow (agentic mode — with api-registry)", () => {
   it("includes service discovery instructions in system prompt", async () => {
     mockCreate.mockResolvedValueOnce(createMockToolResponse(VALID_LINEAR_DAG));
 
-    await generateWorkflow({ description: "test workflow" }, TEST_API_KEY);
+    await generateWorkflow({ description: "test workflow" }, TEST_API_KEY, TEST_IDENTITY);
 
     const call = mockCreate.mock.calls[0][0];
     expect(call.system).toContain("Service Discovery (MANDATORY)");
@@ -575,7 +587,7 @@ describe("generateWorkflow (agentic mode — with api-registry)", () => {
   it("uses higher max_tokens in agentic mode", async () => {
     mockCreate.mockResolvedValueOnce(createMockToolResponse(VALID_LINEAR_DAG));
 
-    await generateWorkflow({ description: "test workflow" }, TEST_API_KEY);
+    await generateWorkflow({ description: "test workflow" }, TEST_API_KEY, TEST_IDENTITY);
 
     const call = mockCreate.mock.calls[0][0];
     expect(call.max_tokens).toBe(16384);


### PR DESCRIPTION
## Summary
- **key-service-client**: Added `x-org-id`, `x-user-id`, `x-run-id` headers to `fetchProviderRequirements` and `fetchAnthropicKey`
- **stats-client**: Added identity headers to `fetchRunCosts` (runs-service) and `fetchEmailStats` (email-gateway-service)
- **api-registry-client**: Added identity headers to `fetchLlmContext` and `fetchServiceSpec`
- **workflow-generator**: Threaded identity through `generateWorkflow` to api-registry calls
- Updated all call sites in `workflows.ts` to pass identity from `res.locals`

Node scripts were already fixed in PRs #68-#70. This PR completes the audit by fixing the remaining src/lib/ clients.

## Test plan
- [x] All 281 existing tests pass
- [x] Updated unit tests verify identity headers are sent in outbound requests
- [x] Updated integration tests verify identity is threaded through route handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)