### PR TITLE
feat: workflow self-healing — validate & auto-upgrade at startup

### DIFF
--- a/drizzle/0014_add_workflow_status.sql
+++ b/drizzle/0014_add_workflow_status.sql
@@ -1,0 +1,25 @@
+-- Add status column for workflow lifecycle (active / deprecated)
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "status" text NOT NULL DEFAULT 'active';
+--> statement-breakpoint
+-- Track upgrade chain: deprecated workflow points to its replacement
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "upgraded_to" uuid;
+--> statement-breakpoint
+-- Tracking: which user created this workflow
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "created_by_user_id" text;
+--> statement-breakpoint
+-- Tracking: which run created this workflow
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "created_by_run_id" text;
+--> statement-breakpoint
+-- Drop old org-scoped unique indexes (workflows are public, not org-scoped)
+DROP INDEX IF EXISTS "idx_workflows_org_name_unique";
+--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_workflows_org_signature_unique";
+--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_workflows_org_signature_name_unique";
+--> statement-breakpoint
+-- Recreate as global partial unique indexes — only active workflows must be unique
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_workflows_name_active" ON "workflows" ("name") WHERE "status" = 'active';
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_workflows_signature_active" ON "workflows" ("signature") WHERE "status" = 'active';
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_workflows_signature_name_active" ON "workflows" ("signature_name") WHERE "status" = 'active';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1772189106410,
       "tag": "0013_add_tags",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1772275506410,
+      "tag": "0014_add_workflow_status",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -137,6 +137,30 @@
             "nullable": true,
             "description": "The DAG definition as submitted."
           },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "deprecated"
