### PR TITLE
fix: remove platform workarounds, use real platform-level endpoints

### DIFF
--- a/src/lib/api-registry-client.ts
+++ b/src/lib/api-registry-client.ts
@@ -34,18 +34,23 @@ function getApiRegistryConfig(): { baseUrl: string; apiKey: string } {
   return { baseUrl: baseUrl.replace(/\/$/, ""), apiKey };
 }
 
+function buildHeaders(apiKey: string, identity?: IdentityHeaders): Record<string, string> {
+  const headers: Record<string, string> = { "x-api-key": apiKey };
+  if (identity) {
+    headers["x-org-id"] = identity.orgId;
+    headers["x-user-id"] = identity.userId;
+    headers["x-run-id"] = identity.runId;
+  }
+  return headers;
+}
+
 /** GET /llm-context — compact summary of all services and endpoints for LLM consumption */
-export async function fetchLlmContext(identity: IdentityHeaders): Promise<LlmContextResponse> {
+export async function fetchLlmContext(identity?: IdentityHeaders): Promise<LlmContextResponse> {
   const { baseUrl, apiKey } = getApiRegistryConfig();
 
   const res = await fetch(`${baseUrl}/llm-context`, {
     method: "GET",
-    headers: {
-      "x-api-key": apiKey,
-      "x-org-id": identity.orgId,
-      "x-user-id": identity.userId,
-      "x-run-id": identity.runId,
-    },
+    headers: buildHeaders(apiKey, identity),
   });
 
   if (!res.ok) {
@@ -60,18 +65,13 @@ export async function fetchLlmContext(identity: IdentityHeaders): Promise<LlmCon
 
 /** GET /services — list all registered services (used for health check + enumeration) */
 export async function fetchServiceList(
-  identity: IdentityHeaders,
+  identity?: IdentityHeaders,
 ): Promise<Array<{ service: string }>> {
   const { baseUrl, apiKey } = getApiRegistryConfig();
 
   const res = await fetch(`${baseUrl}/services`, {
     method: "GET",
-    headers: {
-      "x-api-key": apiKey,
-      "x-org-id": identity.orgId,
-      "x-user-id": identity.userId,
-      "x-run-id": identity.runId,
-    },
+    headers: buildHeaders(apiKey, identity),
   });
 
   if (!res.ok) {
@@ -87,7 +87,7 @@ export async function fetchServiceList(
 /** Fetch OpenAPI specs for multiple services (deduplicated). Returns Map<serviceName, spec> */
 export async function fetchSpecsForServices(
   serviceNames: string[],
-  identity: IdentityHeaders,
+  identity?: IdentityHeaders,
 ): Promise<Map<string, Record<string, unknown>>> {
   const unique = [...new Set(serviceNames)];
   const specs = new Map<string, Record<string, unknown>>();
@@ -113,7 +113,7 @@ export async function fetchSpecsForServices(
 /** GET /openapi/:service — full OpenAPI spec for one service */
 export async function fetchServiceSpec(
   serviceName: string,
-  identity: IdentityHeaders,
+  identity?: IdentityHeaders,
 ): Promise<Record<string, unknown>> {
   const { baseUrl, apiKey } = getApiRegistryConfig();
 
@@ -121,12 +121,7 @@ export async function fetchServiceSpec(
     `${baseUrl}/openapi/${encodeURIComponent(serviceName)}`,
     {
       method: "GET",
-      headers: {
-        "x-api-key": apiKey,
-        "x-org-id": identity.orgId,
-        "x-user-id": identity.userId,
-        "x-run-id": identity.runId,
-      },
+      headers: buildHeaders(apiKey, identity),
     },
   );
 

--- a/src/lib/key-service-client.ts
+++ b/src/lib/key-service-client.ts
@@ -96,3 +96,27 @@ export async function fetchAnthropicKey(
   const body = (await res.json()) as KeyDecryptResponse;
   return body;
 }
+
+/** GET /keys/platform/anthropic/decrypt — platform-level key (no org/user context needed) */
+export async function fetchPlatformAnthropicKey(): Promise<KeyDecryptResponse> {
+  const { baseUrl, apiKey } = getKeyServiceConfig();
+
+  const res = await fetch(`${baseUrl}/keys/platform/anthropic/decrypt`, {
+    method: "GET",
+    headers: {
+      "x-api-key": apiKey,
+      "x-caller-service": "workflow",
+      "x-caller-method": "POST",
+      "x-caller-path": "/startup-upgrade",
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `key-service error: GET /keys/platform/anthropic/decrypt -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  return res.json() as Promise<KeyDecryptResponse>;
+}

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -65,3 +65,65 @@ export async function createRun(opts: {
   const data = (await res.json()) as { id: string };
   return { runId: data.id };
 }
+
+/** POST /v1/platform-runs — create a platform-level run (no org/user context) */
+export async function createPlatformRun(opts: {
+  serviceName: string;
+  taskName: string;
+  workflowName?: string;
+}): Promise<CreateRunResult> {
+  const { baseUrl, apiKey } = getRunsServiceConfig();
+
+  const body: Record<string, string> = {
+    serviceName: opts.serviceName,
+    taskName: opts.taskName,
+  };
+  if (opts.workflowName) {
+    body.workflowName = opts.workflowName;
+  }
+
+  const res = await fetch(`${baseUrl}/v1/platform-runs`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "x-service-name": "workflow-service",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `runs-service error: POST /v1/platform-runs -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  const data = (await res.json()) as { id: string };
+  return { runId: data.id };
+}
+
+/** PATCH /v1/platform-runs/:id — close a platform-level run */
+export async function closePlatformRun(
+  runId: string,
+  status: "completed" | "failed",
+): Promise<void> {
+  const { baseUrl, apiKey } = getRunsServiceConfig();
+
+  const res = await fetch(`${baseUrl}/v1/platform-runs/${encodeURIComponent(runId)}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "x-service-name": "workflow-service",
+    },
+    body: JSON.stringify({ status }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `runs-service error: PATCH /v1/platform-runs/${runId} -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+}

--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -13,7 +13,8 @@ import { dagToOpenFlow } from "./dag-to-openflow.js";
 import { computeDAGSignature } from "./dag-signature.js";
 import { pickSignatureName } from "./signature-words.js";
 import type { WindmillClient } from "./windmill-client.js";
-import type { IdentityHeaders } from "./key-service-client.js";
+import { fetchPlatformAnthropicKey } from "./key-service-client.js";
+import { createPlatformRun, closePlatformRun } from "./runs-client.js";
 
 type Database = typeof DbInstance;
 
@@ -23,20 +24,10 @@ interface StartupValidatorDeps {
 }
 
 /**
- * Temporary identity for API Registry calls.
- * TODO: Remove once API Registry drops identity requirements on read-only spec endpoints.
- */
-const PLATFORM_IDENTITY: IdentityHeaders = {
-  orgId: "workflow-service",
-  userId: "workflow-service",
-  runId: "startup-validation",
-};
-
-/**
  * Ping API Registry to verify it's reachable. Throws on failure.
  */
 export async function checkApiRegistryHealth(): Promise<void> {
-  await fetchServiceList(PLATFORM_IDENTITY);
+  await fetchServiceList();
 }
 
 /**
@@ -68,11 +59,8 @@ export async function validateAndUpgradeWorkflows(
     }
   }
 
-  // 3. Fetch OpenAPI specs for all services
-  const specs = await fetchSpecsForServices(
-    [...allServiceNames],
-    PLATFORM_IDENTITY,
-  );
+  // 3. Fetch OpenAPI specs for all services (no identity needed for read-only endpoints)
+  const specs = await fetchSpecsForServices([...allServiceNames]);
 
   // 4. Validate each workflow
   let validCount = 0;
@@ -146,91 +134,133 @@ async function attemptUpgrade(
   database: Database,
   windmillClient: WindmillClient | null,
 ): Promise<string | null> {
-  // Resolve Anthropic API key — blocked until key-service supports platform-level key resolution
-  // TODO: Replace with platform key resolution once key-service adds GET /keys/platform/anthropic/decrypt
-  const anthropicApiKey = process.env.PLATFORM_ANTHROPIC_API_KEY;
-  if (!anthropicApiKey) {
-    console.warn("[startup] PLATFORM_ANTHROPIC_API_KEY not set — upgrade skipped");
+  // Resolve Anthropic API key via key-service platform endpoint
+  let anthropicApiKey: string;
+  try {
+    const keyResult = await fetchPlatformAnthropicKey();
+    anthropicApiKey = keyResult.key;
+  } catch (err) {
+    console.warn(
+      "[startup] Platform Anthropic key not available — upgrade skipped:",
+      err instanceof Error ? err.message : err,
+    );
     return null;
   }
 
-  const result = await upgradeWorkflow(
-    dag,
-    invalidEndpoints,
-    anthropicApiKey,
-    PLATFORM_IDENTITY,
-    {
-      category: wf.category,
-      channel: wf.channel,
-      audienceType: wf.audienceType,
-      description: wf.description ?? "",
-    },
-  );
-
-  // Compute new signature
-  const newSignature = computeDAGSignature(result.dag);
-
-  // Get used signature names to avoid collisions
-  const existingWorkflows = await database
-    .select({ signatureName: workflows.signatureName })
-    .from(workflows);
-  const usedNames = new Set<string>(existingWorkflows.map((w) => w.signatureName));
-
-  const newSignatureName = pickSignatureName(newSignature, usedNames);
-  const newName = `${result.category}-${result.channel}-${result.audienceType}-${newSignatureName}`;
-
-  // Deploy to Windmill
-  const openFlow = dagToOpenFlow(result.dag, newName);
-  const flowPath = `f/workflows/${wf.orgId}/${newName.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
-  let windmillFlowPath: string | null = null;
-
-  if (windmillClient) {
-    try {
-      await windmillClient.createFlow({
-        path: flowPath,
-        summary: newName,
-        description: result.description,
-        value: openFlow.value,
-        schema: openFlow.schema,
-      });
-      windmillFlowPath = flowPath;
-    } catch (err) {
-      console.error("[startup] Failed to create upgraded flow in Windmill:", err);
-    }
+  // Track this upgrade as a platform-level run
+  let platformRunId: string | undefined;
+  try {
+    const run = await createPlatformRun({
+      serviceName: "workflow",
+      taskName: "startup-upgrade",
+      workflowName: wf.name,
+    });
+    platformRunId = run.runId;
+  } catch (err) {
+    console.warn(
+      "[startup] Failed to create platform run — continuing without tracking:",
+      err instanceof Error ? err.message : err,
+    );
   }
 
-  // Insert new active workflow
-  const [created] = await database
-    .insert(workflows)
-    .values({
-      orgId: wf.orgId,
-      brandId: wf.brandId,
-      humanId: wf.humanId,
-      campaignId: wf.campaignId,
-      subrequestId: wf.subrequestId,
-      styleName: wf.styleName,
-      name: newName,
-      displayName: wf.displayName,
-      description: result.description,
-      category: result.category,
-      channel: result.channel,
-      audienceType: result.audienceType,
-      signature: newSignature,
-      signatureName: newSignatureName,
-      dag: result.dag,
-      tags: wf.tags as string[],
-      status: "active",
-      createdByUserId: "workflow-service",
-      createdByRunId: "startup-upgrade",
-      windmillFlowPath,
-      windmillWorkspace: wf.windmillWorkspace,
-    })
-    .returning();
+  try {
+    const result = await upgradeWorkflow(
+      dag,
+      invalidEndpoints,
+      anthropicApiKey,
+      undefined,
+      {
+        category: wf.category,
+        channel: wf.channel,
+        audienceType: wf.audienceType,
+        description: wf.description ?? "",
+      },
+    );
 
-  // Deprecate old workflow
-  await deprecateWorkflow(database, wf.id, created.id);
+    // Compute new signature
+    const newSignature = computeDAGSignature(result.dag);
 
-  return created.id;
+    // Get used signature names to avoid collisions
+    const existingWorkflows = await database
+      .select({ signatureName: workflows.signatureName })
+      .from(workflows);
+    const usedNames = new Set<string>(existingWorkflows.map((w) => w.signatureName));
+
+    const newSignatureName = pickSignatureName(newSignature, usedNames);
+    const newName = `${result.category}-${result.channel}-${result.audienceType}-${newSignatureName}`;
+
+    // Deploy to Windmill
+    const openFlow = dagToOpenFlow(result.dag, newName);
+    const flowPath = `f/workflows/${wf.orgId}/${newName.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
+    let windmillFlowPath: string | null = null;
+
+    if (windmillClient) {
+      try {
+        await windmillClient.createFlow({
+          path: flowPath,
+          summary: newName,
+          description: result.description,
+          value: openFlow.value,
+          schema: openFlow.schema,
+        });
+        windmillFlowPath = flowPath;
+      } catch (err) {
+        console.error("[startup] Failed to create upgraded flow in Windmill:", err);
+      }
+    }
+
+    // Insert new active workflow
+    const [created] = await database
+      .insert(workflows)
+      .values({
+        orgId: wf.orgId,
+        brandId: wf.brandId,
+        humanId: wf.humanId,
+        campaignId: wf.campaignId,
+        subrequestId: wf.subrequestId,
+        styleName: wf.styleName,
+        name: newName,
+        displayName: wf.displayName,
+        description: result.description,
+        category: result.category,
+        channel: result.channel,
+        audienceType: result.audienceType,
+        signature: newSignature,
+        signatureName: newSignatureName,
+        dag: result.dag,
+        tags: wf.tags as string[],
+        status: "active",
+        createdByUserId: "workflow-service",
+        createdByRunId: platformRunId ?? "startup-upgrade",
+        windmillFlowPath,
+        windmillWorkspace: wf.windmillWorkspace,
+      })
+      .returning();
+
+    // Deprecate old workflow
+    await deprecateWorkflow(database, wf.id, created.id);
+
+    // Close platform run as completed
+    if (platformRunId) {
+      try {
+        await closePlatformRun(platformRunId, "completed");
+      } catch {
+        // Non-blocking
+      }
+    }
+
+    return created.id;
+  } catch (err) {
+    // Close platform run as failed
+    if (platformRunId) {
+      try {
+        await closePlatformRun(platformRunId, "failed");
+      } catch {
+        // Non-blocking
+      }
+    }
+    throw err;
+  }
 }
 
 async function deprecateWorkflow(
@@ -286,9 +316,7 @@ Warning: If an endpoint is actually valid but missing from the OpenAPI spec, upd
       headers: {
         "Content-Type": "application/json",
         "x-api-key": emailApiKey,
-        "x-org-id": wf.orgId,
-        "x-user-id": "workflow-service",
-        "x-run-id": "startup-upgrade",
+        "x-service-name": "workflow-service",
       },
       body: JSON.stringify({
         to: adminEmail,

--- a/src/lib/workflow-upgrader.ts
+++ b/src/lib/workflow-upgrader.ts
@@ -26,7 +26,7 @@ export function setUpgradeAnthropicClient(client: Anthropic | null): void {
 async function resolveToolCall(
   toolName: string,
   toolInput: Record<string, unknown>,
-  identity: IdentityHeaders,
+  identity?: IdentityHeaders,
 ): Promise<{ content: string; isError?: boolean }> {
   switch (toolName) {
     case "list_services": {
@@ -61,7 +61,7 @@ export async function upgradeWorkflow(
   currentDag: DAG,
   invalidEndpoints: InvalidEndpoint[],
   anthropicApiKey: string,
-  identity: IdentityHeaders,
+  identity: IdentityHeaders | undefined,
   metadata: { category: string; channel: string; audienceType: string; description: string },
 ): Promise<UpgradeWorkflowResult> {
   const client = overrideClient ?? new Anthropic({ apiKey: anthropicApiKey });

--- a/tests/unit/key-service-client.test.ts
+++ b/tests/unit/key-service-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { fetchProviderRequirements, fetchAnthropicKey, type IdentityHeaders } from "../../src/lib/key-service-client.js";
+import { fetchProviderRequirements, fetchAnthropicKey, fetchPlatformAnthropicKey, type IdentityHeaders } from "../../src/lib/key-service-client.js";
 
 const TEST_IDENTITY: IdentityHeaders = { orgId: "org-1", userId: "user-1", runId: "run-1" };
 
@@ -218,6 +218,70 @@ describe("fetchAnthropicKey", () => {
     expect(fetch).toHaveBeenCalledWith(
       "http://localhost:4000/keys/anthropic/decrypt?orgId=org+with+spaces&userId=user-1",
       expect.anything()
+    );
+  });
+});
+
+describe("fetchPlatformAnthropicKey", () => {
+  const originalUrl = process.env.KEY_SERVICE_URL;
+  const originalKey = process.env.KEY_SERVICE_API_KEY;
+
+  beforeEach(() => {
+    process.env.KEY_SERVICE_URL = "http://localhost:4000";
+    process.env.KEY_SERVICE_API_KEY = "test-key-svc-key";
+  });
+
+  afterEach(() => {
+    process.env.KEY_SERVICE_URL = originalUrl;
+    process.env.KEY_SERVICE_API_KEY = originalKey;
+    vi.restoreAllMocks();
+  });
+
+  it("calls GET /keys/platform/anthropic/decrypt with x-caller headers and no identity", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ key: "sk-platform-key", keySource: "platform" }),
+      })
+    );
+
+    const result = await fetchPlatformAnthropicKey();
+
+    expect(result).toEqual({ key: "sk-platform-key", keySource: "platform" });
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:4000/keys/platform/anthropic/decrypt",
+      expect.objectContaining({
+        method: "GET",
+        headers: {
+          "x-api-key": "test-key-svc-key",
+          "x-caller-service": "workflow",
+          "x-caller-method": "POST",
+          "x-caller-path": "/startup-upgrade",
+        },
+      })
+    );
+
+    // Should NOT include identity headers
+    const calledHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+    expect(calledHeaders).not.toHaveProperty("x-org-id");
+    expect(calledHeaders).not.toHaveProperty("x-user-id");
+    expect(calledHeaders).not.toHaveProperty("x-run-id");
+  });
+
+  it("throws on non-2xx response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        text: () => Promise.resolve("platform key not configured"),
+      })
+    );
+
+    await expect(fetchPlatformAnthropicKey()).rejects.toThrow(
+      "key-service error: GET /keys/platform/anthropic/decrypt"
     );
   });
 });

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createRun } from "../../src/lib/runs-client.js";
+import { createRun, createPlatformRun, closePlatformRun } from "../../src/lib/runs-client.js";
 
 describe("createRun", () => {
   const originalUrl = process.env.RUNS_SERVICE_URL;
@@ -158,5 +158,172 @@ describe("createRun", () => {
     await expect(
       createRun({ parentRunId: "caller-run-5", orgId: "org-1", userId: "user-1", taskName: "execute-workflow" })
     ).rejects.toThrow("RUNS_SERVICE_URL and RUNS_SERVICE_API_KEY must be set");
+  });
+});
+
+describe("createPlatformRun", () => {
+  const originalUrl = process.env.RUNS_SERVICE_URL;
+  const originalKey = process.env.RUNS_SERVICE_API_KEY;
+
+  beforeEach(() => {
+    process.env.RUNS_SERVICE_URL = "http://localhost:5000";
+    process.env.RUNS_SERVICE_API_KEY = "test-runs-key";
+  });
+
+  afterEach(() => {
+    process.env.RUNS_SERVICE_URL = originalUrl;
+    process.env.RUNS_SERVICE_API_KEY = originalKey;
+    vi.restoreAllMocks();
+  });
+
+  it("calls POST /v1/platform-runs with x-service-name and no identity headers", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: "platform-run-1" }),
+      })
+    );
+
+    const result = await createPlatformRun({
+      serviceName: "workflow",
+      taskName: "startup-upgrade",
+    });
+
+    expect(result).toEqual({ runId: "platform-run-1" });
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:5000/v1/platform-runs",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": "test-runs-key",
+          "x-service-name": "workflow-service",
+        },
+        body: JSON.stringify({
+          serviceName: "workflow",
+          taskName: "startup-upgrade",
+        }),
+      })
+    );
+
+    // Should NOT include identity headers
+    const calledHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+    expect(calledHeaders).not.toHaveProperty("x-org-id");
+    expect(calledHeaders).not.toHaveProperty("x-user-id");
+    expect(calledHeaders).not.toHaveProperty("x-run-id");
+  });
+
+  it("includes workflowName when provided", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: "platform-run-2" }),
+      })
+    );
+
+    await createPlatformRun({
+      serviceName: "workflow",
+      taskName: "startup-upgrade",
+      workflowName: "sales-email-cold-outreach",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:5000/v1/platform-runs",
+      expect.objectContaining({
+        body: JSON.stringify({
+          serviceName: "workflow",
+          taskName: "startup-upgrade",
+          workflowName: "sales-email-cold-outreach",
+        }),
+      })
+    );
+  });
+
+  it("throws on non-2xx response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        text: () => Promise.resolve("boom"),
+      })
+    );
+
+    await expect(
+      createPlatformRun({ serviceName: "workflow", taskName: "startup-upgrade" })
+    ).rejects.toThrow("runs-service error: POST /v1/platform-runs");
+  });
+});
+
+describe("closePlatformRun", () => {
+  const originalUrl = process.env.RUNS_SERVICE_URL;
+  const originalKey = process.env.RUNS_SERVICE_API_KEY;
+
+  beforeEach(() => {
+    process.env.RUNS_SERVICE_URL = "http://localhost:5000";
+    process.env.RUNS_SERVICE_API_KEY = "test-runs-key";
+  });
+
+  afterEach(() => {
+    process.env.RUNS_SERVICE_URL = originalUrl;
+    process.env.RUNS_SERVICE_API_KEY = originalKey;
+    vi.restoreAllMocks();
+  });
+
+  it("calls PATCH /v1/platform-runs/:id with status body and x-service-name header", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true })
+    );
+
+    await closePlatformRun("run-abc", "completed");
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:5000/v1/platform-runs/run-abc",
+      expect.objectContaining({
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": "test-runs-key",
+          "x-service-name": "workflow-service",
+        },
+        body: JSON.stringify({ status: "completed" }),
+      })
+    );
+  });
+
+  it("sends 'failed' status when run fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true })
+    );
+
+    await closePlatformRun("run-def", "failed");
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:5000/v1/platform-runs/run-def",
+      expect.objectContaining({
+        body: JSON.stringify({ status: "failed" }),
+      })
+    );
+  });
+
+  it("throws on non-2xx response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        text: () => Promise.resolve("run not found"),
+      })
+    );
+
+    await expect(
+      closePlatformRun("run-missing", "completed")
+    ).rejects.toThrow("runs-service error: PATCH /v1/platform-runs/run-missing");
   });
 });

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -17,6 +17,20 @@ vi.mock("../../src/lib/workflow-upgrader.js", () => ({
   upgradeWorkflow: (...args: unknown[]) => mockUpgradeWorkflow(...args),
 }));
 
+// Mock key-service client
+const mockFetchPlatformAnthropicKey = vi.fn();
+vi.mock("../../src/lib/key-service-client.js", () => ({
+  fetchPlatformAnthropicKey: (...args: unknown[]) => mockFetchPlatformAnthropicKey(...args),
+}));
+
+// Mock runs-client
+const mockCreatePlatformRun = vi.fn();
+const mockClosePlatformRun = vi.fn();
+vi.mock("../../src/lib/runs-client.js", () => ({
+  createPlatformRun: (...args: unknown[]) => mockCreatePlatformRun(...args),
+  closePlatformRun: (...args: unknown[]) => mockClosePlatformRun(...args),
+}));
+
 // Mock dag-to-openflow
 vi.mock("../../src/lib/dag-to-openflow.js", () => ({
   dagToOpenFlow: vi.fn().mockReturnValue({
@@ -36,9 +50,6 @@ vi.mock("../../src/lib/signature-words.js", () => ({
 }));
 
 // Mock DB
-const mockDbWorkflows: Record<string, unknown>[] = [];
-const mockInsertedWorkflows: Record<string, unknown>[] = [];
-
 vi.mock("../../src/db/index.js", () => ({
   db: "mock-db",
   sql: { end: () => Promise.resolve() },
@@ -58,6 +69,8 @@ describe("checkApiRegistryHealth", () => {
     mockFetchServiceList.mockResolvedValue([{ service: "campaign" }]);
     await expect(checkApiRegistryHealth()).resolves.toBeUndefined();
     expect(mockFetchServiceList).toHaveBeenCalledTimes(1);
+    // Should be called without identity
+    expect(mockFetchServiceList).toHaveBeenCalledWith();
   });
 
   it("throws when API Registry is unreachable", async () => {
@@ -185,10 +198,12 @@ describe("validateAndUpgradeWorkflows", () => {
   beforeEach(() => {
     mockFetchSpecsForServices.mockReset();
     mockUpgradeWorkflow.mockReset();
+    mockFetchPlatformAnthropicKey.mockReset();
+    mockCreatePlatformRun.mockReset();
+    mockClosePlatformRun.mockReset();
     dbSelectResult = [];
     dbUpdates = [];
     dbInserts = [];
-    delete process.env.PLATFORM_ANTHROPIC_API_KEY;
     delete process.env.TRANSACTIONAL_EMAIL_SERVICE_URL;
     delete process.env.ADMIN_NOTIFICATION_EMAIL;
   });
@@ -212,11 +227,12 @@ describe("validateAndUpgradeWorkflows", () => {
     consoleSpy.mockRestore();
   });
 
-  it("deprecates broken workflow when no Anthropic key available", async () => {
+  it("deprecates broken workflow when platform key not available", async () => {
     dbSelectResult = [BROKEN_WORKFLOW];
     mockFetchSpecsForServices.mockResolvedValue(
       new Map([["campaign", CAMPAIGN_SPEC]]),
     );
+    mockFetchPlatformAnthropicKey.mockRejectedValue(new Error("key not found"));
 
     const consoleSpy = vi.spyOn(console, "warn");
 
@@ -235,12 +251,14 @@ describe("validateAndUpgradeWorkflows", () => {
     consoleSpy.mockRestore();
   });
 
-  it("upgrades broken workflow when Anthropic key is available", async () => {
-    process.env.PLATFORM_ANTHROPIC_API_KEY = "test-key";
+  it("upgrades broken workflow using platform key and tracks run", async () => {
     dbSelectResult = [BROKEN_WORKFLOW];
     mockFetchSpecsForServices.mockResolvedValue(
       new Map([["campaign", CAMPAIGN_SPEC]]),
     );
+    mockFetchPlatformAnthropicKey.mockResolvedValue({ key: "test-platform-key", keySource: "platform" });
+    mockCreatePlatformRun.mockResolvedValue({ runId: "platform-run-123" });
+    mockClosePlatformRun.mockResolvedValue(undefined);
 
     const fixedDag = {
       nodes: [
@@ -266,15 +284,37 @@ describe("validateAndUpgradeWorkflows", () => {
       windmillClient: null,
     });
 
+    // Should have resolved the key via platform endpoint
+    expect(mockFetchPlatformAnthropicKey).toHaveBeenCalledTimes(1);
+
+    // Should have created a platform run
+    expect(mockCreatePlatformRun).toHaveBeenCalledWith({
+      serviceName: "workflow",
+      taskName: "startup-upgrade",
+      workflowName: "sales-email-cold-outreach-Broken",
+    });
+
+    // Should have called upgradeWorkflow with the platform key and no identity
+    expect(mockUpgradeWorkflow).toHaveBeenCalledWith(
+      BROKEN_WORKFLOW.dag,
+      expect.any(Array),
+      "test-platform-key",
+      undefined,
+      expect.objectContaining({ category: "sales" }),
+    );
+
     // Should have inserted a new workflow
     expect(dbInserts.length).toBe(1);
     expect(dbInserts[0].status).toBe("active");
     expect(dbInserts[0].createdByUserId).toBe("workflow-service");
-    expect(dbInserts[0].createdByRunId).toBe("startup-upgrade");
+    expect(dbInserts[0].createdByRunId).toBe("platform-run-123");
 
     // Should have deprecated the old workflow
     expect(dbUpdates.length).toBeGreaterThan(0);
     expect(dbUpdates[0].values.status).toBe("deprecated");
+
+    // Should have closed the platform run as completed
+    expect(mockClosePlatformRun).toHaveBeenCalledWith("platform-run-123", "completed");
   });
 
   it("handles empty workflow list gracefully", async () => {
@@ -291,5 +331,28 @@ describe("validateAndUpgradeWorkflows", () => {
       "[startup] No active workflows to validate",
     );
     consoleSpy.mockRestore();
+  });
+
+  it("closes platform run as failed when upgrade throws", async () => {
+    dbSelectResult = [BROKEN_WORKFLOW];
+    mockFetchSpecsForServices.mockResolvedValue(
+      new Map([["campaign", CAMPAIGN_SPEC]]),
+    );
+    mockFetchPlatformAnthropicKey.mockResolvedValue({ key: "test-key", keySource: "platform" });
+    mockCreatePlatformRun.mockResolvedValue({ runId: "platform-run-456" });
+    mockClosePlatformRun.mockResolvedValue(undefined);
+    mockUpgradeWorkflow.mockRejectedValue(new Error("LLM error"));
+
+    await validateAndUpgradeWorkflows({
+      db: createMockDb() as any,
+      windmillClient: null,
+    });
+
+    // Should have closed the platform run as failed
+    expect(mockClosePlatformRun).toHaveBeenCalledWith("platform-run-456", "failed");
+
+    // Should have deprecated the workflow
+    expect(dbUpdates.length).toBeGreaterThan(0);
+    expect(dbUpdates[0].values.status).toBe("deprecated");
   });
 });

--- a/tests/unit/workflow-upgrader.test.ts
+++ b/tests/unit/workflow-upgrader.test.ts
@@ -68,7 +68,7 @@ describe("upgradeWorkflow", () => {
     edges: [{ from: "gate-check", to: "end-run" }],
   };
 
-  const IDENTITY = { orgId: "test-org", userId: "test-user", runId: "test-run" };
+  const IDENTITY = undefined; // Platform-level upgrades don't pass identity
   const METADATA = {
     category: "sales",
     channel: "email",


### PR DESCRIPTION
## Summary
- **API Registry client**: identity headers now optional on all 4 functions — startup validator no longer sends synthetic identity
- **Key-service client**: new `fetchPlatformAnthropicKey()` calls `GET /keys/platform/anthropic/decrypt` with `x-caller-*` headers only (no org/user)
- **Runs-client**: new `createPlatformRun()` and `closePlatformRun()` call `/v1/platform-runs` endpoints with `x-service-name: workflow-service`
- **Startup validator**: removed `PLATFORM_IDENTITY` constant, `PLATFORM_ANTHROPIC_API_KEY` env var, added run tracking for upgrade operations
- **Workflow upgrader**: identity parameter now optional for platform-level calls
- **Email notifications**: use `x-service-name` header instead of synthetic identity

## Removed workarounds (from PR #81)
1. ~~Synthetic `PLATFORM_IDENTITY` for API Registry calls~~ → identity omitted (API Registry no longer requires it)
2. ~~`PLATFORM_ANTHROPIC_API_KEY` env var~~ → `fetchPlatformAnthropicKey()` via key-service
3. ~~No run tracking~~ → `createPlatformRun()`/`closePlatformRun()` via runs-service

## Test plan
- [x] 298 tests passing (9 new tests for platform functions)
- [x] TypeScript strict mode passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)