### PR TITLE
fix: execute-by-name follows upgrade chain instead of 410

### DIFF
--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -29,7 +29,7 @@ router.post(
       const orgId = res.locals.orgId as string;
 
       // Look up workflow by name — only active workflows can be executed
-      const [workflow] = await db
+      let [workflow] = await db
         .select()
         .from(workflows)
         .where(
@@ -40,36 +40,60 @@ router.post(
         );
 
       if (!workflow) {
-        // Check if deprecated — return 410 with upgrade info instead of 404
+        // Check if deprecated — follow upgrade chain to find active replacement
         const [deprecated] = await db
           .select()
           .from(workflows)
           .where(eq(workflows.name, req.params.name));
 
         if (deprecated && deprecated.status === "deprecated") {
-          let upgradedToName: string | null = null;
-          if (deprecated.upgradedTo) {
-            const [replacement] = await db
+          // Follow upgrade chain to the latest active version
+          let currentId = deprecated.upgradedTo;
+          let depth = 0;
+          while (currentId && depth < 10) {
+            const [candidate] = await db
               .select()
               .from(workflows)
-              .where(eq(workflows.id, deprecated.upgradedTo));
-            upgradedToName = replacement?.name ?? null;
+              .where(eq(workflows.id, currentId));
+
+            if (!candidate) break;
+            if (candidate.status === "active") {
+              workflow = candidate;
+              console.log(
+                `[workflow-service] Execute by name: "${req.params.name}" is deprecated, following upgrade chain to "${candidate.name}" (${candidate.id})`,
+              );
+              break;
+            }
+            currentId = candidate.upgradedTo;
+            depth++;
           }
-          res.status(410).json({
-            error: "Workflow has been deprecated",
-            upgradedTo: deprecated.upgradedTo,
-            upgradedToName,
+
+          if (!workflow) {
+            // Dead end — no active workflow at the end of the chain
+            let upgradedToName: string | null = null;
+            if (deprecated.upgradedTo) {
+              const [replacement] = await db
+                .select()
+                .from(workflows)
+                .where(eq(workflows.id, deprecated.upgradedTo));
+              upgradedToName = replacement?.name ?? null;
+            }
+            res.status(410).json({
+              error: "Workflow has been deprecated",
+              upgradedTo: deprecated.upgradedTo,
+              upgradedToName,
+            });
+            return;
+          }
+        } else {
+          console.warn(
+            `[workflow-service] Execute by name: workflow "${req.params.name}" not found (no active workflow with this name)`,
+          );
+          res.status(404).json({
+            error: `Workflow "${req.params.name}" not found`,
           });
           return;
         }
-
-        console.warn(
-          `[workflow-service] Execute by name: workflow "${req.params.name}" not found (no active workflow with this name)`,
-        );
-        res.status(404).json({
-          error: `Workflow "${req.params.name}" not found`,
-        });
-        return;
       }
 
       if (!workflow.windmillFlowPath) {

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -390,7 +390,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
     expect(res.body.error).toContain("nonexistent");
   });
 
-  it("returns 410 when workflow is deprecated (with replacement info)", async () => {
+  it("follows upgrade chain and executes active replacement", async () => {
     mockSelectResponses.push(
       [],  // 1. active-only lookup → not found
       [{   // 2. any-status lookup → deprecated workflow
@@ -399,8 +399,13 @@ describe("POST /workflows/by-name/:name/execute", () => {
         status: "deprecated",
         upgradedTo: "wf-new",
       }],
-      [{   // 3. replacement name lookup
+      [{   // 3. chain follow: replacement is active → execute it
+        id: "wf-new",
         name: "replacement-flow",
+        status: "active",
+        windmillFlowPath: "f/workflows/org_1/replacement_flow",
+        windmillWorkspace: "prod",
+        dag: VALID_LINEAR_DAG,
       }],
     );
 
@@ -409,13 +414,53 @@ describe("POST /workflows/by-name/:name/execute", () => {
       .set(AUTH)
       .send({ inputs: {} });
 
-    expect(res.status).toBe(410);
-    expect(res.body.error).toBe("Workflow has been deprecated");
-    expect(res.body.upgradedTo).toBe("wf-new");
-    expect(res.body.upgradedToName).toBe("replacement-flow");
+    expect(res.status).toBe(201);
+    expect(res.body.status).toBe("queued");
+    expect(mockRunFlow).toHaveBeenCalledWith(
+      "f/workflows/org_1/replacement_flow",
+      expect.objectContaining({ orgId: "org-1" }),
+    );
   });
 
-  it("returns 410 with null upgradedTo when deprecated workflow has no replacement", async () => {
+  it("follows multi-hop upgrade chain to active version", async () => {
+    mockSelectResponses.push(
+      [],  // 1. active-only lookup → not found
+      [{   // 2. any-status lookup → deprecated v1
+        id: "wf-v1",
+        name: "old-flow",
+        status: "deprecated",
+        upgradedTo: "wf-v2",
+      }],
+      [{   // 3. chain hop 1: v2 is also deprecated
+        id: "wf-v2",
+        name: "mid-flow",
+        status: "deprecated",
+        upgradedTo: "wf-v3",
+      }],
+      [{   // 4. chain hop 2: v3 is active → execute it
+        id: "wf-v3",
+        name: "current-flow",
+        status: "active",
+        windmillFlowPath: "f/workflows/org_1/current_flow",
+        windmillWorkspace: "prod",
+        dag: VALID_LINEAR_DAG,
+      }],
+    );
+
+    const res = await request
+      .post("/workflows/by-name/old-flow/execute")
+      .set(AUTH)
+      .send({ inputs: { key: "value" } });
+
+    expect(res.status).toBe(201);
+    expect(res.body.status).toBe("queued");
+    expect(mockRunFlow).toHaveBeenCalledWith(
+      "f/workflows/org_1/current_flow",
+      expect.objectContaining({ orgId: "org-1", key: "value" }),
+    );
+  });
+
+  it("returns 410 when upgrade chain ends without active workflow", async () => {
     mockSelectResponses.push(
       [],  // 1. active-only lookup → not found
       [{   // 2. any-status lookup → deprecated, no replacement
@@ -435,6 +480,31 @@ describe("POST /workflows/by-name/:name/execute", () => {
     expect(res.body.error).toBe("Workflow has been deprecated");
     expect(res.body.upgradedTo).toBeNull();
     expect(res.body.upgradedToName).toBeNull();
+  });
+
+  it("returns 410 when upgrade chain points to missing workflow", async () => {
+    mockSelectResponses.push(
+      [],  // 1. active-only lookup → not found
+      [{   // 2. any-status lookup → deprecated with upgradedTo
+        id: "wf-old",
+        name: "orphan-flow",
+        status: "deprecated",
+        upgradedTo: "wf-missing",
+      }],
+      [],  // 3. chain follow: replacement not found → dead end
+      [{   // 4. 410 replacement name lookup → not found
+        // empty — replacement doesn't exist
+      }],
+    );
+
+    const res = await request
+      .post("/workflows/by-name/orphan-flow/execute")
+      .set(AUTH)
+      .send({ inputs: {} });
+
+    expect(res.status).toBe(410);
+    expect(res.body.error).toBe("Workflow has been deprecated");
+    expect(res.body.upgradedTo).toBe("wf-missing");
   });
 
   it("requires authentication", async () => {


### PR DESCRIPTION
## Summary
- When executing a deprecated workflow by name, the endpoint now follows the `upgradedTo` chain (up to 10 hops) to find the latest active version and executes it transparently
- Only returns 410 when the chain has no active workflow at the end (dead end or missing replacement)
- Fixes broken campaign executions caused by the old dimension-based deprecation (#86) which linked workflows with different names (e.g. `pharaoh` → `solstice`)

## Test plan
- [x] Test: follows single-hop upgrade chain and executes active replacement (201)
- [x] Test: follows multi-hop upgrade chain (v1→v2→v3) to active version (201)
- [x] Test: returns 410 when chain ends without active workflow (null upgradedTo)
- [x] Test: returns 410 when chain points to missing workflow
- [x] All 309 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)