+            ],
+            "description": "Workflow lifecycle status. Only active workflows can be executed."
+          },
+          "upgradedTo": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid",
+            "description": "If deprecated, the ID of the replacement workflow."
+          },
+          "createdByUserId": {
+            "type": "string",
+            "nullable": true,
+            "description": "User ID that created this workflow."
+          },
+          "createdByRunId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Run ID that created this workflow."
+          },
           "windmillFlowPath": {
             "type": "string",
             "nullable": true,
@@ -170,6 +194,10 @@
           "tags",
           "signature",
           "signatureName",
+          "status",
+          "upgradedTo",
+          "createdByUserId",
+          "createdByRunId",
           "windmillFlowPath",
           "windmillWorkspace",
           "createdAt",
@@ -1117,6 +1145,16 @@
             "required": false,
             "description": "Filter workflows that contain this tag.",
             "name": "tag",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by status. Defaults to 'active'. Use 'all' to include deprecated workflows."
+            },
+            "required": false,
+            "description": "Filter by status. Defaults to 'active'. Use 'all' to include deprecated workflows.",
+            "name": "status",
             "in": "query"
           },
           {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -28,6 +28,10 @@ export const workflows = pgTable(
     signatureName: text("signature_name").notNull(),
     dag: jsonb("dag").notNull(),
     tags: jsonb("tags").default([]),
+    status: text("status").notNull().default("active"),
+    upgradedTo: uuid("upgraded_to"),
+    createdByUserId: text("created_by_user_id"),
+    createdByRunId: text("created_by_run_id"),
     windmillFlowPath: text("windmill_flow_path"),
     windmillWorkspace: text("windmill_workspace").notNull().default("prod"),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
@@ -36,12 +40,6 @@ export const workflows = pgTable(
   (table) => [
     index("idx_workflows_org").on(table.orgId),
     index("idx_workflows_campaign").on(table.campaignId),
-    uniqueIndex("idx_workflows_org_name_unique")
-      .on(table.orgId, table.name),
-    uniqueIndex("idx_workflows_org_signature_unique")
-      .on(table.orgId, table.signature),
-    uniqueIndex("idx_workflows_org_signature_name_unique")
-      .on(table.orgId, table.signatureName),
     index("idx_workflows_org_style").on(table.orgId, table.styleName),
   ]
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { workflowRuns } from "./db/schema.js";
 import { getWindmillClient } from "./lib/windmill-client.js";
 import { JobPoller } from "./lib/job-poller.js";
 import { requireIdentity } from "./middleware/auth.js";
+import { checkApiRegistryHealth, validateAndUpgradeWorkflows } from "./lib/startup-validator.js";
 import healthRoutes from "./routes/health.js";
 import workflowsRoutes from "./routes/workflows.js";
 import workflowRunsRoutes from "./routes/workflow-runs.js";
@@ -38,6 +39,19 @@ if (process.env.NODE_ENV !== "test") {
       await migrate(db, { migrationsFolder: "./drizzle" });
       console.log("Migrations complete");
 
+      // Verify API Registry is reachable — fail fast if not
+      if (process.env.API_REGISTRY_SERVICE_URL && process.env.API_REGISTRY_SERVICE_API_KEY) {
+        try {
+          await checkApiRegistryHealth();
+          console.log("API Registry health check passed");
+        } catch (err) {
+          console.error("API Registry is unreachable — aborting startup:", err);
+          process.exit(1);
+        }
+      } else {
+        console.warn("API_REGISTRY_SERVICE_URL / API_REGISTRY_SERVICE_API_KEY not set — skipping API Registry health check");
+      }
+
       // Start job poller (only if Windmill is configured)
       const windmillClient = getWindmillClient();
       if (windmillClient) {
@@ -49,6 +63,13 @@ if (process.env.NODE_ENV !== "test") {
 
       app.listen(Number(PORT), "::", () => {
         console.log(`workflow-service running on port ${PORT}`);
+
+        // Run startup validation non-blocking (after server is accepting requests)
+        if (process.env.API_REGISTRY_SERVICE_URL && process.env.API_REGISTRY_SERVICE_API_KEY) {
+          validateAndUpgradeWorkflows({ db, windmillClient }).catch((err) => {
+            console.error("[startup] Workflow validation failed:", err);
+          });
+        }
       });
     } catch (err) {
       console.error("Startup failed:", err);

--- a/src/lib/api-registry-client.ts
+++ b/src/lib/api-registry-client.ts
@@ -58,6 +58,58 @@ export async function fetchLlmContext(identity: IdentityHeaders): Promise<LlmCon
   return res.json() as Promise<LlmContextResponse>;
 }
 
+/** GET /services — list all registered services (used for health check + enumeration) */
+export async function fetchServiceList(
+  identity: IdentityHeaders,
+): Promise<Array<{ service: string }>> {
+  const { baseUrl, apiKey } = getApiRegistryConfig();
+
+  const res = await fetch(`${baseUrl}/services`, {
+    method: "GET",
+    headers: {
+      "x-api-key": apiKey,
+      "x-org-id": identity.orgId,
+      "x-user-id": identity.userId,
+      "x-run-id": identity.runId,
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `api-registry error: GET /services -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  return res.json() as Promise<Array<{ service: string }>>;
+}
+
+/** Fetch OpenAPI specs for multiple services (deduplicated). Returns Map<serviceName, spec> */
+export async function fetchSpecsForServices(
+  serviceNames: string[],
+  identity: IdentityHeaders,
+): Promise<Map<string, Record<string, unknown>>> {
+  const unique = [...new Set(serviceNames)];
+  const specs = new Map<string, Record<string, unknown>>();
+
+  const results = await Promise.allSettled(
+    unique.map(async (name) => {
+      const spec = await fetchServiceSpec(name, identity);
+      return { name, spec };
+    }),
+  );
+
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      specs.set(result.value.name, result.value.spec);
+    } else {
+      console.warn(`[api-registry] Failed to fetch spec: ${result.reason}`);
+    }
+  }
+
+  return specs;
+}
+
 /** GET /openapi/:service — full OpenAPI spec for one service */
 export async function fetchServiceSpec(
   serviceName: string,

--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -309,6 +309,51 @@ Campaign service orchestrates workflow execution with budget constraints. Key co
 ${styleDirective ? `## Style Directive\n\n${styleDirective}\n\n` : ""}Generate a single workflow DAG that fulfills the user's description. Use the create_workflow tool to return the result.`;
 }
 
+export interface BuildUpgradeSystemPromptOptions {
+  currentDag: Record<string, unknown>;
+  invalidEndpoints: Array<{ service: string; method: string; path: string; reason: string }>;
+}
+
+export function buildUpgradeSystemPrompt(options: BuildUpgradeSystemPromptOptions): string {
+  const { currentDag, invalidEndpoints } = options;
+
+  const brokenList = invalidEndpoints
+    .map((ep) => `- ${ep.method} ${ep.service}${ep.path} — ${ep.reason}`)
+    .join("\n");
+
+  return `You are a workflow maintenance engineer. Your job is to FIX a broken workflow DAG by correcting invalid endpoint paths.
+
+## Current DAG (DO NOT change business logic)
+
+\`\`\`json
+${JSON.stringify(currentDag, null, 2)}
+\`\`\`
+
+## Broken Endpoints
+
+The following endpoints in this DAG are invalid — they no longer exist in the upstream service:
+
+${brokenList}
+
+## Your Task
+
+1. Call list_services to see all available services
+2. Call get_service_endpoints for EACH service that has a broken endpoint — find the correct path
+3. Call create_workflow with a corrected DAG
+
+## CRITICAL RULES
+
+- **Preserve ALL business logic exactly**: same node IDs, same edges, same conditions, same inputMapping, same retries, same onError
+- **Only change what's broken**: update config.path (and config.service or config.method if needed) on the affected nodes
+- **Do NOT add, remove, or reorder nodes or edges**
+- **Do NOT change inputMapping, conditions, stopAfterIf, skipIf, or any other config keys**
+- **Keep the same category, channel, audienceType, and description**
+- **Use the discovery tools to verify the correct endpoint exists before fixing**
+- If you cannot find a replacement endpoint, keep the original and note it in the description
+
+Return the corrected DAG via the create_workflow tool.`;
+}
+
 export function buildRetryUserMessage(
   originalDescription: string,
   validationErrors: Array<{ field: string; message: string }>,

--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -1,0 +1,302 @@
+import { eq } from "drizzle-orm";
+import { workflows, type Workflow } from "../db/schema.js";
+import type { db as DbInstance } from "../db/index.js";
+import type { DAG } from "./dag-validator.js";
+import { extractHttpEndpoints } from "./extract-http-endpoints.js";
+import {
+  fetchServiceList,
+  fetchSpecsForServices,
+} from "./api-registry-client.js";
+import { validateWorkflowEndpoints } from "./validate-workflow-endpoints.js";
+import { upgradeWorkflow } from "./workflow-upgrader.js";
+import { dagToOpenFlow } from "./dag-to-openflow.js";
+import { computeDAGSignature } from "./dag-signature.js";
+import { pickSignatureName } from "./signature-words.js";
+import type { WindmillClient } from "./windmill-client.js";
+import type { IdentityHeaders } from "./key-service-client.js";
+
+type Database = typeof DbInstance;
+
+interface StartupValidatorDeps {
+  db: Database;
+  windmillClient: WindmillClient | null;
+}
+
+/**
+ * Temporary identity for API Registry calls.
+ * TODO: Remove once API Registry drops identity requirements on read-only spec endpoints.
+ */
+const PLATFORM_IDENTITY: IdentityHeaders = {
+  orgId: "workflow-service",
+  userId: "workflow-service",
+  runId: "startup-validation",
+};
+
+/**
+ * Ping API Registry to verify it's reachable. Throws on failure.
+ */
+export async function checkApiRegistryHealth(): Promise<void> {
+  await fetchServiceList(PLATFORM_IDENTITY);
+}
+
+/**
+ * Validate all active workflows against the API Registry.
+ * Deprecates workflows with broken endpoints and attempts LLM-powered upgrade.
+ */
+export async function validateAndUpgradeWorkflows(
+  deps: StartupValidatorDeps,
+): Promise<void> {
+  const { db: database, windmillClient } = deps;
+
+  // 1. Fetch all active workflows
+  const activeWorkflows = await database
+    .select()
+    .from(workflows)
+    .where(eq(workflows.status, "active"));
+
+  if (activeWorkflows.length === 0) {
+    console.log("[startup] No active workflows to validate");
+    return;
+  }
+
+  // 2. Collect unique service names across all workflows
+  const allServiceNames = new Set<string>();
+  for (const wf of activeWorkflows) {
+    const endpoints = extractHttpEndpoints(wf.dag as DAG);
+    for (const ep of endpoints) {
+      allServiceNames.add(ep.service);
+    }
+  }
+
+  // 3. Fetch OpenAPI specs for all services
+  const specs = await fetchSpecsForServices(
+    [...allServiceNames],
+    PLATFORM_IDENTITY,
+  );
+
+  // 4. Validate each workflow
+  let validCount = 0;
+  let upgradedCount = 0;
+  let failedCount = 0;
+
+  for (const wf of activeWorkflows) {
+    const dag = wf.dag as DAG;
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    if (result.valid) {
+      validCount++;
+      continue;
+    }
+
+    console.warn(
+      `[startup] Workflow "${wf.name}" (${wf.id}) has ${result.invalidEndpoints.length} broken endpoint(s):`,
+      result.invalidEndpoints.map((ep) => `${ep.method} ${ep.service}${ep.path}`).join(", "),
+    );
+
+    // Attempt upgrade
+    try {
+      const upgraded = await attemptUpgrade(
+        wf,
+        dag,
+        result.invalidEndpoints,
+        database,
+        windmillClient,
+      );
+
+      if (upgraded) {
+        upgradedCount++;
+        console.log(
+          `[startup] Workflow "${wf.name}" upgraded successfully -> new ID: ${upgraded}`,
+        );
+      } else {
+        // Upgrade skipped (no Anthropic key available)
+        failedCount++;
+        await deprecateWorkflow(database, wf.id, null);
+        console.warn(
+          `[startup] Workflow "${wf.name}" deprecated (upgrade skipped: platform key not available)`,
+        );
+      }
+    } catch (err) {
+      failedCount++;
+      await deprecateWorkflow(database, wf.id, null);
+      console.error(
+        `[startup] Workflow "${wf.name}" upgrade failed, deprecated:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+
+    // Send admin notification
+    try {
+      await sendAdminNotification(wf, result.invalidEndpoints, upgradedCount > failedCount);
+    } catch {
+      // Non-blocking — log and continue
+      console.warn(`[startup] Failed to send admin notification for "${wf.name}"`);
+    }
+  }
+
+  console.log(
+    `[startup] Validated ${activeWorkflows.length} workflows: ${validCount} valid, ${upgradedCount} upgraded, ${failedCount} failed`,
+  );
+}
+
+async function attemptUpgrade(
+  wf: Workflow,
+  dag: DAG,
+  invalidEndpoints: Array<{ service: string; method: string; path: string; reason: string }>,
+  database: Database,
+  windmillClient: WindmillClient | null,
+): Promise<string | null> {
+  // Resolve Anthropic API key — blocked until key-service supports platform-level key resolution
+  // TODO: Replace with platform key resolution once key-service adds GET /keys/platform/anthropic/decrypt
+  const anthropicApiKey = process.env.PLATFORM_ANTHROPIC_API_KEY;
+  if (!anthropicApiKey) {
+    console.warn("[startup] PLATFORM_ANTHROPIC_API_KEY not set — upgrade skipped");
+    return null;
+  }
+
+  const result = await upgradeWorkflow(
+    dag,
+    invalidEndpoints,
+    anthropicApiKey,
+    PLATFORM_IDENTITY,
+    {
+      category: wf.category,
+      channel: wf.channel,
+      audienceType: wf.audienceType,
+      description: wf.description ?? "",
+    },
+  );
+
+  // Compute new signature
+  const newSignature = computeDAGSignature(result.dag);
+
+  // Get used signature names to avoid collisions
+  const existingWorkflows = await database
+    .select({ signatureName: workflows.signatureName })
+    .from(workflows);
+  const usedNames = new Set<string>(existingWorkflows.map((w) => w.signatureName));
+
+  const newSignatureName = pickSignatureName(newSignature, usedNames);
+  const newName = `${result.category}-${result.channel}-${result.audienceType}-${newSignatureName}`;
+
+  // Deploy to Windmill
+  const openFlow = dagToOpenFlow(result.dag, newName);
+  const flowPath = `f/workflows/${wf.orgId}/${newName.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
+  let windmillFlowPath: string | null = null;
+
+  if (windmillClient) {
+    try {
+      await windmillClient.createFlow({
+        path: flowPath,
+        summary: newName,
+        description: result.description,
+        value: openFlow.value,
+        schema: openFlow.schema,
+      });
+      windmillFlowPath = flowPath;
+    } catch (err) {
+      console.error("[startup] Failed to create upgraded flow in Windmill:", err);
+    }
+  }
+
+  // Insert new active workflow
+  const [created] = await database
+    .insert(workflows)
+    .values({
+      orgId: wf.orgId,
+      brandId: wf.brandId,
+      humanId: wf.humanId,
+      campaignId: wf.campaignId,
+      subrequestId: wf.subrequestId,
+      styleName: wf.styleName,
+      name: newName,
+      displayName: wf.displayName,
+      description: result.description,
+      category: result.category,
+      channel: result.channel,
+      audienceType: result.audienceType,
+      signature: newSignature,
+      signatureName: newSignatureName,
+      dag: result.dag,
+      tags: wf.tags as string[],
+      status: "active",
+      createdByUserId: "workflow-service",
+      createdByRunId: "startup-upgrade",
+      windmillFlowPath,
+      windmillWorkspace: wf.windmillWorkspace,
+    })
+    .returning();
+
+  // Deprecate old workflow
+  await deprecateWorkflow(database, wf.id, created.id);
+
+  return created.id;
+}
+
+async function deprecateWorkflow(
+  database: Database,
+  workflowId: string,
+  upgradedTo: string | null,
+): Promise<void> {
+  await database
+    .update(workflows)
+    .set({
+      status: "deprecated",
+      upgradedTo,
+      updatedAt: new Date(),
+    })
+    .where(eq(workflows.id, workflowId));
+}
+
+async function sendAdminNotification(
+  wf: Workflow,
+  invalidEndpoints: Array<{ service: string; method: string; path: string; reason: string }>,
+  upgraded: boolean,
+): Promise<void> {
+  const emailServiceUrl = process.env.TRANSACTIONAL_EMAIL_SERVICE_URL;
+  const emailApiKey = process.env.TRANSACTIONAL_EMAIL_SERVICE_API_KEY;
+  const adminEmail = process.env.ADMIN_NOTIFICATION_EMAIL;
+
+  if (!emailServiceUrl || !emailApiKey || !adminEmail) {
+    return;
+  }
+
+  const endpointList = invalidEndpoints
+    .map((ep) => `${ep.method} ${ep.service}${ep.path} — ${ep.reason}`)
+    .join("\n");
+
+  const subject = upgraded
+    ? `[Workflow Service] Workflow "${wf.name}" auto-upgraded`
+    : `[Workflow Service] Workflow "${wf.name}" deprecated — manual intervention required`;
+
+  const body = `Workflow: ${wf.name} (${wf.id})
+Org ID: ${wf.orgId}
+Status: ${upgraded ? "Auto-upgraded successfully" : "Deprecated — upgrade failed"}
+
+Invalid endpoints:
+${endpointList}
+
+${upgraded ? "A new version has been created with corrected endpoints." : "The workflow has been deprecated but could not be automatically fixed. Please review and fix manually."}
+
+Warning: If an endpoint is actually valid but missing from the OpenAPI spec, update the spec in the source service and redeploy.`;
+
+  try {
+    await fetch(`${emailServiceUrl}/send`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": emailApiKey,
+        "x-org-id": wf.orgId,
+        "x-user-id": "workflow-service",
+        "x-run-id": "startup-upgrade",
+      },
+      body: JSON.stringify({
+        to: adminEmail,
+        subject,
+        bodyText: body,
+      }),
+    });
+  } catch {
+    // Non-blocking
+  }
+}

--- a/src/lib/validate-workflow-endpoints.ts
+++ b/src/lib/validate-workflow-endpoints.ts
@@ -1,0 +1,70 @@
+import type { DAG } from "./dag-validator.js";
+import { extractHttpEndpoints } from "./extract-http-endpoints.js";
+
+export interface InvalidEndpoint {
+  service: string;
+  method: string;
+  path: string;
+  reason: string;
+}
+
+export interface EndpointValidationResult {
+  valid: boolean;
+  invalidEndpoints: InvalidEndpoint[];
+}
+
+/**
+ * Validates that every http.call endpoint in a DAG actually exists
+ * in the corresponding service's OpenAPI spec.
+ */
+export function validateWorkflowEndpoints(
+  dag: DAG,
+  specs: Map<string, Record<string, unknown>>,
+): EndpointValidationResult {
+  const endpoints = extractHttpEndpoints(dag);
+  const invalidEndpoints: InvalidEndpoint[] = [];
+
+  for (const ep of endpoints) {
+    const spec = specs.get(ep.service);
+
+    if (!spec) {
+      invalidEndpoints.push({
+        ...ep,
+        reason: `Service "${ep.service}" not found in API Registry`,
+      });
+      continue;
+    }
+
+    const paths = spec.paths as Record<string, Record<string, unknown>> | undefined;
+    if (!paths) {
+      invalidEndpoints.push({
+        ...ep,
+        reason: `Service "${ep.service}" has no paths in its OpenAPI spec`,
+      });
+      continue;
+    }
+
+    const pathEntry = paths[ep.path];
+    if (!pathEntry) {
+      invalidEndpoints.push({
+        ...ep,
+        reason: `Path "${ep.path}" not found in ${ep.service} spec`,
+      });
+      continue;
+    }
+
+    const methodEntry = pathEntry[ep.method.toLowerCase()];
+    if (!methodEntry) {
+      invalidEndpoints.push({
+        ...ep,
+        reason: `Method ${ep.method} not found for path "${ep.path}" in ${ep.service} spec`,
+      });
+      continue;
+    }
+  }
+
+  return {
+    valid: invalidEndpoints.length === 0,
+    invalidEndpoints,
+  };
+}

--- a/src/lib/workflow-upgrader.ts
+++ b/src/lib/workflow-upgrader.ts
@@ -1,0 +1,196 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { validateDAG, type DAG } from "./dag-validator.js";
+import {
+  buildUpgradeSystemPrompt,
+  buildRetryUserMessage,
+  AGENTIC_TOOLS,
+} from "./prompt-templates.js";
+import {
+  fetchLlmContext,
+  fetchServiceSpec,
+} from "./api-registry-client.js";
+import type { IdentityHeaders } from "./key-service-client.js";
+import type { InvalidEndpoint } from "./validate-workflow-endpoints.js";
+
+const MAX_RETRIES = 2;
+const MAX_AGENT_TURNS = 10;
+const MODEL = "claude-opus-4-6";
+
+let overrideClient: Anthropic | null = null;
+
+/** Exported for testing — allows injecting a mock client */
+export function setUpgradeAnthropicClient(client: Anthropic | null): void {
+  overrideClient = client;
+}
+
+async function resolveToolCall(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  identity: IdentityHeaders,
+): Promise<{ content: string; isError?: boolean }> {
+  switch (toolName) {
+    case "list_services": {
+      const context = await fetchLlmContext(identity);
+      const summary = context.services.map((s) => ({
+        name: s.service,
+        description: s.description ?? s.title ?? "",
+        endpointCount: s.endpoints.length,
+        endpoints: s.endpoints.map((e) => `${e.method} ${e.path}`),
+      }));
+      return { content: JSON.stringify(summary, null, 2) };
+    }
+    case "get_service_endpoints": {
+      const serviceName = toolInput.service as string;
+      const spec = await fetchServiceSpec(serviceName, identity);
+      return { content: JSON.stringify(spec, null, 2) };
+    }
+    default:
+      return { content: `Unknown tool: ${toolName}`, isError: true };
+  }
+}
+
+export interface UpgradeWorkflowResult {
+  dag: DAG;
+  category: string;
+  channel: string;
+  audienceType: string;
+  description: string;
+}
+
+export async function upgradeWorkflow(
+  currentDag: DAG,
+  invalidEndpoints: InvalidEndpoint[],
+  anthropicApiKey: string,
+  identity: IdentityHeaders,
+  metadata: { category: string; channel: string; audienceType: string; description: string },
+): Promise<UpgradeWorkflowResult> {
+  const client = overrideClient ?? new Anthropic({ apiKey: anthropicApiKey });
+
+  const systemPrompt = buildUpgradeSystemPrompt({
+    currentDag: currentDag as unknown as Record<string, unknown>,
+    invalidEndpoints,
+  });
+
+  const tools = AGENTIC_TOOLS;
+
+  const userMessage = `Fix this workflow. The category is "${metadata.category}", channel is "${metadata.channel}", audienceType is "${metadata.audienceType}". Description: "${metadata.description}". Only fix the broken endpoints listed above.`;
+
+  const messages: Anthropic.Messages.MessageParam[] = [
+    { role: "user", content: userMessage },
+  ];
+
+  let dagRetries = 0;
+
+  for (let turn = 0; turn < MAX_AGENT_TURNS; turn++) {
+    const response = await client.messages.create({
+      model: MODEL,
+      max_tokens: 16384,
+      system: systemPrompt,
+      messages,
+      tools,
+      tool_choice: { type: "auto" as const },
+    });
+
+    const createWorkflowCall = response.content.find(
+      (block): block is Anthropic.Messages.ToolUseBlock =>
+        block.type === "tool_use" && block.name === "create_workflow",
+    );
+
+    if (createWorkflowCall) {
+      const result = createWorkflowCall.input as {
+        category: string;
+        channel: string;
+        audienceType: string;
+        description: string;
+        dag: DAG;
+      };
+
+      const validation = validateDAG(result.dag);
+
+      if (validation.valid) {
+        return {
+          dag: result.dag,
+          category: result.category,
+          channel: result.channel,
+          audienceType: result.audienceType,
+          description: result.description,
+        };
+      }
+
+      dagRetries++;
+      if (dagRetries > MAX_RETRIES) {
+        throw new UpgradeValidationError(
+          "Upgraded DAG is invalid after retries",
+          validation.errors,
+        );
+      }
+
+      messages.push({ role: "assistant", content: response.content });
+      messages.push({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: createWorkflowCall.id,
+            is_error: true,
+            content: buildRetryUserMessage(userMessage, validation.errors),
+          },
+        ],
+      });
+      continue;
+    }
+
+    // Resolve discovery tool calls
+    const toolUseBlocks = response.content.filter(
+      (block): block is Anthropic.Messages.ToolUseBlock =>
+        block.type === "tool_use",
+    );
+
+    if (toolUseBlocks.length === 0) {
+      throw new Error("LLM did not return a tool use response during upgrade");
+    }
+
+    messages.push({ role: "assistant", content: response.content });
+
+    const toolResults: Anthropic.Messages.ToolResultBlockParam[] = [];
+    for (const toolBlock of toolUseBlocks) {
+      try {
+        const resolved = await resolveToolCall(
+          toolBlock.name,
+          toolBlock.input as Record<string, unknown>,
+          identity,
+        );
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: toolBlock.id,
+          content: resolved.content,
+          ...(resolved.isError ? { is_error: true } : {}),
+        });
+      } catch (err) {
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: toolBlock.id,
+          content: `Error: ${err instanceof Error ? err.message : "Unknown error"}`,
+          is_error: true,
+        });
+      }
+    }
+
+    messages.push({ role: "user", content: toolResults });
+  }
+
+  throw new Error("Upgrade exceeded maximum turns without producing a corrected workflow");
+}
+
+export class UpgradeValidationError extends Error {
+  public readonly validationErrors: Array<{ field: string; message: string }>;
+
+  constructor(
+    message: string,
+    errors: Array<{ field: string; message: string }>,
+  ) {
+    super(message);
+    this.name = "UpgradeValidationError";
+    this.validationErrors = errors;
+  }
+}

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -28,11 +28,16 @@ router.post(
       const body = ExecuteByNameSchema.parse(req.body);
       const orgId = res.locals.orgId as string;
 
-      // Look up workflow by name only — workflows are public resources
+      // Look up workflow by name — only active workflows can be executed
       const [workflow] = await db
         .select()
         .from(workflows)
-        .where(eq(workflows.name, req.params.name));
+        .where(
+          and(
+            eq(workflows.name, req.params.name),
+            eq(workflows.status, "active"),
+          )
+        );
 
       if (!workflow) {
         res.status(404).json({
@@ -128,7 +133,12 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
     const [workflow] = await db
       .select()
       .from(workflows)
-      .where(eq(workflows.id, req.params.id));
+      .where(
+        and(
+          eq(workflows.id, req.params.id),
+          eq(workflows.status, "active"),
+        )
+      );
 
     if (!workflow) {
       res.status(404).json({ error: "Workflow not found" });

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -74,6 +74,7 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
         and(
           eq(workflows.orgId, orgId),
           eq(workflows.signature, signature),
+          eq(workflows.status, "active"),
         )
       );
 
@@ -206,6 +207,8 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
           humanId,
           brandId,
           styleName,
+          createdByUserId: userId,
+          createdByRunId: runId,
         })
         .returning();
 
@@ -319,6 +322,8 @@ router.post("/workflows", requireApiKey, async (req, res) => {
         signatureName,
         dag: body.dag,
         windmillFlowPath: flowPath,
+        createdByUserId: res.locals.userId as string,
+        createdByRunId: res.locals.runId as string,
       })
       .returning();
 
@@ -365,7 +370,7 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
       const dag = wf.dag as DAG;
       const signature = computeDAGSignature(wf.dag);
 
-      // Check if workflow already exists for this (orgId, signature)
+      // Check if workflow already exists for this (orgId, signature) — only active
       const [existing] = await db
         .select()
         .from(workflows)
@@ -373,6 +378,7 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
           and(
             eq(workflows.orgId, orgId),
             eq(workflows.signature, signature),
+            eq(workflows.status, "active"),
           )
         );
 
@@ -460,6 +466,8 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
             signatureName,
             dag: wf.dag,
             windmillFlowPath: flowPath,
+            createdByUserId: res.locals.userId as string,
+            createdByRunId: res.locals.runId as string,
           })
           .returning();
 
@@ -503,8 +511,8 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
       runId: res.locals.runId as string,
     };
 
-    // 1. Get all workflows matching the dimensions (all filters optional)
-    const conditions: ReturnType<typeof eq>[] = [];
+    // 1. Get all active workflows matching the dimensions (all filters optional)
+    const conditions: ReturnType<typeof eq>[] = [eq(workflows.status, "active")];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (category) conditions.push(eq(workflows.category, category));
     if (channel) conditions.push(eq(workflows.channel, channel));
@@ -645,12 +653,17 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
   }
 });
 
