### PR TITLE
fix: use x-org-id header identity in all endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -285,7 +285,7 @@
           "orgId": {
             "type": "string",
             "minLength": 1,
-            "description": "Organization ID that owns this workflow."
+            "description": "Deprecated — use x-org-id header instead. Kept optional for backwards compatibility."
           },
           "brandId": {
             "type": "string",
@@ -329,7 +329,6 @@
           }
         },
         "required": [
-          "orgId",
           "name",
           "category",
           "channel",
@@ -699,7 +698,7 @@
           "orgId": {
             "type": "string",
             "minLength": 1,
-            "description": "Organization ID that owns these workflows. Workflows are scoped to (orgId + signature). This is idempotent — deploying the same DAG updates the existing workflow."
+            "description": "Deprecated — use x-org-id header instead. Kept optional for backwards compatibility."
           },
           "workflows": {
             "type": "array",
@@ -711,7 +710,6 @@
           }
         },
         "required": [
-          "orgId",
           "workflows"
         ]
       },
@@ -828,7 +826,7 @@
           "orgId": {
             "type": "string",
             "minLength": 1,
-            "description": "Organization ID. The generated workflow will be deployed under this orgId."
+            "description": "Deprecated — use x-org-id header instead. Kept optional for backwards compatibility."
           },
           "description": {
             "type": "string",
@@ -843,7 +841,6 @@
           }
         },
         "required": [
-          "orgId",
           "description"
         ]
       },

