### PR TITLE
fix: remove /internal/ prefix from campaign endpoint paths

### DIFF
--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -234,13 +234,13 @@ Campaign service orchestrates workflow execution with budget constraints. Key co
     {
       "id": "gate-check",
       "type": "http.call",
-      "config": { "service": "campaign", "method": "POST", "path": "/internal/gate-check", "stopAfterIf": "result.allowed == false" },
+      "config": { "service": "campaign", "method": "POST", "path": "/gate-check", "stopAfterIf": "result.allowed == false" },
       "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId", "body.orgId": "$ref:flow_input.orgId" }
     },
     {
       "id": "start-run",
       "type": "http.call",
-      "config": { "service": "campaign", "method": "POST", "path": "/internal/start-run" },
+      "config": { "service": "campaign", "method": "POST", "path": "/start-run" },
       "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId", "body.orgId": "$ref:flow_input.orgId" }
     },
     {
@@ -274,13 +274,13 @@ Campaign service orchestrates workflow execution with budget constraints. Key co
     {
       "id": "end-run",
       "type": "http.call",
-      "config": { "service": "campaign", "method": "POST", "path": "/internal/end-run", "body": { "success": true } },
+      "config": { "service": "campaign", "method": "POST", "path": "/end-run", "body": { "success": true } },
       "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId", "body.leadFound": "$ref:fetch-lead.output.found" }
     },
     {
       "id": "end-run-error",
       "type": "http.call",
-      "config": { "service": "campaign", "method": "POST", "path": "/internal/end-run", "body": { "success": false } },
+      "config": { "service": "campaign", "method": "POST", "path": "/end-run", "body": { "success": false } },
       "inputMapping": { "body.campaignId": "$ref:flow_input.campaignId" }
     }
   ],

--- a/src/lib/service-catalog.ts
+++ b/src/lib/service-catalog.ts
@@ -8,7 +8,7 @@ export const SERVICE_CATALOG: ServiceInfo[] = [
   {
     name: "campaign",
     description: "Campaign lifecycle: gate-check (budget/volume validation), start-run (creates execution run), end-run (finalizes run, auto-retriggers if budget remains)",
-    keyEndpoints: ["POST /internal/gate-check", "POST /internal/start-run", "POST /internal/end-run"],
+    keyEndpoints: ["POST /gate-check", "POST /start-run", "POST /end-run"],
   },
   {
     name: "lead",

--- a/tests/unit/workflow-generator.test.ts
+++ b/tests/unit/workflow-generator.test.ts
@@ -193,7 +193,7 @@ const MOCK_LLM_CONTEXT = {
       title: "Campaign Service",
       description: "Campaign lifecycle",
       endpoints: [
-        { method: "POST", path: "/internal/gate-check", summary: "Gate check" },
+        { method: "POST", path: "/gate-check", summary: "Gate check" },
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- Campaign-service mounts gate-check, start-run, and end-run at the root path (`POST /gate-check`, `POST /end-run`), not under `/internal/`
- Updated service catalog, prompt templates (example DAGs), and test fixtures to use the correct paths
- All 283 tests pass

## Test plan
- [x] All existing tests pass (283/283)
- [ ] Verify generated workflows use correct paths (`/gate-check`, `/end-run` instead of `/internal/gate-check`, `/internal/end-run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)