-// GET /workflows — List workflows
+// GET /workflows — List workflows (defaults to active only; ?status=all for all)
 router.get("/workflows", requireApiKey, async (req, res) => {
   try {
-    const { orgId, brandId, humanId, campaignId, category, channel, audienceType, tag } = req.query;
+    const { orgId, brandId, humanId, campaignId, category, channel, audienceType, tag, status } = req.query;
 
     const conditions: ReturnType<typeof eq>[] = [];
+
+    // Default to active workflows unless ?status=all is passed
+    if (status !== "all") {
+      conditions.push(eq(workflows.status, typeof status === "string" ? status : "active"));
+    }
 
     if (orgId && typeof orgId === "string") {
       conditions.push(eq(workflows.orgId, orgId));

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -151,6 +151,10 @@ export const WorkflowResponseSchema = z
     signature: z.string().describe("Deterministic SHA-256 hash of the canonical DAG JSON. Changes when any node, edge, or config changes."),
     signatureName: z.string().describe("Human-readable name for this signature (e.g. 'Sequoia'). Used to distinguish workflow variants within the same category/channel/audienceType."),
     dag: z.unknown().describe("The DAG definition as submitted."),
+    status: z.enum(["active", "deprecated"]).describe("Workflow lifecycle status. Only active workflows can be executed."),
+    upgradedTo: z.string().uuid().nullable().describe("If deprecated, the ID of the replacement workflow."),
+    createdByUserId: z.string().nullable().describe("User ID that created this workflow."),
+    createdByRunId: z.string().nullable().describe("Run ID that created this workflow."),
     windmillFlowPath: z.string().nullable().describe("Internal Windmill flow path (managed automatically)."),
     windmillWorkspace: z.string().describe("Windmill workspace (managed automatically)."),
     createdAt: z.string(),
@@ -477,6 +481,7 @@ registry.registerPath({
       channel: WorkflowChannelSchema.optional(),
       audienceType: WorkflowAudienceTypeSchema.optional(),
       tag: z.string().optional().describe("Filter workflows that contain this tag."),
+      status: z.string().optional().describe("Filter by status. Defaults to 'active'. Use 'all' to include deprecated workflows."),
     }),
   },
   responses: {

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock API registry client
+const mockFetchServiceList = vi.fn();
+const mockFetchSpecsForServices = vi.fn();
+
+vi.mock("../../src/lib/api-registry-client.js", () => ({
+  fetchServiceList: (...args: unknown[]) => mockFetchServiceList(...args),
+  fetchSpecsForServices: (...args: unknown[]) => mockFetchSpecsForServices(...args),
+  fetchLlmContext: vi.fn().mockResolvedValue({ services: [] }),
+  fetchServiceSpec: vi.fn().mockResolvedValue({}),
+}));
+
+// Mock upgrader
+const mockUpgradeWorkflow = vi.fn();
+vi.mock("../../src/lib/workflow-upgrader.js", () => ({
+  upgradeWorkflow: (...args: unknown[]) => mockUpgradeWorkflow(...args),
+}));
+
+// Mock dag-to-openflow
+vi.mock("../../src/lib/dag-to-openflow.js", () => ({
+  dagToOpenFlow: vi.fn().mockReturnValue({
+    value: { modules: [], same_worker: false },
+    schema: {},
+  }),
+}));
+
+// Mock dag-signature
+vi.mock("../../src/lib/dag-signature.js", () => ({
+  computeDAGSignature: vi.fn().mockReturnValue("new-signature-hash"),
+}));
+
+// Mock signature-words
+vi.mock("../../src/lib/signature-words.js", () => ({
+  pickSignatureName: vi.fn().mockReturnValue("Redwood"),
+}));
+
+// Mock DB
+const mockDbWorkflows: Record<string, unknown>[] = [];
+const mockInsertedWorkflows: Record<string, unknown>[] = [];
+
+vi.mock("../../src/db/index.js", () => ({
+  db: "mock-db",
+  sql: { end: () => Promise.resolve() },
+}));
+
+import {
+  checkApiRegistryHealth,
+  validateAndUpgradeWorkflows,
+} from "../../src/lib/startup-validator.js";
+
+describe("checkApiRegistryHealth", () => {
+  beforeEach(() => {
+    mockFetchServiceList.mockReset();
+  });
+
+  it("succeeds when API Registry is reachable", async () => {
+    mockFetchServiceList.mockResolvedValue([{ service: "campaign" }]);
+    await expect(checkApiRegistryHealth()).resolves.toBeUndefined();
+    expect(mockFetchServiceList).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when API Registry is unreachable", async () => {
+    mockFetchServiceList.mockRejectedValue(new Error("Connection refused"));
+    await expect(checkApiRegistryHealth()).rejects.toThrow("Connection refused");
+  });
+});
+
+describe("validateAndUpgradeWorkflows", () => {
+  const VALID_WORKFLOW = {
+    id: "wf-1",
+    orgId: "org-1",
+    name: "sales-email-cold-outreach-Sequoia",
+    category: "sales",
+    channel: "email",
+    audienceType: "cold-outreach",
+    description: "Test",
+    status: "active",
+    signature: "sig-1",
+    signatureName: "Sequoia",
+    windmillWorkspace: "prod",
+    windmillFlowPath: "f/workflows/org-1/flow",
+    dag: {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/gate-check" },
+        },
+      ],
+      edges: [],
+    },
+    tags: [],
+    brandId: null,
+    humanId: null,
+    campaignId: null,
+    subrequestId: null,
+    styleName: null,
+    displayName: null,
+    upgradedTo: null,
+    createdByUserId: null,
+    createdByRunId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const BROKEN_WORKFLOW = {
+    ...VALID_WORKFLOW,
+    id: "wf-2",
+    name: "sales-email-cold-outreach-Broken",
+    signatureName: "Broken",
+    dag: {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/internal/gate-check" },
+        },
+      ],
+      edges: [],
+    },
+  };
+
+  const CAMPAIGN_SPEC = {
+    paths: {
+      "/gate-check": { post: {} },
+      "/start-run": { post: {} },
+      "/end-run": { post: {} },
+    },
+  };
+
+  // Build a mock database that tracks operations
+  let dbSelectResult: Record<string, unknown>[] = [];
+  let dbUpdates: Array<{ values: Record<string, unknown>; id: string }> = [];
+  let dbInserts: Record<string, unknown>[] = [];
+
+  let selectCallCount = 0;
+
+  function createMockDb() {
+    selectCallCount = 0;
+    return {
+      select: () => ({
+        from: () => {
+          selectCallCount++;
+          const currentCount = selectCallCount;
+
+          const getData = () => {
+            if (currentCount === 1) {
+              return Promise.resolve(dbSelectResult);
+            }
+            return Promise.resolve(
+              dbSelectResult.map((r) => ({ signatureName: (r as Record<string, unknown>).signatureName })),
+            );
+          };
+
+          // Return a thenable with .where() — supports both `await db.select().from()` and `.from().where()`
+          const promise = getData();
+          (promise as any).where = () => getData();
+          return promise;
+        },
+      }),
+      insert: () => ({
+        values: (row: Record<string, unknown>) => {
+          const newRow = {
+            id: "wf-new-" + Math.random().toString(36).slice(2, 8),
+            ...row,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          };
+          dbInserts.push(newRow);
+          return { returning: () => Promise.resolve([newRow]) };
+        },
+      }),
+      update: () => ({
+        set: (values: Record<string, unknown>) => ({
+          where: () => {
+            dbUpdates.push({ values, id: "unknown" });
+            return { returning: () => Promise.resolve([]) };
+          },
+        }),
+      }),
+    };
+  }
+
+  beforeEach(() => {
+    mockFetchSpecsForServices.mockReset();
+    mockUpgradeWorkflow.mockReset();
+    dbSelectResult = [];
+    dbUpdates = [];
+    dbInserts = [];
+    delete process.env.PLATFORM_ANTHROPIC_API_KEY;
+    delete process.env.TRANSACTIONAL_EMAIL_SERVICE_URL;
+    delete process.env.ADMIN_NOTIFICATION_EMAIL;
+  });
+
+  it("logs success when all workflows are valid", async () => {
+    dbSelectResult = [VALID_WORKFLOW];
+    mockFetchSpecsForServices.mockResolvedValue(
+      new Map([["campaign", CAMPAIGN_SPEC]]),
+    );
+
+    const consoleSpy = vi.spyOn(console, "log");
+
+    await validateAndUpgradeWorkflows({
+      db: createMockDb() as any,
+      windmillClient: null,
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("1 valid"),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it("deprecates broken workflow when no Anthropic key available", async () => {
+    dbSelectResult = [BROKEN_WORKFLOW];
+    mockFetchSpecsForServices.mockResolvedValue(
+      new Map([["campaign", CAMPAIGN_SPEC]]),
+    );
+
+    const consoleSpy = vi.spyOn(console, "warn");
+
+    await validateAndUpgradeWorkflows({
+      db: createMockDb() as any,
+      windmillClient: null,
+    });
+
+    // Should have called update to deprecate
+    expect(dbUpdates.length).toBeGreaterThan(0);
+    expect(dbUpdates[0].values).toMatchObject({
+      status: "deprecated",
+      upgradedTo: null,
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it("upgrades broken workflow when Anthropic key is available", async () => {
+    process.env.PLATFORM_ANTHROPIC_API_KEY = "test-key";
+    dbSelectResult = [BROKEN_WORKFLOW];
+    mockFetchSpecsForServices.mockResolvedValue(
+      new Map([["campaign", CAMPAIGN_SPEC]]),
+    );
+
+    const fixedDag = {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/gate-check" },
+        },
+      ],
+      edges: [],
+    };
+
+    mockUpgradeWorkflow.mockResolvedValue({
+      dag: fixedDag,
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      description: "Fixed workflow",
+    });
+
+    await validateAndUpgradeWorkflows({
+      db: createMockDb() as any,
+      windmillClient: null,
+    });
+
+    // Should have inserted a new workflow
+    expect(dbInserts.length).toBe(1);
+    expect(dbInserts[0].status).toBe("active");
+    expect(dbInserts[0].createdByUserId).toBe("workflow-service");
+    expect(dbInserts[0].createdByRunId).toBe("startup-upgrade");
+
+    // Should have deprecated the old workflow
+    expect(dbUpdates.length).toBeGreaterThan(0);
+    expect(dbUpdates[0].values.status).toBe("deprecated");
+  });
+
+  it("handles empty workflow list gracefully", async () => {
+    dbSelectResult = [];
+
+    const consoleSpy = vi.spyOn(console, "log");
+
+    await validateAndUpgradeWorkflows({
+      db: createMockDb() as any,
+      windmillClient: null,
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[startup] No active workflows to validate",
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/unit/validate-workflow-endpoints.test.ts
+++ b/tests/unit/validate-workflow-endpoints.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import { validateWorkflowEndpoints } from "../../src/lib/validate-workflow-endpoints.js";
+import type { DAG } from "../../src/lib/dag-validator.js";
+
+const CAMPAIGN_SPEC: Record<string, unknown> = {
+  paths: {
+    "/gate-check": { post: { summary: "Gate check" } },
+    "/start-run": { post: { summary: "Start run" } },
+    "/end-run": { post: { summary: "End run" } },
+  },
+};
+
+const LEAD_SPEC: Record<string, unknown> = {
+  paths: {
+    "/buffer/next": { post: { summary: "Get next lead" } },
+  },
+};
+
+describe("validateWorkflowEndpoints", () => {
+  it("returns valid for a DAG with all correct endpoints", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/gate-check" },
+        },
+        {
+          id: "fetch-lead",
+          type: "http.call",
+          config: { service: "lead", method: "POST", path: "/buffer/next" },
+        },
+      ],
+      edges: [{ from: "gate-check", to: "fetch-lead" }],
+    };
+
+    const specs = new Map<string, Record<string, unknown>>([
+      ["campaign", CAMPAIGN_SPEC],
+      ["lead", LEAD_SPEC],
+    ]);
+
+    const result = validateWorkflowEndpoints(dag, specs);
+    expect(result.valid).toBe(true);
+    expect(result.invalidEndpoints).toHaveLength(0);
+  });
+
+  it("detects a stale path (e.g., /internal/gate-check)", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/internal/gate-check" },
+        },
+      ],
+      edges: [],
+    };
+
+    const specs = new Map([["campaign", CAMPAIGN_SPEC]]);
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    expect(result.valid).toBe(false);
+    expect(result.invalidEndpoints).toHaveLength(1);
+    expect(result.invalidEndpoints[0].path).toBe("/internal/gate-check");
+    expect(result.invalidEndpoints[0].reason).toContain("not found");
+  });
+
+  it("detects missing service in the registry", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "call-unknown",
+          type: "http.call",
+          config: { service: "nonexistent", method: "GET", path: "/foo" },
+        },
+      ],
+      edges: [],
+    };
+
+    const specs = new Map<string, Record<string, unknown>>();
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    expect(result.valid).toBe(false);
+    expect(result.invalidEndpoints[0].reason).toContain('not found in API Registry');
+  });
+
+  it("detects wrong HTTP method", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "GET", path: "/gate-check" },
+        },
+      ],
+      edges: [],
+    };
+
+    const specs = new Map([["campaign", CAMPAIGN_SPEC]]);
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    expect(result.valid).toBe(false);
+    expect(result.invalidEndpoints[0].reason).toContain("Method GET not found");
+  });
+
+  it("skips non-http.call nodes", () => {
+    const dag: DAG = {
+      nodes: [
+        { id: "wait-step", type: "wait", config: { seconds: 5 } },
+        { id: "branch", type: "condition" },
+      ],
+      edges: [{ from: "wait-step", to: "branch" }],
+    };
+
+    const specs = new Map<string, Record<string, unknown>>();
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    expect(result.valid).toBe(true);
+    expect(result.invalidEndpoints).toHaveLength(0);
+  });
+
+  it("handles spec with no paths", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "call",
+          type: "http.call",
+          config: { service: "empty-service", method: "POST", path: "/foo" },
+        },
+      ],
+      edges: [],
+    };
+
+    const specs = new Map([["empty-service", { info: { title: "Empty" } }]]);
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    expect(result.valid).toBe(false);
+    expect(result.invalidEndpoints[0].reason).toContain("no paths");
+  });
+
+  it("validates multiple broken endpoints in one workflow", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/internal/gate-check" },
+        },
+        {
+          id: "end-run",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/internal/end-run" },
+        },
+        {
+          id: "start-run",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/start-run" },
+        },
+      ],
+      edges: [
+        { from: "gate-check", to: "start-run" },
+        { from: "start-run", to: "end-run" },
+      ],
+    };
+
+    const specs = new Map([["campaign", CAMPAIGN_SPEC]]);
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    expect(result.valid).toBe(false);
+    expect(result.invalidEndpoints).toHaveLength(2);
+    const brokenPaths = result.invalidEndpoints.map((e) => e.path);
+    expect(brokenPaths).toContain("/internal/gate-check");
+    expect(brokenPaths).toContain("/internal/end-run");
+  });
+});