--- a/scripts/migrate-clerk-ids.ts
+++ b/scripts/migrate-clerk-ids.ts
@@ -1,0 +1,110 @@
+/**
+ * One-time migration: resolve Clerk org IDs → internal UUIDs in the workflows table.
+ *
+ * Finds all rows where org_id looks like a Clerk ID (starts with "org_"),
+ * resolves each to an internal UUID via client-service, and updates the row.
+ *
+ * Usage:
+ *   CLIENT_SERVICE_URL=https://client.distribute.org \
+ *   CLIENT_SERVICE_API_KEY=xxx \
+ *   WORKFLOW_SERVICE_DATABASE_URL=postgresql://... \
+ *   npx tsx scripts/migrate-clerk-ids.ts
+ *
+ * Add --dry-run to preview changes without writing.
+ */
+
+import { db } from "../src/db/index.js";
+import { workflows } from "../src/db/schema.js";
+import { sql } from "drizzle-orm";
+
+const CLIENT_SERVICE_URL = process.env.CLIENT_SERVICE_URL;
+const CLIENT_SERVICE_API_KEY = process.env.CLIENT_SERVICE_API_KEY;
+const DRY_RUN = process.argv.includes("--dry-run");
+
+if (!CLIENT_SERVICE_URL || !CLIENT_SERVICE_API_KEY) {
+  console.error("CLIENT_SERVICE_URL and CLIENT_SERVICE_API_KEY must be set");
+  process.exit(1);
+}
+
+async function resolveClerkOrgId(clerkOrgId: string): Promise<string | null> {
+  const res = await fetch(`${CLIENT_SERVICE_URL}/orgs/by-clerk/${clerkOrgId}`, {
+    headers: {
+      "x-api-key": CLIENT_SERVICE_API_KEY!,
+      "x-org-id": "system",
+      "x-user-id": "system",
+      "x-run-id": "migrate-clerk-ids",
+    },
+  });
+
+  if (!res.ok) {
+    console.error(`  Failed to resolve ${clerkOrgId}: ${res.status} ${res.statusText}`);
+    return null;
+  }
+
+  const data = (await res.json()) as { org: { id: string } };
+  return data.org.id;
+}
+
+async function main() {
+  console.log(DRY_RUN ? "=== DRY RUN ===" : "=== LIVE MIGRATION ===");
+
+  // Find all workflows with Clerk-style org_id
+  const clerkRows = await db
+    .select({ id: workflows.id, orgId: workflows.orgId })
+    .from(workflows)
+    .where(sql`${workflows.orgId} LIKE 'org_%'`);
+
+  console.log(`Found ${clerkRows.length} workflows with Clerk org IDs`);
+
+  if (clerkRows.length === 0) {
+    console.log("Nothing to migrate.");
+    process.exit(0);
+  }
+
+  // Deduplicate Clerk IDs
+  const uniqueClerkIds = [...new Set(clerkRows.map((r) => r.orgId))];
+  console.log(`Unique Clerk org IDs: ${uniqueClerkIds.join(", ")}`);
+
+  // Resolve each Clerk ID → internal UUID
+  const clerkToUuid = new Map<string, string>();
+  for (const clerkId of uniqueClerkIds) {
+    const uuid = await resolveClerkOrgId(clerkId);
+    if (uuid) {
+      clerkToUuid.set(clerkId, uuid);
+      console.log(`  ${clerkId} → ${uuid}`);
+    } else {
+      console.error(`  ${clerkId} → FAILED (skipping)`);
+    }
+  }
+
+  // Update rows
+  let updated = 0;
+  let skipped = 0;
+
+  for (const row of clerkRows) {
+    const uuid = clerkToUuid.get(row.orgId);
+    if (!uuid) {
+      skipped++;
+      continue;
+    }
+
+    if (DRY_RUN) {
+      console.log(`  [dry-run] Would update workflow ${row.id}: ${row.orgId} → ${uuid}`);
+    } else {
+      await db
+        .update(workflows)
+        .set({ orgId: uuid })
+        .where(sql`${workflows.id} = ${row.id}`);
+      console.log(`  Updated workflow ${row.id}: ${row.orgId} → ${uuid}`);
+    }
+    updated++;
+  }
+
+  console.log(`\nDone. Updated: ${updated}, Skipped: ${skipped}`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -121,6 +121,7 @@ router.post(
 router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
   try {
     const body = ExecuteWorkflowSchema.parse(req.body ?? {});
+    const orgId = res.locals.orgId as string;
 
     const [workflow] = await db
       .select()
@@ -147,7 +148,7 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
     try {
       const { runId: newRunId } = await createRun({
         parentRunId: callerRunId,
-        orgId: workflow.orgId,
+        orgId,
         userId: executeUserId,
       });
       ownRunId = newRunId;
@@ -162,7 +163,7 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
     const client = getWindmillClient();
     if (client) {
       try {
-        const flowInputs = { ...body.inputs, orgId: workflow.orgId, userId: executeUserId, runId: ownRunId, serviceEnvs: collectServiceEnvs() };
+        const flowInputs = { ...body.inputs, orgId, userId: executeUserId, runId: ownRunId, serviceEnvs: collectServiceEnvs() };
         windmillJobId = await client.runFlow(
           workflow.windmillFlowPath,
           flowInputs
@@ -181,7 +182,7 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
       .insert(workflowRuns)
       .values({
         workflowId: workflow.id,
-        orgId: workflow.orgId,
+        orgId,
         userId: executeUserId,
         campaignId: workflow.campaignId,
         subrequestId: workflow.subrequestId,

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -45,7 +45,7 @@ function generateFlowPath(scope: string, name: string): string {
 router.post("/workflows/generate", requireApiKey, async (req, res) => {
   try {
     const body = GenerateWorkflowSchema.parse(req.body);
-    const orgId = body.orgId;
+    const orgId = res.locals.orgId as string;
     const userId = res.locals.userId as string;
     const runId = res.locals.runId as string;
     const identity = { orgId, userId, runId };
@@ -262,6 +262,7 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
 router.post("/workflows", requireApiKey, async (req, res) => {
   try {
     const body = CreateWorkflowSchema.parse(req.body);
+    const orgId = res.locals.orgId as string;
     const dag = body.dag as DAG;
 
     // Validate the DAG
@@ -273,7 +274,7 @@ router.post("/workflows", requireApiKey, async (req, res) => {
 
     // Translate to OpenFlow
     const openFlow = dagToOpenFlow(dag, body.name);
-    const flowPath = generateFlowPath(body.orgId, body.name);
+    const flowPath = generateFlowPath(orgId, body.name);
 
     // Push to Windmill (if configured)
     const client = getWindmillClient();
@@ -296,7 +297,7 @@ router.post("/workflows", requireApiKey, async (req, res) => {
     const existingWorkflows = await db
       .select({ signatureName: workflows.signatureName })
       .from(workflows)
-      .where(eq(workflows.orgId, body.orgId));
+      .where(eq(workflows.orgId, orgId));
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
     const signatureName = pickSignatureName(signature, usedNames);
 
@@ -304,7 +305,7 @@ router.post("/workflows", requireApiKey, async (req, res) => {
     const [workflow] = await db
       .insert(workflows)
       .values({
-        orgId: body.orgId,
+        orgId,
         brandId: body.brandId,
         campaignId: body.campaignId,
         subrequestId: body.subrequestId,
@@ -336,7 +337,7 @@ router.post("/workflows", requireApiKey, async (req, res) => {
 router.put("/workflows/deploy", requireApiKey, async (req, res) => {
   try {
     const body = DeployWorkflowsSchema.parse(req.body);
-    const orgId = body.orgId;
+    const orgId = res.locals.orgId as string;
 
     // Validate ALL DAGs first — reject if any are invalid
     const dagErrors: { index: number; errors: unknown[] }[] = [];

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -108,7 +108,9 @@ export const WorkflowAudienceTypeSchema = z
 
 export const CreateWorkflowSchema = z
   .object({
-    orgId: z.string().min(1).describe("Organization ID that owns this workflow."),
+    orgId: z.string().min(1).optional().describe(
+      "Deprecated — use x-org-id header instead. Kept optional for backwards compatibility."
+    ),
     brandId: z.string().optional().describe("Optional brand ID for scoping."),
     campaignId: z.string().optional().describe("Optional campaign ID for scoping."),
     subrequestId: z.string().optional().describe("Optional subrequest ID for cost tracking."),
@@ -214,9 +216,8 @@ export const DeployWorkflowItemSchema = z
 
 export const DeployWorkflowsSchema = z
   .object({
-    orgId: z.string().min(1).describe(
-      "Organization ID that owns these workflows. Workflows are scoped to (orgId + signature). " +
-      "This is idempotent — deploying the same DAG updates the existing workflow."
+    orgId: z.string().min(1).optional().describe(
+      "Deprecated — use x-org-id header instead. Kept optional for backwards compatibility."
     ),
     workflows: z.array(DeployWorkflowItemSchema).min(1).describe("The workflows to deploy."),
   })
@@ -307,7 +308,9 @@ export const GenerateWorkflowHintsSchema = z
 
 export const GenerateWorkflowSchema = z
   .object({
-    orgId: z.string().min(1).describe("Organization ID. The generated workflow will be deployed under this orgId."),
+    orgId: z.string().min(1).optional().describe(
+      "Deprecated — use x-org-id header instead. Kept optional for backwards compatibility."
+    ),
     description: z.string().min(10).describe(
       "Natural language description of the desired workflow. Be specific about the steps, services, and data flow."
     ),

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -162,10 +162,10 @@ describe("POST /workflows/:id/execute", () => {
     );
   });
 
-  it("stores userId in DB", async () => {
+  it("uses x-org-id header (not workflow.orgId) for run attribution", async () => {
     mockWorkflows.push({
       id: "wf-1",
-      orgId: "org-1",
+      orgId: "deployer-org-different",
       name: "Test Flow",
       windmillFlowPath: "f/workflows/org_1/test_flow",
       windmillWorkspace: "prod",
@@ -174,11 +174,18 @@ describe("POST /workflows/:id/execute", () => {
 
     const res = await request
       .post("/workflows/wf-1/execute")
-      .set(AUTH)
+      .set(AUTH) // x-org-id: "org-1"
       .send({ inputs: {} });
 
     expect(res.status).toBe(201);
+    expect(res.body.orgId).toBe("org-1"); // from header, not workflow.orgId
     expect(res.body.userId).toBe("user-1");
+
+    expect(mockCreateRun).toHaveBeenCalledWith({
+      parentRunId: "run-caller-1",
+      orgId: "org-1", // from header
+      userId: "user-1",
+    });
   });
 
   it("returns 502 when runs-service fails", async () => {

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -311,12 +311,12 @@ describe("PUT /workflows/deploy", () => {
     expect(wf.name).toBe(`sales-email-cold-outreach-${wf.signatureName}`);
   });
 
-  it("stores orgId from body in DB", async () => {
+  it("stores orgId from x-org-id header (not body) in DB", async () => {
     const res = await request
       .put("/workflows/deploy")
-      .set(AUTH)
+      .set(AUTH) // x-org-id: "org-1"
       .send({
-        orgId: "org_test_id",
+        orgId: "org_should_be_ignored",
         workflows: [
           {
             ...DEPLOY_ITEM,
@@ -328,7 +328,7 @@ describe("PUT /workflows/deploy", () => {
 
     expect(res.status).toBe(200);
     const inserted = mockDbRows[mockDbRows.length - 1];
-    expect(inserted.orgId).toBe("org_test_id");
+    expect(inserted.orgId).toBe("org-1"); // from header, not body
   });
 
   it("updates existing workflow when same DAG is redeployed (idempotent)", async () => {


### PR DESCRIPTION
## Summary
- All write endpoints (`POST /workflows`, `PUT /workflows/deploy`, `POST /workflows/generate`, `POST /workflows/:id/execute`) now use `res.locals.orgId` from the `x-org-id` header instead of `body.orgId`
- `orgId` in request body schemas is now optional for backwards compatibility
- `POST /workflows/:id/execute` no longer reads `workflow.orgId` (which could be a stale Clerk ID) — uses header identity instead
- Includes `scripts/migrate-clerk-ids.ts` to resolve existing Clerk org IDs to internal UUIDs via client-service

## Test plan
- [x] Test verifies deploy stores orgId from header, not body
- [x] Test verifies execute-by-id uses header orgId, not workflow.orgId
- [x] All existing tests updated and passing (281/281)
- [ ] Run `scripts/migrate-clerk-ids.ts --dry-run` against prod to preview Clerk ID resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)