### PR TITLE
fix: prevent startup-validator from mass-deprecating workflows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ if (process.env.NODE_ENV !== "test") {
         // Run startup validation non-blocking (after server is accepting requests)
         if (process.env.API_REGISTRY_SERVICE_URL && process.env.API_REGISTRY_SERVICE_API_KEY) {
           validateAndUpgradeWorkflows({ db, windmillClient }).catch((err) => {
-            console.error("[startup] Workflow validation failed:", err);
+            console.error("[workflow-service] Workflow validation failed:", err);
           });
         }
       });

--- a/src/lib/job-poller.ts
+++ b/src/lib/job-poller.ts
@@ -16,7 +16,7 @@ export class JobPoller {
 
   start(): void {
     if (this.intervalId) return;
-    console.log(`[JobPoller] Starting (every ${this.pollIntervalMs}ms)`);
+    console.log(`[workflow-service] JobPoller starting (every ${this.pollIntervalMs}ms)`);
     this.intervalId = setInterval(() => this.poll(), this.pollIntervalMs);
   }
 
@@ -24,7 +24,7 @@ export class JobPoller {
     if (this.intervalId) {
       clearInterval(this.intervalId);
       this.intervalId = null;
-      console.log("[JobPoller] Stopped");
+      console.log("[workflow-service] JobPoller stopped");
     }
   }
 
@@ -54,12 +54,12 @@ export class JobPoller {
               .set({
                 status: newStatus,
                 result: success ? job.result : null,
-                error: success ? null : String(job.result ?? "Unknown error"),
+                error: success ? null : (typeof job.result === "string" ? job.result : JSON.stringify(job.result ?? "Unknown error")),
                 completedAt: new Date(),
               })
               .where(eq(table.id, run.id));
 
-            console.log(`[JobPoller] Run ${run.id} → ${newStatus}`);
+            console.log(`[workflow-service] JobPoller: run ${run.id} → ${newStatus}`);
           } else if (run.status === "queued") {
             await this.db
               .update(table)
@@ -71,13 +71,13 @@ export class JobPoller {
           }
         } catch (err) {
           console.error(
-            `[JobPoller] Error polling job ${run.windmillJobId}:`,
+            `[workflow-service] Error polling job ${run.windmillJobId}:`,
             err
           );
         }
       }
     } catch (err) {
-      console.error("[JobPoller] Error fetching active runs:", err);
+      console.error("[workflow-service] Error fetching active runs:", err);
     } finally {
       this.isPolling = false;
     }

