### PR TITLE
fix: remove /internal/ prefix from start-run path in test fixtures

### DIFF
--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -330,7 +330,7 @@ export const DAG_WITH_FLOW_INPUT_REFS: DAG = {
     {
       id: "start-run",
       type: "http.call",
-      config: { service: "campaign", method: "POST", path: "/internal/start-run" },
+      config: { service: "campaign", method: "POST", path: "/start-run" },
       inputMapping: {
         "body.campaignId": "$ref:flow_input.campaignId",
         "body.orgId": "$ref:flow_input.orgId",
@@ -346,7 +346,7 @@ export const DAG_WITH_CONFIG_RETRIES: DAG = {
     {
       id: "start-run",
       type: "http.call",
-      config: { service: "campaign", method: "POST", path: "/internal/start-run", retries: 0 },
+      config: { service: "campaign", method: "POST", path: "/start-run", retries: 0 },
       inputMapping: {
         "body.campaignId": "$ref:flow_input.campaignId",
         "body.orgId": "$ref:flow_input.orgId",


### PR DESCRIPTION
## Summary
- PR #78 removed `/internal/` from gate-check and end-run paths but missed `start-run` in two test fixtures
- Campaign-service routes are `/gate-check`, `/start-run`, `/end-run` — none use `/internal/` prefix
- Aligns test fixtures with actual campaign-service API

## Test plan
- [x] All 273 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)