### PR TITLE
fix: crash at startup when workflows are broken and unfixable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,15 +61,13 @@ if (process.env.NODE_ENV !== "test") {
         console.log("Windmill not configured (WINDMILL_SERVER_URL / WINDMILL_SERVER_API_KEY missing) — job poller disabled");
       }
 
+      // Validate workflows before accepting traffic — crash if broken and unfixable
+      if (process.env.API_REGISTRY_SERVICE_URL && process.env.API_REGISTRY_SERVICE_API_KEY) {
+        await validateAndUpgradeWorkflows({ db, windmillClient });
+      }
+
       app.listen(Number(PORT), "::", () => {
         console.log(`workflow-service running on port ${PORT}`);
-
-        // Run startup validation non-blocking (after server is accepting requests)
-        if (process.env.API_REGISTRY_SERVICE_URL && process.env.API_REGISTRY_SERVICE_API_KEY) {
-          validateAndUpgradeWorkflows({ db, windmillClient }).catch((err) => {
-            console.error("[workflow-service] Workflow validation failed:", err);
-          });
-        }
       });
     } catch (err) {
       console.error("Startup failed:", err);

--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -32,7 +32,9 @@ export async function checkApiRegistryHealth(): Promise<void> {
 
 /**
  * Validate all active workflows against the API Registry.
- * Deprecates workflows with broken endpoints and attempts LLM-powered upgrade.
+ * Attempts LLM-powered upgrade for broken workflows.
+ * Throws if any workflow has broken endpoints that cannot be fixed — the service
+ * should crash at startup rather than silently running with broken workflows.
  */
 export async function validateAndUpgradeWorkflows(
   deps: StartupValidatorDeps,
@@ -124,6 +126,12 @@ export async function validateAndUpgradeWorkflows(
   console.log(
     `[workflow-service] Validated ${activeWorkflows.length} workflows: ${validCount} valid, ${upgradedCount} upgraded, ${failedCount} failed`,
   );
+
+  if (failedCount > 0) {
+    throw new Error(
+      `[workflow-service] ${failedCount} workflow(s) have broken endpoints that could not be auto-upgraded. Fix the workflows or provide the platform Anthropic key, then restart.`,
+    );
+  }
 }
 
 async function attemptUpgrade(

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -227,30 +227,24 @@ describe("validateAndUpgradeWorkflows", () => {
     consoleSpy.mockRestore();
   });
 
-  it("keeps broken workflow active when platform key not available", async () => {
+  it("throws when broken workflow cannot be upgraded (no platform key)", async () => {
     dbSelectResult = [BROKEN_WORKFLOW];
     mockFetchSpecsForServices.mockResolvedValue(
       new Map([["campaign", CAMPAIGN_SPEC]]),
     );
     mockFetchPlatformAnthropicKey.mockRejectedValue(new Error("key not found"));
 
-    const consoleSpy = vi.spyOn(console, "warn");
-
-    await validateAndUpgradeWorkflows({
-      db: createMockDb() as any,
-      windmillClient: null,
-    });
+    // Should throw to crash the service at startup
+    await expect(
+      validateAndUpgradeWorkflows({
+        db: createMockDb() as any,
+        windmillClient: null,
+      }),
+    ).rejects.toThrow("workflow(s) have broken endpoints that could not be auto-upgraded");
 
     // Should NOT deprecate — no DB updates to set status deprecated
     const deprecations = dbUpdates.filter((u) => u.values.status === "deprecated");
     expect(deprecations.length).toBe(0);
-
-    // Should warn about the broken endpoints
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("keeping active"),
-    );
-
-    consoleSpy.mockRestore();
   });
 
   it("upgrades broken workflow using platform key and tracks run", async () => {
@@ -335,7 +329,7 @@ describe("validateAndUpgradeWorkflows", () => {
     consoleSpy.mockRestore();
   });
 
-  it("closes platform run as failed when upgrade throws but keeps workflow active", async () => {
+  it("throws when upgrade fails (LLM error) and closes platform run as failed", async () => {
     dbSelectResult = [BROKEN_WORKFLOW];
     mockFetchSpecsForServices.mockResolvedValue(
       new Map([["campaign", CAMPAIGN_SPEC]]),
@@ -345,15 +339,18 @@ describe("validateAndUpgradeWorkflows", () => {
     mockClosePlatformRun.mockResolvedValue(undefined);
     mockUpgradeWorkflow.mockRejectedValue(new Error("LLM error"));
 
-    await validateAndUpgradeWorkflows({
-      db: createMockDb() as any,
-      windmillClient: null,
-    });
+    // Should throw to crash the service at startup
+    await expect(
+      validateAndUpgradeWorkflows({
+        db: createMockDb() as any,
+        windmillClient: null,
+      }),
+    ).rejects.toThrow("workflow(s) have broken endpoints that could not be auto-upgraded");
 
     // Should have closed the platform run as failed
     expect(mockClosePlatformRun).toHaveBeenCalledWith("platform-run-456", "failed");
 
-    // Should NOT deprecate the workflow — keep it active
+    // Should NOT deprecate the workflow
     const deprecations = dbUpdates.filter((u) => u.values.status === "deprecated");
     expect(deprecations.length).toBe(0);
   });


### PR DESCRIPTION
## Summary
- Startup validator now **throws** (crashes the process) when workflows have broken endpoints that cannot be auto-upgraded, instead of silently continuing
- Validation runs **before** `app.listen()` so the service never accepts traffic in a degraded state
- Railway will auto-restart the service, making the issue immediately visible in logs
- Follows up on PR #83 which fixed the mass-deprecation bug

## Test plan
- [x] Updated tests: verify `validateAndUpgradeWorkflows` throws when upgrade fails
- [x] All 301 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)