--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -46,7 +46,7 @@ export async function validateAndUpgradeWorkflows(
     .where(eq(workflows.status, "active"));
 
   if (activeWorkflows.length === 0) {
-    console.log("[startup] No active workflows to validate");
+    console.log("[workflow-service] No active workflows to validate");
     return;
   }
 
@@ -77,7 +77,7 @@ export async function validateAndUpgradeWorkflows(
     }
 
     console.warn(
-      `[startup] Workflow "${wf.name}" (${wf.id}) has ${result.invalidEndpoints.length} broken endpoint(s):`,
+      `[workflow-service] Workflow "${wf.name}" (${wf.id}) has ${result.invalidEndpoints.length} broken endpoint(s):`,
       result.invalidEndpoints.map((ep) => `${ep.method} ${ep.service}${ep.path}`).join(", "),
     );
 
@@ -94,21 +94,20 @@ export async function validateAndUpgradeWorkflows(
       if (upgraded) {
         upgradedCount++;
         console.log(
-          `[startup] Workflow "${wf.name}" upgraded successfully -> new ID: ${upgraded}`,
+          `[workflow-service] Workflow "${wf.name}" upgraded successfully -> new ID: ${upgraded}`,
         );
       } else {
-        // Upgrade skipped (no Anthropic key available)
+        // Upgrade skipped (no Anthropic key available) — keep workflow active
         failedCount++;
-        await deprecateWorkflow(database, wf.id, null);
         console.warn(
-          `[startup] Workflow "${wf.name}" deprecated (upgrade skipped: platform key not available)`,
+          `[workflow-service] Workflow "${wf.name}" has broken endpoints but upgrade skipped (platform key not available) — keeping active`,
         );
       }
     } catch (err) {
+      // Upgrade failed — keep workflow active rather than breaking all campaigns
       failedCount++;
-      await deprecateWorkflow(database, wf.id, null);
       console.error(
-        `[startup] Workflow "${wf.name}" upgrade failed, deprecated:`,
+        `[workflow-service] Workflow "${wf.name}" upgrade failed — keeping active:`,
         err instanceof Error ? err.message : err,
       );
     }
@@ -118,12 +117,12 @@ export async function validateAndUpgradeWorkflows(
       await sendAdminNotification(wf, result.invalidEndpoints, upgradedCount > failedCount);
     } catch {
       // Non-blocking — log and continue
-      console.warn(`[startup] Failed to send admin notification for "${wf.name}"`);
+      console.warn(`[workflow-service] Failed to send admin notification for "${wf.name}"`);
     }
   }
 
   console.log(
-    `[startup] Validated ${activeWorkflows.length} workflows: ${validCount} valid, ${upgradedCount} upgraded, ${failedCount} failed`,
+    `[workflow-service] Validated ${activeWorkflows.length} workflows: ${validCount} valid, ${upgradedCount} upgraded, ${failedCount} failed`,
   );
 }
 
@@ -141,7 +140,7 @@ async function attemptUpgrade(
     anthropicApiKey = keyResult.key;
   } catch (err) {
     console.warn(
-      "[startup] Platform Anthropic key not available — upgrade skipped:",
+      "[workflow-service] Platform Anthropic key not available — upgrade skipped:",
       err instanceof Error ? err.message : err,
     );
     return null;
@@ -158,7 +157,7 @@ async function attemptUpgrade(
     platformRunId = run.runId;
   } catch (err) {
     console.warn(
-      "[startup] Failed to create platform run — continuing without tracking:",
+      "[workflow-service] Failed to create platform run — continuing without tracking:",
       err instanceof Error ? err.message : err,
     );
   }
@@ -205,7 +204,7 @@ async function attemptUpgrade(
         });
         windmillFlowPath = flowPath;
       } catch (err) {
-        console.error("[startup] Failed to create upgraded flow in Windmill:", err);
+        console.error("[workflow-service] Failed to create upgraded flow in Windmill:", err);
       }
     }
 

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -40,6 +40,9 @@ router.post(
         );
 
       if (!workflow) {
+        console.warn(
+          `[workflow-service] Execute by name: workflow "${req.params.name}" not found (no active workflow with this name)`,
+        );
         res.status(404).json({
           error: `Workflow "${req.params.name}" not found`,
         });
@@ -68,7 +71,7 @@ router.post(
         });
         ownRunId = newRunId;
       } catch (err) {
-        console.error("[workflow-runs] Failed to create run in runs-service:", err);
+        console.error("[workflow-service] Failed to create run in runs-service:", err);
         res.status(502).json({ error: "Failed to create run in runs-service" });
         return;
       }
@@ -85,7 +88,7 @@ router.post(
           );
         } catch (err) {
           console.error(
-            "[workflow-runs] Failed to run flow in Windmill:",
+            "[workflow-service] Failed to run flow in Windmill:",
             err
           );
           res
@@ -112,13 +115,17 @@ router.post(
         })
         .returning();
 
+      console.log(
+        `[workflow-service] Workflow "${workflow.name}" execution started: runId=${ownRunId}, windmillJobId=${windmillJobId ?? "none"}`,
+      );
+
       res.status(201).json(formatRun(run));
     } catch (err: unknown) {
       if (err instanceof Error && err.name === "ZodError") {
         res.status(400).json({ error: "Validation error", details: err });
         return;
       }
-      console.error("[workflow-runs] POST execute-by-name error:", err);
+      console.error("[workflow-service] POST execute-by-name error:", err);
       res.status(500).json({ error: "Internal server error" });
     }
   }