--- a/tests/unit/workflow-upgrader.test.ts
+++ b/tests/unit/workflow-upgrader.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { DAG } from "../../src/lib/dag-validator.js";
+
+// Mock the API registry client
+vi.mock("../../src/lib/api-registry-client.js", () => ({
+  fetchLlmContext: vi.fn().mockResolvedValue({
+    services: [
+      {
+        service: "campaign",
+        description: "Campaign service",
+        endpoints: [
+          { method: "POST", path: "/gate-check", summary: "Gate check" },
+          { method: "POST", path: "/start-run", summary: "Start run" },
+          { method: "POST", path: "/end-run", summary: "End run" },
+        ],
+      },
+    ],
+  }),
+  fetchServiceSpec: vi.fn().mockResolvedValue({
+    paths: {
+      "/gate-check": { post: {} },
+      "/start-run": { post: {} },
+      "/end-run": { post: {} },
+    },
+  }),
+}));
+
+import {
+  upgradeWorkflow,
+  setUpgradeAnthropicClient,
+  UpgradeValidationError,
+} from "../../src/lib/workflow-upgrader.js";
+
+describe("upgradeWorkflow", () => {
+  const BROKEN_DAG: DAG = {
+    nodes: [
+      {
+        id: "gate-check",
+        type: "http.call",
+        config: { service: "campaign", method: "POST", path: "/internal/gate-check", stopAfterIf: "result.allowed == false" },
+        inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" },
+      },
+      {
+        id: "end-run",
+        type: "http.call",
+        config: { service: "campaign", method: "POST", path: "/end-run", body: { success: true } },
+        inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" },
+      },
+    ],
+    edges: [{ from: "gate-check", to: "end-run" }],
+  };
+
+  const FIXED_DAG: DAG = {
+    nodes: [
+      {
+        id: "gate-check",
+        type: "http.call",
+        config: { service: "campaign", method: "POST", path: "/gate-check", stopAfterIf: "result.allowed == false" },
+        inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" },
+      },
+      {
+        id: "end-run",
+        type: "http.call",
+        config: { service: "campaign", method: "POST", path: "/end-run", body: { success: true } },
+        inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" },
+      },
+    ],
+    edges: [{ from: "gate-check", to: "end-run" }],
+  };
+
+  const IDENTITY = { orgId: "test-org", userId: "test-user", runId: "test-run" };
+  const METADATA = {
+    category: "sales",
+    channel: "email",
+    audienceType: "cold-outreach",
+    description: "Test workflow",
+  };
+
+  afterEach(() => {
+    setUpgradeAnthropicClient(null);
+  });
+
+  it("calls the LLM with upgrade prompt and returns corrected DAG", async () => {
+    // Mock Anthropic client that immediately returns a fixed DAG via create_workflow
+    const mockClient = {
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [
+            {
+              type: "tool_use",
+              id: "tool-1",
+              name: "create_workflow",
+              input: {
+                category: "sales",
+                channel: "email",
+                audienceType: "cold-outreach",
+                description: "Test workflow (fixed)",
+                dag: FIXED_DAG,
+              },
+            },
+          ],
+        }),
+      },
+    };
+
+    setUpgradeAnthropicClient(mockClient as any);
+
+    const result = await upgradeWorkflow(
+      BROKEN_DAG,
+      [{ service: "campaign", method: "POST", path: "/internal/gate-check", reason: "not found" }],
+      "fake-key",
+      IDENTITY,
+      METADATA,
+    );
+
+    expect(result.dag.nodes[0].config?.path).toBe("/gate-check");
+    expect(result.category).toBe("sales");
+    expect(mockClient.messages.create).toHaveBeenCalledTimes(1);
+
+    // Verify the system prompt mentions the broken endpoint
+    const systemArg = mockClient.messages.create.mock.calls[0][0].system;
+    expect(systemArg).toContain("/internal/gate-check");
+    expect(systemArg).toContain("FIX a broken workflow");
+  });
+
+  it("handles discovery tool calls before generating the fixed DAG", async () => {
+    let callCount = 0;
+    const mockClient = {
+      messages: {
+        create: vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            // First call: model wants to call list_services
+            return Promise.resolve({
+              content: [
+                { type: "tool_use", id: "t1", name: "list_services", input: {} },
+              ],
+            });
+          }
+          // Second call: model returns the fixed DAG
+          return Promise.resolve({
+            content: [
+              {
+                type: "tool_use",
+                id: "t2",
+                name: "create_workflow",
+                input: {
+                  category: "sales",
+                  channel: "email",
+                  audienceType: "cold-outreach",
+                  description: "Fixed",
+                  dag: FIXED_DAG,
+                },
+              },
+            ],
+          });
+        }),
+      },
+    };
+
+    setUpgradeAnthropicClient(mockClient as any);
+
+    const result = await upgradeWorkflow(
+      BROKEN_DAG,
+      [{ service: "campaign", method: "POST", path: "/internal/gate-check", reason: "not found" }],
+      "fake-key",
+      IDENTITY,
+      METADATA,
+    );
+
+    expect(result.dag.nodes[0].config?.path).toBe("/gate-check");
+    expect(mockClient.messages.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when LLM produces invalid DAG after retries", async () => {
+    const invalidDag: DAG = {
+      nodes: [
+        { id: "a", type: "nonexistent-type" },
+      ],
+      edges: [{ from: "a", to: "b" }], // 'b' doesn't exist
+    };
+
+    const mockClient = {
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [
+            {
+              type: "tool_use",
+              id: "t1",
+              name: "create_workflow",
+              input: {
+                category: "sales",
+                channel: "email",
+                audienceType: "cold-outreach",
+                description: "Bad",
+                dag: invalidDag,
+              },
+            },
+          ],
+        }),
+      },
+    };
+
+    setUpgradeAnthropicClient(mockClient as any);
+
+    await expect(
+      upgradeWorkflow(
+        BROKEN_DAG,
+        [{ service: "campaign", method: "POST", path: "/internal/gate-check", reason: "not found" }],
+        "fake-key",
+        IDENTITY,
+        METADATA,
+      ),
+    ).rejects.toThrow(UpgradeValidationError);
+  });
+});


