### PR TITLE
fix: remove orgId from body, document identity headers in OpenAPI

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -282,11 +282,6 @@
       "CreateWorkflowRequest": {
         "type": "object",
         "properties": {
-          "orgId": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Deprecated — use x-org-id header instead. Kept optional for backwards compatibility."
-          },
           "brandId": {
             "type": "string",
             "description": "Optional brand ID for scoping."
@@ -695,11 +690,6 @@
       "DeployWorkflowsRequest": {
         "type": "object",
         "properties": {
-          "orgId": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Deprecated — use x-org-id header instead. Kept optional for backwards compatibility."
-          },
           "workflows": {
             "type": "array",
             "items": {
@@ -823,11 +813,6 @@
       "GenerateWorkflowRequest": {
         "type": "object",
         "properties": {
-          "orgId": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Deprecated — use x-org-id header instead. Kept optional for backwards compatibility."
-          },
           "description": {
             "type": "string",
             "minLength": 10,
@@ -945,11 +930,6 @@
       "ExecuteByNameRequest": {
         "type": "object",
         "properties": {
-          "orgId": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Deprecated — ignored for workflow lookup. The executing org is identified via the x-org-id header. Kept optional for backwards compatibility."
-          },
           "inputs": {
             "type": "object",
             "additionalProperties": {
@@ -992,6 +972,38 @@
         "security": [
           {
             "apiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -1106,6 +1118,36 @@
             "description": "Filter workflows that contain this tag.",
             "name": "tag",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1153,6 +1195,36 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1197,6 +1269,36 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -1251,6 +1353,36 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1296,6 +1428,36 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1352,6 +1514,36 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1388,6 +1580,36 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -1435,6 +1657,36 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1472,6 +1724,36 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1542,6 +1824,36 @@
             "required": false,
             "name": "status",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1589,6 +1901,36 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1615,6 +1957,38 @@
         "security": [
           {
             "apiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -1661,6 +2035,38 @@
         "security": [
           {
             "apiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -1786,6 +2192,36 @@
             "description": "Which metric to optimize for. Defaults to 'replies'.",
             "name": "objective",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1852,6 +2288,36 @@
             "required": true,
             "name": "name",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "requestBody": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -108,9 +108,6 @@ export const WorkflowAudienceTypeSchema = z
 
 export const CreateWorkflowSchema = z
   .object({
-    orgId: z.string().min(1).optional().describe(
-      "Deprecated — use x-org-id header instead. Kept optional for backwards compatibility."
-    ),
     brandId: z.string().optional().describe("Optional brand ID for scoping."),
     campaignId: z.string().optional().describe("Optional campaign ID for scoping."),
     subrequestId: z.string().optional().describe("Optional subrequest ID for cost tracking."),
@@ -216,9 +213,6 @@ export const DeployWorkflowItemSchema = z
 
 export const DeployWorkflowsSchema = z
   .object({
-    orgId: z.string().min(1).optional().describe(
-      "Deprecated — use x-org-id header instead. Kept optional for backwards compatibility."
-    ),
     workflows: z.array(DeployWorkflowItemSchema).min(1).describe("The workflows to deploy."),
   })
   .openapi("DeployWorkflowsRequest");
@@ -247,10 +241,6 @@ export const DeployWorkflowsResponseSchema = z
 
 export const ExecuteByNameSchema = z
   .object({
-    orgId: z.string().min(1).optional().describe(
-      "Deprecated — ignored for workflow lookup. The executing org is identified via the x-org-id header. " +
-      "Kept optional for backwards compatibility."
-    ),
     inputs: z.record(z.unknown()).optional().describe(
       "Runtime inputs for the workflow. Accessible in nodes via $ref:flow_input.fieldName."
     ),
@@ -308,9 +298,6 @@ export const GenerateWorkflowHintsSchema = z
 
 export const GenerateWorkflowSchema = z
   .object({
-    orgId: z.string().min(1).optional().describe(
-      "Deprecated — use x-org-id header instead. Kept optional for backwards compatibility."
-    ),
     description: z.string().min(10).describe(
       "Natural language description of the desired workflow. Be specific about the steps, services, and data flow."
     ),
@@ -425,6 +412,14 @@ export const HealthResponseSchema = z
   })
   .openapi("HealthResponse");
 
+// --- Identity header parameters (required on all endpoints except /health and /openapi.json) ---
+
+const IdentityHeaders = z.object({
+  "x-org-id": z.string().describe("Internal org UUID (from client-service). Required."),
+  "x-user-id": z.string().describe("Internal user UUID (from client-service). Required."),
+  "x-run-id": z.string().describe("Run ID for tracing across services. Required."),
+});
+
 // --- Register Paths ---
 
 registry.registerPath({
@@ -447,6 +442,7 @@ registry.registerPath({
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     body: {
       required: true,
       content: { "application/json": { schema: CreateWorkflowSchema } },
@@ -471,6 +467,7 @@ registry.registerPath({
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     query: z.object({
       orgId: z.string().optional(),
       brandId: z.string().optional(),
@@ -501,6 +498,7 @@ registry.registerPath({
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     params: z.object({ id: z.string().uuid() }),
   },
   responses: {
@@ -526,6 +524,7 @@ registry.registerPath({
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     params: z.object({ id: z.string().uuid() }),
   },
   responses: {
@@ -553,6 +552,7 @@ registry.registerPath({
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     params: z.object({ id: z.string().uuid() }),
     body: {
       required: true,
@@ -578,6 +578,7 @@ registry.registerPath({
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     params: z.object({ id: z.string().uuid() }),
   },
   responses: {
@@ -599,6 +600,7 @@ registry.registerPath({
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     params: z.object({ id: z.string().uuid() }),
   },
   responses: {
@@ -616,6 +618,7 @@ registry.registerPath({
   tags: ["Workflow Runs"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     params: z.object({ id: z.string().uuid() }),
     body: {
       required: false,
@@ -640,6 +643,7 @@ registry.registerPath({
   tags: ["Workflow Runs"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     params: z.object({ id: z.string().uuid() }),
   },
   responses: {
@@ -676,6 +680,7 @@ registry.registerPath({
   tags: ["Workflow Runs"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     params: z.object({ id: z.string().uuid() }),
   },
   responses: {
@@ -699,6 +704,7 @@ registry.registerPath({
   tags: ["Workflow Runs"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     query: z.object({
       workflowId: z.string().uuid().optional(),
       orgId: z.string().optional(),
@@ -727,6 +733,7 @@ registry.registerPath({
   tags: ["Workflow Runs"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     params: z.object({ id: z.string().uuid() }),
   },
   responses: {
@@ -751,6 +758,7 @@ registry.registerPath({
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     body: {
       required: true,
       content: { "application/json": { schema: DeployWorkflowsSchema } },
@@ -781,6 +789,7 @@ registry.registerPath({
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     body: {
       required: true,
       content: { "application/json": { schema: GenerateWorkflowSchema } },
@@ -813,6 +822,7 @@ registry.registerPath({
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     query: BestWorkflowQuerySchema,
   },
   responses: {
@@ -848,6 +858,7 @@ registry.registerPath({
   tags: ["Workflow Runs"],
   security: [{ apiKey: [] }],
   request: {
+    headers: IdentityHeaders,
     params: z.object({ name: z.string() }),
     body: {
       required: true,

--- a/tests/integration/generate-workflow.test.ts
+++ b/tests/integration/generate-workflow.test.ts
@@ -110,7 +110,6 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        orgId: "org-1",
         description: "I want a cold email outreach workflow that finds leads and sends emails",
       });
 
@@ -144,7 +143,6 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        orgId: "org-1",
         description: "A workflow that does something impossible with bad types",
       });
 
@@ -158,7 +156,6 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(IDENTITY)
       .send({
-        orgId: "org-1",
         description: "test workflow description here",
       });
 
@@ -169,7 +166,7 @@ describe("POST /workflows/generate", () => {
     const res = await request
       .post("/workflows/generate")
       .set(AUTH)
-      .send({ orgId: "org-1" });
+      .send({});
 
     expect(res.status).toBe(400);
   });
@@ -178,7 +175,7 @@ describe("POST /workflows/generate", () => {
     const res = await request
       .post("/workflows/generate")
       .set(AUTH)
-      .send({ orgId: "org-1", description: "hi" });
+      .send({ description: "hi" });
 
     expect(res.status).toBe(400);
   });
@@ -196,7 +193,6 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        orgId: "org-1",
         description: "Cold email outreach with lead search",
         hints: { services: ["lead", "email-gateway"] },
       });
@@ -218,7 +214,6 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        orgId: "org-1",
         description: "Some workflow description for testing errors",
       });
 
@@ -235,7 +230,6 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        orgId: "org-1",
         description: "Some workflow description for testing key-service errors",
       });
 
@@ -258,7 +252,6 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        orgId: "org-1",
         description: "Cold email outreach in the style of Alex Hormozi",
         style: { type: "human", humanId: "human-123", name: "Hormozi" },
       });
@@ -290,7 +283,6 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        orgId: "org-1",
         description: "Cold email outreach in my brand style with good copy",
         style: { type: "brand", brandId: "brand-456", name: "My Brand" },
       });
@@ -305,7 +297,6 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        orgId: "org-1",
         description: "Cold email outreach in expert style",
         style: { type: "human", name: "Hormozi" },
       });
@@ -318,7 +309,6 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        orgId: "org-1",
         description: "Cold email outreach in brand style long description",
         style: { type: "brand", name: "My Brand" },
       });
@@ -339,7 +329,6 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        orgId: "org-1",
         description: "Standard cold email outreach without any style preference",
       });
 
@@ -359,7 +348,6 @@ describe("POST /workflows/generate", () => {
       .post("/workflows/generate")
       .set(AUTH)
       .send({
-        orgId: "org-1",
         description: "Some workflow description for testing missing config",
       });
 

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -327,7 +327,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
     expect(res.body.userId).toBe("user-b");
   });
 
-  it("does not require orgId in body (uses header instead)", async () => {
+  it("uses x-org-id header for identity (orgId not in body)", async () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "deployer-org",

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -88,7 +88,6 @@ describe("POST /workflows", () => {
       .post("/workflows")
       .set(AUTH)
       .send({
-        orgId: "org-1",
         name: "Test Flow",
         category: "sales",
         channel: "email",
@@ -113,7 +112,6 @@ describe("POST /workflows", () => {
       .post("/workflows")
       .set(AUTH)
       .send({
-        orgId: "org-1",
         name: "Multi-Channel Flow",
         category: "sales",
         channel: "email",
@@ -131,7 +129,6 @@ describe("POST /workflows", () => {
       .post("/workflows")
       .set(AUTH)
       .send({
-        orgId: "org-1",
         name: "Bad Flow",
         category: "sales",
         channel: "email",
@@ -149,7 +146,6 @@ describe("POST /workflows", () => {
       .post("/workflows")
       .set(IDENTITY)
       .send({
-        orgId: "org-1",
         name: "No Auth",
         dag: VALID_LINEAR_DAG,
       });
@@ -251,7 +247,6 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        orgId: "org-deploy",
         workflows: [
           {
             ...DEPLOY_ITEM,
@@ -270,7 +265,6 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        orgId: "org-deploy",
         workflows: [
           {
             ...DEPLOY_ITEM,
@@ -288,7 +282,6 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        orgId: "org-deploy",
         workflows: [
           {
             ...DEPLOY_ITEM,
@@ -311,16 +304,15 @@ describe("PUT /workflows/deploy", () => {
     expect(wf.name).toBe(`sales-email-cold-outreach-${wf.signatureName}`);
   });
 
-  it("stores orgId from x-org-id header (not body) in DB", async () => {
+  it("stores orgId from x-org-id header in DB", async () => {
     const res = await request
       .put("/workflows/deploy")
       .set(AUTH) // x-org-id: "org-1"
       .send({
-        orgId: "org_should_be_ignored",
         workflows: [
           {
             ...DEPLOY_ITEM,
-            description: "Workflow with orgId",
+            description: "Workflow with header orgId",
             dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
           },
         ],
@@ -328,7 +320,7 @@ describe("PUT /workflows/deploy", () => {
 
     expect(res.status).toBe(200);
     const inserted = mockDbRows[mockDbRows.length - 1];
-    expect(inserted.orgId).toBe("org-1"); // from header, not body
+    expect(inserted.orgId).toBe("org-1"); // from header
   });
 
   it("updates existing workflow when same DAG is redeployed (idempotent)", async () => {
@@ -356,7 +348,6 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        orgId: "org-deploy",
         workflows: [
           {
             ...DEPLOY_ITEM,
@@ -373,7 +364,6 @@ describe("PUT /workflows/deploy", () => {
 
   it("same DAG produces same signature across deploys", async () => {
     const payload = {
-      orgId: "org-deploy",
       workflows: [{ ...DEPLOY_ITEM, dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND }],
     };
 
@@ -394,7 +384,6 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        orgId: "org-deploy",
         workflows: [{ ...DEPLOY_ITEM, dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND }],
       });
     expect(res1.body.workflows[0].signature).toBe(sig1);
@@ -405,7 +394,6 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        orgId: "org-deploy",
         workflows: [{ ...DEPLOY_ITEM, dag: VALID_LINEAR_DAG }],
       });
     expect(res2.body.workflows[0].signature).toBe(sig2);
@@ -416,7 +404,6 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        orgId: "org-deploy",
         workflows: [
           {
             // Missing category, channel, audienceType
@@ -433,7 +420,6 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        orgId: "org-deploy",
         workflows: [
           {
             category: "sales",
@@ -452,7 +438,6 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        orgId: "org-deploy",
         workflows: [
           {
             category: "sales",
@@ -471,7 +456,6 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        orgId: "org-deploy",
         workflows: [
           {
             category: "invalid-category",
@@ -510,7 +494,6 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(AUTH)
       .send({
-        orgId: "org-deploy",
         workflows: [
           { ...DEPLOY_ITEM, dag: VALID_LINEAR_DAG },
           { ...DEPLOY_ITEM, dag: DAG_WITH_UNKNOWN_TYPE },
@@ -527,7 +510,6 @@ describe("PUT /workflows/deploy", () => {
       .put("/workflows/deploy")
       .set(IDENTITY)
       .send({
-        orgId: "org-deploy",
         workflows: [{ ...DEPLOY_ITEM, dag: VALID_LINEAR_DAG }],
       });
 
@@ -538,7 +520,7 @@ describe("PUT /workflows/deploy", () => {
     const res = await request
       .put("/workflows/deploy")
       .set(AUTH)
-      .send({ orgId: "org-deploy" }); // missing workflows
+      .send({}); // missing workflows
 
     expect(res.status).toBe(400);
   });


### PR DESCRIPTION
## Summary
- **Removed `orgId`** from all request body schemas (`CreateWorkflowSchema`, `DeployWorkflowsSchema`, `ExecuteByNameSchema`, `GenerateWorkflowSchema`) — no optional, no fallback
- **Documented `x-org-id`, `x-user-id`, `x-run-id`** as required header parameters in OpenAPI spec for all endpoints (except `/health` and `/openapi.json`)
- Updated all tests to stop sending `orgId` in request bodies
- Regenerated `openapi.json`

## Context
Follows PRs #74 and #75 which switched all endpoints to use header identity. This PR completes the cleanup by removing the deprecated body field entirely and making the identity headers visible in the OpenAPI spec.

## Test plan
- [x] All 281 tests pass
- [x] OpenAPI spec regenerated with identity headers on all secured endpoints
- [x] No `orgId` in any request body across tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)