@@ -167,7 +174,7 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
       });
       ownRunId = newRunId;
     } catch (err) {
-      console.error("[workflow-runs] Failed to create run in runs-service:", err);
+      console.error("[workflow-service] Failed to create run in runs-service:", err);
       res.status(502).json({ error: "Failed to create run in runs-service" });
       return;
     }
@@ -183,7 +190,7 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
           flowInputs
         );
       } catch (err) {
-        console.error("[workflow-runs] Failed to run flow in Windmill:", err);
+        console.error("[workflow-service] Failed to run flow in Windmill:", err);
         res
           .status(502)
           .json({ error: "Failed to start workflow in Windmill" });
@@ -214,7 +221,7 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
       res.status(400).json({ error: "Validation error", details: err });
       return;
     }
-    console.error("[workflow-runs] POST execute error:", err);
+    console.error("[workflow-service] POST execute error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -271,7 +278,7 @@ router.get("/workflow-runs/:id", requireApiKey, async (req, res) => {
         }
       } catch (err) {
         console.error(
-          "[workflow-runs] Failed to poll Windmill job:",
+          "[workflow-service] Failed to poll Windmill job:",
           err
         );
         // Return what we have in DB
@@ -280,7 +287,7 @@ router.get("/workflow-runs/:id", requireApiKey, async (req, res) => {
 
     res.json(formatRun(run));
   } catch (err) {
-    console.error("[workflow-runs] GET by id error:", err);
+    console.error("[workflow-service] GET by id error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -315,7 +322,7 @@ router.get("/workflow-runs", requireApiKey, async (req, res) => {
 
     res.json({ workflowRuns: results.map(formatRun) });
   } catch (err) {
-    console.error("[workflow-runs] GET list error:", err);
+    console.error("[workflow-service] GET list error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -354,7 +361,7 @@ router.get("/workflow-runs/:id/debug", requireApiKey, async (req, res) => {
       result: job.result ?? null,
     });
   } catch (err) {
-    console.error("[workflow-runs] GET debug error:", err);
+    console.error("[workflow-service] GET debug error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -384,7 +391,7 @@ router.post("/workflow-runs/:id/cancel", requireApiKey, async (req, res) => {
         try {
           await cancelClient.cancelJob(run.windmillJobId, "Cancelled by user");
         } catch (err) {
-          console.error("[workflow-runs] Failed to cancel Windmill job:", err);
+          console.error("[workflow-service] Failed to cancel Windmill job:", err);
         }
       }
     }
@@ -397,7 +404,7 @@ router.post("/workflow-runs/:id/cancel", requireApiKey, async (req, res) => {
 
     res.json(formatRun(updated));
   } catch (err) {
-    console.error("[workflow-runs] POST cancel error:", err);
+    console.error("[workflow-service] POST cancel error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -104,7 +104,7 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
             schema: openFlow.schema,
           });
         } catch (err) {
-          console.error("[workflows] generate: failed to update Windmill flow:", err);
+          console.error("[workflow-service] generate: failed to update Windmill flow:", err);
         }
       }
 
@@ -186,7 +186,7 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
             schema: openFlow.schema,
           });
         } catch (err) {
-          console.error("[workflows] generate: failed to create Windmill flow:", err);
+          console.error("[workflow-service] generate: failed to create Windmill flow:", err);
         }
       }
 
@@ -246,7 +246,7 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
       return;
     }
     if (err instanceof Error && err.message.startsWith("key-service error:")) {
-      console.error("[workflows] generate: key-service error:", err.message);
+      console.error("[workflow-service] generate: key-service error:", err.message);
       res.status(502).json({ error: err.message });
       return;
     }
@@ -254,7 +254,7 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
       res.status(502).json({ error: err.message });
       return;
     }