### PR DESCRIPTION
## Summary

- At startup, validates all active workflows' HTTP endpoints against the API Registry
- If API Registry is unreachable, the service **fails to start** (fail-fast)
- Broken workflows are **deprecated** and **auto-upgraded** via a specialized LLM prompt that preserves business logic while fixing stale paths
- Admin email notifications sent for each deprecated/upgraded workflow
- All query paths now filter by `status = 'active'` — deprecated workflows are invisible to clients

### Schema changes
- New columns: `status` (active/deprecated), `upgraded_to`, `created_by_user_id`, `created_by_run_id`
- Unique indexes changed from org-scoped to global partial indexes (`WHERE status = 'active'`)
- Migration: `drizzle/0014_add_workflow_status.sql`

### New files
- `src/lib/validate-workflow-endpoints.ts` — validates DAG endpoints against OpenAPI specs
- `src/lib/workflow-upgrader.ts` — LLM-powered upgrade with preservation prompt
- `src/lib/startup-validator.ts` — orchestrator: validate → deprecate → upgrade → notify

### Blocked items (see forwardable messages below)
- **Platform Anthropic key**: gated by `PLATFORM_ANTHROPIC_API_KEY` env var until key-service supports `GET /keys/platform/anthropic/decrypt` without identity headers
- **Run tracking**: startup upgrades don't create runs yet — waiting on runs-service to support platform-level runs
- **API Registry identity**: using synthetic `workflow-service` identity until API Registry drops identity requirements on read-only spec endpoints

## Test plan
- [x] 289 tests pass (273 existing + 16 new)
- [x] `npm run build` compiles cleanly
- [x] OpenAPI spec regenerated with new `status`, `upgradedTo`, `createdByUserId`, `createdByRunId` fields
- [ ] Manual: deploy a workflow with a stale path, restart service, verify deprecation + upgrade + email

🤖 Generated with [Claude Code](https://claude.com/claude-code)