### PR TITLE
fix: correct runs-service API path and request body

### DIFF
--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -22,16 +22,28 @@ export interface CreateRunResult {
  * @param opts.parentRunId - The caller's run ID (from x-run-id header)
  * @param opts.orgId - Organization ID
  * @param opts.userId - User ID
+ * @param opts.taskName - Name of the task being executed
+ * @param opts.workflowName - Optional workflow name for tracking
  * @returns The newly created run's ID
  */
 export async function createRun(opts: {
   parentRunId: string;
   orgId: string;
   userId: string;
+  taskName: string;
+  workflowName?: string;
 }): Promise<CreateRunResult> {
   const { baseUrl, apiKey } = getRunsServiceConfig();
 
-  const res = await fetch(`${baseUrl}/runs/start`, {
+  const body: Record<string, string> = {
+    serviceName: "workflow",
+    taskName: opts.taskName,
+  };
+  if (opts.workflowName) {
+    body.workflowName = opts.workflowName;
+  }
+
+  const res = await fetch(`${baseUrl}/v1/runs`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -40,21 +52,16 @@ export async function createRun(opts: {
       "x-user-id": opts.userId,
       "x-run-id": opts.parentRunId,
     },
-    body: JSON.stringify({
-      parentRunId: opts.parentRunId,
-      service: "workflow",
-      orgId: opts.orgId,
-      userId: opts.userId,
-    }),
+    body: JSON.stringify(body),
   });
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `runs-service error: POST /runs/start -> ${res.status} ${res.statusText}: ${text}`
+      `runs-service error: POST /v1/runs -> ${res.status} ${res.statusText}: ${text}`
     );
   }
 
-  const body = (await res.json()) as { runId: string };
-  return { runId: body.runId };
+  const data = (await res.json()) as { id: string };
+  return { runId: data.id };
 }

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -58,6 +58,8 @@ router.post(
           parentRunId: callerRunId,
           orgId,
           userId,
+          taskName: "execute-workflow",
+          workflowName: workflow.name,
         });
         ownRunId = newRunId;
       } catch (err) {
@@ -150,6 +152,8 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
         parentRunId: callerRunId,
         orgId,
         userId: executeUserId,
+        taskName: "execute-workflow",
+        workflowName: workflow.name,
       });
       ownRunId = newRunId;
     } catch (err) {

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -138,6 +138,8 @@ describe("POST /workflows/:id/execute", () => {
       parentRunId: "run-caller-1",
       orgId: "org-1",
       userId: "user-1",
+      taskName: "execute-workflow",
+      workflowName: "Test Flow",
     });
   });
 
@@ -185,6 +187,8 @@ describe("POST /workflows/:id/execute", () => {
       parentRunId: "run-caller-1",
       orgId: "org-1", // from header
       userId: "user-1",
+      taskName: "execute-workflow",
+      workflowName: "Test Flow",
     });
   });
 
@@ -272,6 +276,8 @@ describe("POST /workflows/by-name/:name/execute", () => {
       parentRunId: "run-caller-1",
       orgId: "org-1",
       userId: "user-1",
+      taskName: "execute-workflow",
+      workflowName: "create-user-flow",
     });
   });
 

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -16,12 +16,12 @@ describe("createRun", () => {
     vi.restoreAllMocks();
   });
 
-  it("calls POST /runs/start with parentRunId, orgId, userId", async () => {
+  it("calls POST /v1/runs with serviceName + taskName in body and identity in headers", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ runId: "new-run-123" }),
+        json: () => Promise.resolve({ id: "new-run-123" }),
       })
     );
 
@@ -29,11 +29,12 @@ describe("createRun", () => {
       parentRunId: "caller-run-1",
       orgId: "org-1",
       userId: "user-1",
+      taskName: "execute-workflow",
     });
 
     expect(result).toEqual({ runId: "new-run-123" });
     expect(fetch).toHaveBeenCalledWith(
-      "http://localhost:5000/runs/start",
+      "http://localhost:5000/v1/runs",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -44,13 +45,63 @@ describe("createRun", () => {
           "x-run-id": "caller-run-1",
         }),
         body: JSON.stringify({
-          parentRunId: "caller-run-1",
-          service: "workflow",
-          orgId: "org-1",
-          userId: "user-1",
+          serviceName: "workflow",
+          taskName: "execute-workflow",
         }),
       })
     );