-    console.error("[workflows] GENERATE error:", err);
+    console.error("[workflow-service] GENERATE error:", err);
     res.status(500).json({
       error: err instanceof Error ? err.message : "Internal server error",
     });
@@ -291,7 +291,7 @@ router.post("/workflows", requireApiKey, async (req, res) => {
           schema: openFlow.schema,
         });
       } catch (err) {
-        console.error("[workflows] Failed to create flow in Windmill:", err);
+        console.error("[workflow-service] Failed to create flow in Windmill:", err);
       }
     }
 
@@ -333,7 +333,7 @@ router.post("/workflows", requireApiKey, async (req, res) => {
       res.status(400).json({ error: "Validation error", details: err });
       return;
     }
-    console.error("[workflows] POST error:", err);
+    console.error("[workflow-service] POST error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -396,7 +396,7 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
               schema: openFlow.schema,
             });
           } catch (err) {
-            console.error("[workflows] deploy: failed to update Windmill flow:", err);
+            console.error("[workflow-service] deploy: failed to update Windmill flow:", err);
           }
         }
 
@@ -447,7 +447,7 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
               schema: openFlow.schema,
             });
           } catch (err) {
-            console.error("[workflows] deploy: failed to create Windmill flow:", err);
+            console.error("[workflow-service] deploy: failed to create Windmill flow:", err);
           }
         }
 
@@ -491,7 +491,7 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
       res.status(400).json({ error: "Validation error", details: err });
       return;
     }
-    console.error("[workflows] PUT deploy error:", err);
+    console.error("[workflow-service] PUT deploy error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -644,11 +644,11 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
         err.message.includes("EMAIL_GATEWAY_SERVICE_URL") ||
         err.message.startsWith("email-gateway-service error:"))
     ) {
-      console.error("[workflows] best: external service error:", err.message);
+      console.error("[workflow-service] best: external service error:", err.message);
       res.status(502).json({ error: err.message });
       return;
     }
-    console.error("[workflows] GET best error:", err);
+    console.error("[workflow-service] GET best error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -696,7 +696,7 @@ router.get("/workflows", requireApiKey, async (req, res) => {
 
     res.json({ workflows: results.map(formatWorkflow) });
   } catch (err) {
-    console.error("[workflows] GET list error:", err);
+    console.error("[workflow-service] GET list error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -716,7 +716,7 @@ router.get("/workflows/:id", requireApiKey, async (req, res) => {
 
     res.json(formatWorkflow(workflow));
   } catch (err) {
-    console.error("[workflows] GET by id error:", err);
+    console.error("[workflow-service] GET by id error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -757,7 +757,7 @@ router.get("/workflows/:id/required-providers", requireApiKey, async (req, res) 
     });
   } catch (err) {
     if (err instanceof Error && err.message.startsWith("key-service error:")) {
-      console.error("[workflows] required-providers: key-service error:", err.message);
+      console.error("[workflow-service] required-providers: key-service error:", err.message);
       res.status(502).json({ error: err.message });
       return;
     }
@@ -765,7 +765,7 @@ router.get("/workflows/:id/required-providers", requireApiKey, async (req, res) 
       res.status(502).json({ error: err.message });
       return;
     }
-    console.error("[workflows] required-providers error:", err);
+    console.error("[workflow-service] required-providers error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -818,7 +818,7 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
             });
           } catch (err) {
             console.error(
-              "[workflows] Failed to update flow in Windmill:",
+              "[workflow-service] Failed to update flow in Windmill:",
               err
             );
           }
@@ -838,7 +838,7 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
       res.status(400).json({ error: "Validation error", details: err });
       return;
     }
-    console.error("[workflows] PUT error:", err);
+    console.error("[workflow-service] PUT error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -864,7 +864,7 @@ router.delete("/workflows/:id", requireApiKey, async (req, res) => {
           await client.deleteFlow(existing.windmillFlowPath);
         } catch (err) {
           console.error(
-            "[workflows] Failed to delete flow in Windmill:",
+            "[workflow-service] Failed to delete flow in Windmill:",
             err
           );
         }
@@ -877,7 +877,7 @@ router.delete("/workflows/:id", requireApiKey, async (req, res) => {
 
     res.json({ message: "Workflow deleted" });
   } catch (err) {
-    console.error("[workflows] DELETE error:", err);
+    console.error("[workflow-service] DELETE error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -898,7 +898,7 @@ router.post("/workflows/:id/validate", requireApiKey, async (req, res) => {
     const validation = validateDAG(workflow.dag as DAG);
     res.json(validation);
   } catch (err) {
-    console.error("[workflows] VALIDATE error:", err);
+    console.error("[workflow-service] VALIDATE error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/tests/unit/job-poller.test.ts
+++ b/tests/unit/job-poller.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// We need to mock drizzle operators since they're used internally
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col: unknown, val: unknown) => ({ col, val, op: "eq" })),
+  inArray: vi.fn((col: unknown, vals: unknown[]) => ({ col, vals, op: "inArray" })),
+}));
+
+vi.mock("../../src/db/index.js", () => ({
+  db: "mock-db",
+  sql: { end: () => Promise.resolve() },
+}));
+
+import { JobPoller } from "../../src/lib/job-poller.js";
+
+describe("JobPoller error serialization", () => {
+  let dbSetCalls: Array<Record<string, unknown>>;
+  let mockGetJob: ReturnType<typeof vi.fn>;
+
+  function createMockDb(runs: Array<Record<string, unknown>>) {
+    dbSetCalls = [];
+    return {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve(runs),
+        }),
+      }),
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          dbSetCalls.push(values);
+          return {
+            where: () => Promise.resolve(),
+          };
+        },
+      }),
+    };
+  }
+
+  function createMockWindmillClient() {
+    mockGetJob = vi.fn();
+    return { getJob: mockGetJob } as any;
+  }
+
+  const mockTable = {
+    status: "status",
+    id: "id",
+  };
+
+  beforeEach(() => {
+    dbSetCalls = [];
+  });
+
+  it("serializes object errors as JSON instead of [object Object]", async () => {
+    const errorResult = { message: "Node gate-check failed", code: 500, details: { step: "gate-check" } };
+    const runs = [{ id: "run-1", windmillJobId: "job-1", status: "running" }];
+    const mockDb = createMockDb(runs);
+    const mockClient = createMockWindmillClient();
+    mockGetJob.mockResolvedValue({ running: false, success: false, result: errorResult });
+
+    const poller = new JobPoller(mockDb, mockClient, mockTable, 60_000);
+
+    // Directly call the private poll method via start + immediate trigger
+    // Instead, we access poll directly for testing
+    const pollMethod = (poller as any).poll.bind(poller);
+    await pollMethod();
+
+    expect(dbSetCalls.length).toBe(1);
+    expect(dbSetCalls[0].status).toBe("failed");
+    expect(dbSetCalls[0].error).toBe(JSON.stringify(errorResult));
+    // Must NOT be [object Object]
+    expect(dbSetCalls[0].error).not.toBe("[object Object]");
+  });
+
+  it("preserves string errors as-is", async () => {
+    const runs = [{ id: "run-2", windmillJobId: "job-2", status: "running" }];
+    const mockDb = createMockDb(runs);
+    const mockClient = createMockWindmillClient();
+    mockGetJob.mockResolvedValue({ running: false, success: false, result: "Simple error message" });
+
+    const poller = new JobPoller(mockDb, mockClient, mockTable, 60_000);
+    const pollMethod = (poller as any).poll.bind(poller);
+    await pollMethod();
+
+    expect(dbSetCalls.length).toBe(1);
+    expect(dbSetCalls[0].error).toBe("Simple error message");
+  });
+
+  it("handles null/undefined error results", async () => {
+    const runs = [{ id: "run-3", windmillJobId: "job-3", status: "queued" }];
+    const mockDb = createMockDb(runs);
+    const mockClient = createMockWindmillClient();
+    mockGetJob.mockResolvedValue({ running: false, success: false, result: null });
+
+    const poller = new JobPoller(mockDb, mockClient, mockTable, 60_000);
+    const pollMethod = (poller as any).poll.bind(poller);
+    await pollMethod();
+
+    expect(dbSetCalls.length).toBe(1);
+    expect(dbSetCalls[0].error).toBe('"Unknown error"');
+  });
+});

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -227,7 +227,7 @@ describe("validateAndUpgradeWorkflows", () => {
     consoleSpy.mockRestore();
   });
 