+  });
+
+  it("includes workflowName in body when provided", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: "new-run-789" }),
+      })
+    );
+
+    await createRun({
+      parentRunId: "caller-run-1",
+      orgId: "org-1",
+      userId: "user-1",
+      taskName: "execute-workflow",
+      workflowName: "sales-email-cold-outreach",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:5000/v1/runs",
+      expect.objectContaining({
+        body: JSON.stringify({
+          serviceName: "workflow",
+          taskName: "execute-workflow",
+          workflowName: "sales-email-cold-outreach",
+        }),
+      })
+    );
+  });
+
+  it("does not send orgId, userId, or parentRunId in request body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: "new-run-456" }),
+      })
+    );
+
+    await createRun({
+      parentRunId: "caller-run-1",
+      orgId: "org-1",
+      userId: "user-1",
+      taskName: "execute-workflow",
+    });
+
+    const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const sentBody = JSON.parse(callArgs[1].body);
+    expect(sentBody).not.toHaveProperty("orgId");
+    expect(sentBody).not.toHaveProperty("userId");
+    expect(sentBody).not.toHaveProperty("parentRunId");
   });
 
   it("strips trailing slash from RUNS_SERVICE_URL", async () => {
@@ -60,7 +111,7 @@ describe("createRun", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ runId: "new-run-456" }),
+        json: () => Promise.resolve({ id: "new-run-456" }),
       })
     );
 
@@ -68,10 +119,11 @@ describe("createRun", () => {
       parentRunId: "caller-run-2",
       orgId: "org-1",
       userId: "user-1",
+      taskName: "execute-workflow",
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "http://localhost:5000/runs/start",
+      "http://localhost:5000/v1/runs",
       expect.anything()
     );
   });
@@ -88,7 +140,7 @@ describe("createRun", () => {
     );
 
     await expect(
-      createRun({ parentRunId: "caller-run-3", orgId: "org-1", userId: "user-1" })
+      createRun({ parentRunId: "caller-run-3", orgId: "org-1", userId: "user-1", taskName: "execute-workflow" })
     ).rejects.toThrow("runs-service error:");
   });
 
@@ -96,7 +148,7 @@ describe("createRun", () => {
     delete process.env.RUNS_SERVICE_URL;
 
     await expect(
-      createRun({ parentRunId: "caller-run-4", orgId: "org-1", userId: "user-1" })
+      createRun({ parentRunId: "caller-run-4", orgId: "org-1", userId: "user-1", taskName: "execute-workflow" })
     ).rejects.toThrow("RUNS_SERVICE_URL and RUNS_SERVICE_API_KEY must be set");
   });
 
@@ -104,7 +156,7 @@ describe("createRun", () => {
     delete process.env.RUNS_SERVICE_API_KEY;
 
     await expect(
-      createRun({ parentRunId: "caller-run-5", orgId: "org-1", userId: "user-1" })
+      createRun({ parentRunId: "caller-run-5", orgId: "org-1", userId: "user-1", taskName: "execute-workflow" })
     ).rejects.toThrow("RUNS_SERVICE_URL and RUNS_SERVICE_API_KEY must be set");
   });
 });


### PR DESCRIPTION
## Summary
- Fixed `runs-client.ts` calling wrong endpoint (`/runs/start` → `/v1/runs`) causing 404 errors
- Fixed request body to send `{serviceName, taskName}` instead of `{parentRunId, service, orgId, userId}` (identity already in headers)
- Fixed response parsing to use `id` field (not `runId`) matching runs-service OpenAPI spec
- Added `taskName` and `workflowName` to `createRun` interface and both execute call sites

## Test plan
- [x] Unit tests for runs-client updated (correct URL, body fields, no redundant body params)
- [x] Integration tests for workflow-runs updated (createRun called with taskName + workflowName)
- [x] All 283 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)