-  it("deprecates broken workflow when platform key not available", async () => {
+  it("keeps broken workflow active when platform key not available", async () => {
     dbSelectResult = [BROKEN_WORKFLOW];
     mockFetchSpecsForServices.mockResolvedValue(
       new Map([["campaign", CAMPAIGN_SPEC]]),
@@ -241,12 +241,14 @@ describe("validateAndUpgradeWorkflows", () => {
       windmillClient: null,
     });
 
-    // Should have called update to deprecate
-    expect(dbUpdates.length).toBeGreaterThan(0);
-    expect(dbUpdates[0].values).toMatchObject({
-      status: "deprecated",
-      upgradedTo: null,
-    });
+    // Should NOT deprecate — no DB updates to set status deprecated
+    const deprecations = dbUpdates.filter((u) => u.values.status === "deprecated");
+    expect(deprecations.length).toBe(0);
+
+    // Should warn about the broken endpoints
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("keeping active"),
+    );
 
     consoleSpy.mockRestore();
   });
@@ -328,12 +330,12 @@ describe("validateAndUpgradeWorkflows", () => {
     });
 
     expect(consoleSpy).toHaveBeenCalledWith(
-      "[startup] No active workflows to validate",
+      "[workflow-service] No active workflows to validate",
     );
     consoleSpy.mockRestore();
   });
 
-  it("closes platform run as failed when upgrade throws", async () => {
+  it("closes platform run as failed when upgrade throws but keeps workflow active", async () => {
     dbSelectResult = [BROKEN_WORKFLOW];
     mockFetchSpecsForServices.mockResolvedValue(
       new Map([["campaign", CAMPAIGN_SPEC]]),
@@ -351,8 +353,8 @@ describe("validateAndUpgradeWorkflows", () => {
     // Should have closed the platform run as failed
     expect(mockClosePlatformRun).toHaveBeenCalledWith("platform-run-456", "failed");
 
-    // Should have deprecated the workflow
-    expect(dbUpdates.length).toBeGreaterThan(0);
-    expect(dbUpdates[0].values.status).toBe("deprecated");
+    // Should NOT deprecate the workflow — keep it active
+    const deprecations = dbUpdates.filter((u) => u.values.status === "deprecated");
+    expect(deprecations.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- **Root cause**: The self-healing startup validator (commit a03cef8) was deprecating all 13 workflows when the platform Anthropic key was unavailable, leaving zero active workflows. Campaign executions then failed with 404 ("workflow not found") because the execute endpoint filters on `status = "active"`.
- **Fix**: Workflows now stay active when upgrade cannot be performed (no key or upgrade failure). Only deprecate when a replacement is successfully created.
- **Error serialization**: Fixed `String(errorObject)` → `JSON.stringify()` in job-poller to prevent `[object Object]` being stored instead of actual error details.
- **Logging**: Unified all log prefixes to `[workflow-service]` for easier debugging in shared Railway logs. Added execution-path logging (workflow not found, execution started).
- **DB fix applied**: Re-activated all 13 deprecated workflows directly in production DB.

## Test plan
- [x] Updated startup-validator tests: verify workflows stay active when upgrade fails
- [x] New job-poller unit test: verify error objects are serialized as JSON
- [x] All 301 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)