### PR TITLE
feat: deploy logging + body field validation against API registry

### DIFF
--- a/src/lib/openapi-schema-resolver.ts
+++ b/src/lib/openapi-schema-resolver.ts
@@ -1,0 +1,164 @@
+export interface ResolvedSchema {
+  properties: Record<string, unknown>;
+  required: string[];
+}
+
+/**
+ * Resolves a JSON Schema that may contain $ref pointers within an OpenAPI spec.
+ * Handles $ref, allOf, oneOf, anyOf by merging all variants' properties.
+ * Returns null if the schema has no properties (primitive, array, etc.).
+ */
+export function resolveSchema(
+  schema: Record<string, unknown>,
+  spec: Record<string, unknown>,
+  depth = 0,
+): ResolvedSchema | null {
+  if (depth > 10) return null;
+
+  // Follow $ref
+  if (typeof schema.$ref === "string") {
+    const resolved = followRef(schema.$ref, spec);
+    if (!resolved) return null;
+    return resolveSchema(resolved, spec, depth + 1);
+  }
+
+  // Handle allOf — merge all sub-schemas
+  if (Array.isArray(schema.allOf)) {
+    const merged: ResolvedSchema = { properties: {}, required: [] };
+    for (const sub of schema.allOf) {
+      if (typeof sub !== "object" || sub === null) continue;
+      const resolved = resolveSchema(sub as Record<string, unknown>, spec, depth + 1);
+      if (resolved) {
+        Object.assign(merged.properties, resolved.properties);
+        merged.required.push(...resolved.required);
+      }
+    }
+    return Object.keys(merged.properties).length > 0 ? merged : null;
+  }
+
+  // Handle oneOf/anyOf — merge all variants to get the union of known fields
+  for (const combiner of ["oneOf", "anyOf"] as const) {
+    if (Array.isArray(schema[combiner])) {
+      const merged: ResolvedSchema = { properties: {}, required: [] };
+      for (const sub of schema[combiner] as unknown[]) {
+        if (typeof sub !== "object" || sub === null) continue;
+        const resolved = resolveSchema(sub as Record<string, unknown>, spec, depth + 1);
+        if (resolved) {
+          Object.assign(merged.properties, resolved.properties);
+          // Only keep required fields that appear in ALL variants
+        }
+      }
+      // Also merge direct properties if present
+      if (typeof schema.properties === "object" && schema.properties !== null) {
+        Object.assign(merged.properties, schema.properties);
+      }
+      return Object.keys(merged.properties).length > 0 ? merged : null;
+    }
+  }
+
+  // Direct schema with properties
+  if (typeof schema.properties === "object" && schema.properties !== null) {
+    return {
+      properties: schema.properties as Record<string, unknown>,
+      required: Array.isArray(schema.required) ? (schema.required as string[]) : [],
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Follows a JSON Pointer $ref like "#/components/schemas/Foo" within a spec.
+ */
+function followRef(
+  ref: string,
+  spec: Record<string, unknown>,
+): Record<string, unknown> | null {
+  if (!ref.startsWith("#/")) return null;
+  const parts = ref.slice(2).split("/");
+  let current: unknown = spec;
+  for (const part of parts) {
+    if (typeof current !== "object" || current === null) return null;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return typeof current === "object" && current !== null
+    ? (current as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Extracts the requestBody schema for an endpoint from an OpenAPI spec.
+ */
+export function getRequestBodySchema(
+  spec: Record<string, unknown>,
+  path: string,
+  method: string,
+): ResolvedSchema | null {
+  const paths = spec.paths as Record<string, Record<string, unknown>> | undefined;
+  if (!paths) return null;
+
+  const pathEntry = paths[path];
+  if (!pathEntry) return null;
+
+  const operation = pathEntry[method.toLowerCase()] as Record<string, unknown> | undefined;
+  if (!operation) return null;
+
+  const requestBody = operation.requestBody as Record<string, unknown> | undefined;
+  if (!requestBody) return null;
+
+  const content = requestBody.content as Record<string, Record<string, unknown>> | undefined;
+  if (!content) {
+    // Some specs put schema directly on requestBody (simplified format from api-registry)
+    if (requestBody.schema && typeof requestBody.schema === "object") {
+      return resolveSchema(requestBody.schema as Record<string, unknown>, spec);
+    }
+    return null;
+  }
+
+  const jsonContent = content["application/json"];
+  if (!jsonContent?.schema) return null;
+
+  return resolveSchema(jsonContent.schema as Record<string, unknown>, spec);
+}
+
+/**
+ * Extracts the success response schema for an endpoint from an OpenAPI spec.
+ * Tries 200, then 201, then 2xx.
+ */
+export function getResponseSchema(
+  spec: Record<string, unknown>,
+  path: string,
+  method: string,
+): ResolvedSchema | null {
+  const paths = spec.paths as Record<string, Record<string, unknown>> | undefined;
+  if (!paths) return null;
+
+  const pathEntry = paths[path];
+  if (!pathEntry) return null;
+
+  const operation = pathEntry[method.toLowerCase()] as Record<string, unknown> | undefined;
+  if (!operation) return null;
+
+  const responses = operation.responses as Record<string, Record<string, unknown>> | undefined;
+  if (!responses) return null;
+
+  for (const code of ["200", "201", "2xx"]) {
+    const response = responses[code];
+    if (!response) continue;
+
+    // Check for schema directly on response (simplified format)
+    if (response.schema && typeof response.schema === "object") {
+      return resolveSchema(response.schema as Record<string, unknown>, spec);
+    }
+
+    const content = response.content as Record<string, Record<string, unknown>> | undefined;
+    if (!content) continue;
+
+    const jsonContent = content["application/json"];
+    if (!jsonContent?.schema) continue;
+
+    return resolveSchema(jsonContent.schema as Record<string, unknown>, spec);
+  }
+
+  return null;
+}

--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -73,6 +73,13 @@ export async function validateAndUpgradeWorkflows(
     const dag = wf.dag as DAG;
     const result = validateWorkflowEndpoints(dag, specs);
 
+    if (result.fieldIssues.length > 0) {
+      console.warn(
+        `[workflow-service] Workflow "${wf.name}" (${wf.id}) has ${result.fieldIssues.length} field issue(s):`,
+        result.fieldIssues.map((f) => `${f.severity}: ${f.reason}`).join("; "),
+      );
+    }
+
     if (result.valid) {
       validCount++;
       continue;

--- a/src/lib/validate-workflow-endpoints.ts
+++ b/src/lib/validate-workflow-endpoints.ts
@@ -1,5 +1,6 @@
-import type { DAG } from "./dag-validator.js";
+import type { DAG, DAGNode } from "./dag-validator.js";
 import { extractHttpEndpoints } from "./extract-http-endpoints.js";
+import { getRequestBodySchema, getResponseSchema } from "./openapi-schema-resolver.js";
 
 export interface InvalidEndpoint {
   service: string;
@@ -8,14 +9,26 @@ export interface InvalidEndpoint {
   reason: string;
 }
 
+export interface FieldValidationIssue {
+  nodeId: string;
+  service: string;
+  method: string;
+  path: string;
+  field: string;
+  severity: "error" | "warning";
+  reason: string;
+}
+
 export interface EndpointValidationResult {
   valid: boolean;
   invalidEndpoints: InvalidEndpoint[];
+  fieldIssues: FieldValidationIssue[];
 }
 
 /**
  * Validates that every http.call endpoint in a DAG actually exists
- * in the corresponding service's OpenAPI spec.
+ * in the corresponding service's OpenAPI spec, and that body fields
+ * match the endpoint's request schema.
  */
 export function validateWorkflowEndpoints(
   dag: DAG,
@@ -63,8 +76,151 @@ export function validateWorkflowEndpoints(
     }
   }
 
+  // Second pass: field-level validation
+  const fieldIssues = validateFields(dag, specs);
+  const hasFieldErrors = fieldIssues.some((i) => i.severity === "error");
+
   return {
-    valid: invalidEndpoints.length === 0,
+    valid: invalidEndpoints.length === 0 && !hasFieldErrors,
     invalidEndpoints,
+    fieldIssues,
   };
+}
+
+/**
+ * Extracts the body field names a node will send to its endpoint.
+ * Sources: config.body (static keys) + inputMapping "body.*" keys.
+ */
+export function extractBodyFields(node: DAGNode): string[] {
+  const fields = new Set<string>();
+
+  // Static body fields from config.body
+  const body = node.config?.body;
+  if (body && typeof body === "object" && body !== null) {
+    for (const key of Object.keys(body as Record<string, unknown>)) {
+      fields.add(key);
+    }
+  }
+
+  // Dynamic body fields from inputMapping "body.*"
+  if (node.inputMapping) {
+    for (const key of Object.keys(node.inputMapping)) {
+      if (key.startsWith("body.")) {
+        // "body.campaignId" → "campaignId"
+        // "body.metadata.field" → "metadata" (top-level key only)
+        const rest = key.slice(5);
+        const topLevel = rest.split(".")[0];
+        if (topLevel) fields.add(topLevel);
+      }
+    }
+  }
+
+  return [...fields];
+}
+
+/**
+ * Finds all downstream $ref:nodeId.output.field references for a given source node.
+ */
+export function extractOutputRefs(
+  dag: DAG,
+  sourceNodeId: string,
+): Array<{ downstreamNodeId: string; field: string }> {
+  const refs: Array<{ downstreamNodeId: string; field: string }> = [];
+  const normalizedId = sourceNodeId.replace(/-/g, "_");
+  const hyphenId = sourceNodeId;
+
+  for (const node of dag.nodes) {
+    if (!node.inputMapping) continue;
+
+    for (const ref of Object.values(node.inputMapping)) {
+      if (typeof ref !== "string" || !ref.startsWith("$ref:")) continue;
+
+      const path = ref.replace("$ref:", "");
+      // Match both "node-id.output.field" and "node-id.field" patterns
+      const parts = path.split(".");
+      const refNodeId = parts[0];
+      if (refNodeId !== hyphenId && refNodeId !== normalizedId) continue;
+
+      // Skip "output" keyword, get the actual field name
+      const rest = parts.slice(1).filter((p) => p !== "output");
+      if (rest.length > 0) {
+        refs.push({ downstreamNodeId: node.id, field: rest[0] });
+      }
+      // If rest.length === 0, it's a whole-output reference — skip validation
+    }
+  }
+
+  return refs;
+}
+
+function validateFields(
+  dag: DAG,
+  specs: Map<string, Record<string, unknown>>,
+): FieldValidationIssue[] {
+  const issues: FieldValidationIssue[] = [];
+
+  for (const node of dag.nodes) {
+    if (node.type !== "http.call") continue;
+    if (!node.config) continue;
+
+    const { service, method, path } = node.config;
+    if (typeof service !== "string" || typeof method !== "string" || typeof path !== "string") continue;
+
+    const spec = specs.get(service);
+    if (!spec) continue; // Already reported as invalidEndpoint
+
+    // --- Input (body) field validation ---
+    // Skip if body is passed as a whole object (not field-by-field)
+    const hasWholeBodyMapping = node.inputMapping?.body !== undefined &&
+      typeof node.inputMapping.body === "string";
+
+    if (!hasWholeBodyMapping) {
+      const requestSchema = getRequestBodySchema(spec, path, method);
+      if (requestSchema) {
+        const bodyFields = extractBodyFields(node);
+
+        // Unknown body fields → warning
+        for (const field of bodyFields) {
+          if (!requestSchema.properties[field]) {
+            issues.push({
+              nodeId: node.id,
+              service, method, path, field,
+              severity: "warning",
+              reason: `Body field "${field}" not in ${service} ${method} ${path} schema (expected: ${Object.keys(requestSchema.properties).join(", ")})`,
+            });
+          }
+        }
+
+        // Missing required fields → error
+        for (const required of requestSchema.required) {
+          if (!bodyFields.includes(required)) {
+            issues.push({
+              nodeId: node.id,
+              service, method, path, field: required,
+              severity: "error",
+              reason: `Required field "${required}" missing from node "${node.id}" for ${service} ${method} ${path}`,
+            });
+          }
+        }
+      }
+    }
+
+    // --- Output field validation ---
+    const responseSchema = getResponseSchema(spec, path, method);
+    if (responseSchema) {
+      const outputRefs = extractOutputRefs(dag, node.id);
+      for (const ref of outputRefs) {
+        if (!responseSchema.properties[ref.field]) {
+          issues.push({
+            nodeId: node.id,
+            service, method, path, field: ref.field,
+            severity: "warning",
+            reason: `Output field "${ref.field}" referenced by "${ref.downstreamNodeId}" not in ${service} ${method} ${path} response schema`,
+          });
+        }
+      }
+    }
+  }
+
+  return issues;
 }

--- a/src/lib/workflow-generator.ts
+++ b/src/lib/workflow-generator.ts
@@ -8,7 +8,10 @@ import {
 import {
   fetchLlmContext,
   fetchServiceSpec,
+  fetchSpecsForServices,
 } from "./api-registry-client.js";
+import { extractHttpEndpoints } from "./extract-http-endpoints.js";
+import { validateWorkflowEndpoints } from "./validate-workflow-endpoints.js";
 import type { IdentityHeaders } from "./key-service-client.js";
 
 export interface GenerateWorkflowInput {
@@ -140,6 +143,56 @@ export async function generateWorkflow(
       const validation = validateDAG(result.dag);
 
       if (validation.valid) {
+        // Also validate endpoint fields against API registry
+        const httpEndpoints = extractHttpEndpoints(result.dag);
+        if (httpEndpoints.length > 0) {
+          try {
+            const serviceNames = [...new Set(httpEndpoints.map((e) => e.service))];
+            const specs = await fetchSpecsForServices(serviceNames, identity);
+            const endpointResult = validateWorkflowEndpoints(result.dag, specs);
+
+            if (!endpointResult.valid) {
+              const fieldErrors = [
+                ...endpointResult.invalidEndpoints.map((e) => ({
+                  field: `${e.method} ${e.service}${e.path}`,
+                  message: e.reason,
+                })),
+                ...endpointResult.fieldIssues
+                  .filter((f) => f.severity === "error")
+                  .map((f) => ({
+                    field: `nodes[${f.nodeId}].${f.field}`,
+                    message: f.reason,
+                  })),
+              ];
+
+              dagRetries++;
+              if (dagRetries > MAX_RETRIES) {
+                throw new GenerationValidationError(
+                  "Generated DAG has invalid endpoint fields after retries",
+                  fieldErrors,
+                );
+              }
+
+              messages.push({ role: "assistant", content: response.content });
+              messages.push({
+                role: "user",
+                content: [
+                  {
+                    type: "tool_result",
+                    tool_use_id: createWorkflowCall.id,
+                    is_error: true,
+                    content: buildRetryUserMessage(input.description, fieldErrors),
+                  },
+                ],
+              });
+              continue;
+            }
+          } catch (err) {
+            if (err instanceof GenerationValidationError) throw err;
+            console.warn("[workflow-service] generate: field validation skipped:", err);
+          }
+        }
+
         return {
           dag: result.dag,
           category: result.category,

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -20,6 +20,8 @@ import {
 import { computeDAGSignature } from "../lib/dag-signature.js";
 import { pickSignatureName } from "../lib/signature-words.js";
 import { extractHttpEndpoints } from "../lib/extract-http-endpoints.js";
+import { validateWorkflowEndpoints } from "../lib/validate-workflow-endpoints.js";
+import { fetchSpecsForServices } from "../lib/api-registry-client.js";
 import { fetchProviderRequirements, fetchAnthropicKey } from "../lib/key-service-client.js";
 import { fetchRunCosts, fetchEmailStats } from "../lib/stats-client.js";
 
@@ -380,6 +382,8 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
     const body = DeployWorkflowsSchema.parse(req.body);
     const orgId = res.locals.orgId as string;
 
+    console.log(`[workflow-service] deploy: org=${orgId} workflows=${body.workflows.length}`);
+
     // Validate ALL DAGs first — reject if any are invalid
     const dagErrors: { index: number; errors: unknown[] }[] = [];
     for (let i = 0; i < body.workflows.length; i++) {
@@ -391,6 +395,60 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
     if (dagErrors.length > 0) {
       res.status(400).json({ error: "Invalid DAGs", details: dagErrors });
       return;
+    }
+
+    // Validate endpoint fields against API registry (if configured)
+    if (process.env.API_REGISTRY_SERVICE_URL && process.env.API_REGISTRY_SERVICE_API_KEY) {
+      const allServiceNames = new Set<string>();
+      for (const wf of body.workflows) {
+        for (const ep of extractHttpEndpoints(wf.dag as DAG)) {
+          allServiceNames.add(ep.service);
+        }
+      }
+
+      if (allServiceNames.size > 0) {
+        try {
+          const specs = await fetchSpecsForServices([...allServiceNames]);
+          const validationErrors: Array<{ index: number; issues: unknown[] }> = [];
+
+          for (let i = 0; i < body.workflows.length; i++) {
+            const result = validateWorkflowEndpoints(body.workflows[i].dag as DAG, specs);
+
+            if (result.fieldIssues.length > 0) {
+              console.warn(
+                `[workflow-service] deploy: workflow[${i}] field issues:`,
+                result.fieldIssues.map((f) => `${f.severity}: ${f.reason}`).join("; "),
+              );
+            }
+
+            const errors = [
+              ...result.invalidEndpoints.map((e) => ({
+                severity: "error",
+                reason: e.reason,
+              })),
+              ...result.fieldIssues.filter((f) => f.severity === "error"),
+            ];
+
+            if (errors.length > 0) {
+              validationErrors.push({ index: i, issues: errors });
+            }
+          }
+
+          if (validationErrors.length > 0) {
+            console.error(
+              `[workflow-service] deploy: rejected — ${validationErrors.length} workflow(s) with field errors`,
+            );
+            res.status(400).json({
+              error: "Endpoint field validation failed",
+              details: validationErrors,
+            });
+            return;
+          }
+        } catch (err) {
+          console.warn("[workflow-service] deploy: api-registry validation skipped:", err);
+          // Don't block deploy if api-registry is unavailable
+        }
+      }
     }
 
     // Fetch all existing signatureNames for this orgId to avoid collisions
@@ -420,6 +478,9 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
 
       if (existing) {
         // Same DAG already deployed — update metadata
+        console.log(
+          `[workflow-service] deploy: sig=${signature.slice(0, 12)} matched "${existing.name}" (${existing.id}) -> update`,
+        );
         const openFlow = dagToOpenFlow(dag, existing.name);
         const client = getWindmillClient();
 
@@ -469,6 +530,9 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
         usedNames.add(signatureName);
 
         const name = `${wf.category}-${wf.channel}-${wf.audienceType}-${signatureName}`;
+        console.log(
+          `[workflow-service] deploy: sig=${signature.slice(0, 12)} no active match -> create "${name}"`,
+        );
 
         const openFlow = dagToOpenFlow(dag, name);
         const flowPath = generateFlowPath(orgId, name);
@@ -521,6 +585,12 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
         });
       }
     }
+
+    const createdCount = results.filter((r) => r.action === "created").length;
+    const updatedCount = results.filter((r) => r.action === "updated").length;
+    console.log(
+      `[workflow-service] deploy complete: org=${orgId} total=${results.length} created=${createdCount} updated=${updatedCount}`,
+    );
 
     res.json({ workflows: results });
   } catch (err: unknown) {

--- a/tests/unit/openapi-schema-resolver.test.ts
+++ b/tests/unit/openapi-schema-resolver.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveSchema,
+  getRequestBodySchema,
+  getResponseSchema,
+} from "../../src/lib/openapi-schema-resolver.js";
+
+describe("resolveSchema", () => {
+  it("resolves a direct schema with properties", () => {
+    const schema = {
+      type: "object",
+      properties: { name: { type: "string" }, age: { type: "number" } },
+      required: ["name"],
+    };
+    const result = resolveSchema(schema, {});
+    expect(result).toEqual({
+      properties: { name: { type: "string" }, age: { type: "number" } },
+      required: ["name"],
+    });
+  });
+
+  it("follows $ref to components/schemas", () => {
+    const schema = { $ref: "#/components/schemas/User" };
+    const spec = {
+      components: {
+        schemas: {
+          User: {
+            type: "object",
+            properties: { id: { type: "string" }, email: { type: "string" } },
+            required: ["id", "email"],
+          },
+        },
+      },
+    };
+    const result = resolveSchema(schema, spec);
+    expect(result).toEqual({
+      properties: { id: { type: "string" }, email: { type: "string" } },
+      required: ["id", "email"],
+    });
+  });
+
+  it("handles nested $ref (schema references another schema)", () => {
+    const schema = { $ref: "#/components/schemas/Alias" };
+    const spec = {
+      components: {
+        schemas: {
+          Alias: { $ref: "#/components/schemas/Real" },
+          Real: {
+            type: "object",
+            properties: { value: { type: "string" } },
+            required: ["value"],
+          },
+        },
+      },
+    };
+    const result = resolveSchema(schema, spec);
+    expect(result).toEqual({
+      properties: { value: { type: "string" } },
+      required: ["value"],
+    });
+  });
+
+  it("handles allOf by merging properties", () => {
+    const schema = {
+      allOf: [
+        {
+          type: "object",
+          properties: { a: { type: "string" } },
+          required: ["a"],
+        },
+        {
+          type: "object",
+          properties: { b: { type: "number" } },
+          required: ["b"],
+        },
+      ],
+    };
+    const result = resolveSchema(schema, {});
+    expect(result?.properties).toEqual({ a: { type: "string" }, b: { type: "number" } });
+    expect(result?.required).toEqual(["a", "b"]);
+  });
+
+  it("handles oneOf by merging all variants' properties", () => {
+    const schema = {
+      oneOf: [
+        { type: "object", properties: { x: { type: "string" } } },
+        { type: "object", properties: { y: { type: "number" } } },
+      ],
+    };
+    const result = resolveSchema(schema, {});
+    expect(result?.properties).toEqual({ x: { type: "string" }, y: { type: "number" } });
+  });
+
+  it("returns null for schemas without properties", () => {
+    expect(resolveSchema({ type: "string" }, {})).toBeNull();
+    expect(resolveSchema({ type: "array", items: { type: "string" } }, {})).toBeNull();
+  });
+
+  it("handles circular $ref gracefully (depth limit)", () => {
+    const schema = { $ref: "#/components/schemas/Loop" };
+    const spec = {
+      components: { schemas: { Loop: { $ref: "#/components/schemas/Loop" } } },
+    };
+    expect(resolveSchema(schema, spec)).toBeNull();
+  });
+
+  it("returns empty required array when required is not defined", () => {
+    const schema = { type: "object", properties: { foo: { type: "string" } } };
+    const result = resolveSchema(schema, {});
+    expect(result?.required).toEqual([]);
+  });
+});
+
+describe("getRequestBodySchema", () => {
+  const spec = {
+    paths: {
+      "/gate-check": {
+        post: {
+          requestBody: {
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    campaignId: { type: "string" },
+                    orgId: { type: "string" },
+                  },
+                  required: ["campaignId", "orgId"],
+                },
+              },
+            },
+          },
+        },
+      },
+      "/health": {
+        get: { summary: "Health check" },
+      },
+    },
+  };
+
+  it("returns schema for POST endpoint with requestBody", () => {
+    const result = getRequestBodySchema(spec, "/gate-check", "POST");
+    expect(result?.properties).toHaveProperty("campaignId");
+    expect(result?.properties).toHaveProperty("orgId");
+    expect(result?.required).toEqual(["campaignId", "orgId"]);
+  });
+
+  it("returns null for GET endpoint (no requestBody)", () => {
+    expect(getRequestBodySchema(spec, "/health", "GET")).toBeNull();
+  });
+
+  it("returns null when path does not exist", () => {
+    expect(getRequestBodySchema(spec, "/nonexistent", "POST")).toBeNull();
+  });
+
+  it("handles simplified format (schema directly on requestBody)", () => {
+    const simplified = {
+      paths: {
+        "/send": {
+          post: {
+            requestBody: {
+              schema: {
+                type: "object",
+                properties: { to: { type: "string" } },
+                required: ["to"],
+              },
+            },
+          },
+        },
+      },
+    };
+    const result = getRequestBodySchema(simplified, "/send", "POST");
+    expect(result?.properties).toHaveProperty("to");
+    expect(result?.required).toEqual(["to"]);
+  });
+
+  it("resolves $ref in requestBody schema", () => {
+    const specWithRef = {
+      paths: {
+        "/create": {
+          post: {
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/CreateReq" },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          CreateReq: {
+            type: "object",
+            properties: { name: { type: "string" } },
+            required: ["name"],
+          },
+        },
+      },
+    };
+    const result = getRequestBodySchema(specWithRef, "/create", "POST");
+    expect(result?.properties).toHaveProperty("name");
+  });
+});
+
+describe("getResponseSchema", () => {
+  it("returns schema for 200 response", () => {
+    const spec = {
+      paths: {
+        "/check": {
+          post: {
+            responses: {
+              "200": {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: { allowed: { type: "boolean" } },
+                      required: ["allowed"],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const result = getResponseSchema(spec, "/check", "POST");
+    expect(result?.properties).toHaveProperty("allowed");
+  });
+
+  it("falls back to 201 response", () => {
+    const spec = {
+      paths: {
+        "/create": {
+          post: {
+            responses: {
+              "201": {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: { id: { type: "string" } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const result = getResponseSchema(spec, "/create", "POST");
+    expect(result?.properties).toHaveProperty("id");
+  });
+
+  it("handles simplified format (schema directly on response)", () => {
+    const spec = {
+      paths: {
+        "/run": {
+          post: {
+            responses: {
+              "200": {
+                schema: {
+                  type: "object",
+                  properties: { status: { type: "string" } },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const result = getResponseSchema(spec, "/run", "POST");
+    expect(result?.properties).toHaveProperty("status");
+  });
+
+  it("returns null when no response schema exists", () => {
+    const spec = {
+      paths: { "/noop": { post: { responses: { "204": {} } } } },
+    };
+    expect(getResponseSchema(spec, "/noop", "POST")).toBeNull();
+  });
+});

--- a/tests/unit/validate-workflow-endpoints.test.ts
+++ b/tests/unit/validate-workflow-endpoints.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { validateWorkflowEndpoints } from "../../src/lib/validate-workflow-endpoints.js";
+import {
+  validateWorkflowEndpoints,
+  extractBodyFields,
+  extractOutputRefs,
+} from "../../src/lib/validate-workflow-endpoints.js";
 import type { DAG } from "../../src/lib/dag-validator.js";
 
 const CAMPAIGN_SPEC: Record<string, unknown> = {
@@ -7,6 +11,101 @@ const CAMPAIGN_SPEC: Record<string, unknown> = {
     "/gate-check": { post: { summary: "Gate check" } },
     "/start-run": { post: { summary: "Start run" } },
     "/end-run": { post: { summary: "End run" } },
+  },
+};
+
+const CAMPAIGN_SPEC_WITH_SCHEMAS: Record<string, unknown> = {
+  paths: {
+    "/gate-check": {
+      post: {
+        summary: "Gate check",
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  campaignId: { type: "string" },
+                  orgId: { type: "string" },
+                },
+                required: ["campaignId", "orgId"],
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    allowed: { type: "boolean" },
+                    reason: { type: "string" },
+                  },
+                  required: ["allowed"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/start-run": {
+      post: {
+        summary: "Start run",
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  campaignId: { type: "string" },
+                  orgId: { type: "string" },
+                },
+                required: ["campaignId", "orgId"],
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    runId: { type: "string" },
+                    brandId: { type: "string" },
+                    appId: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/end-run": {
+      post: {
+        summary: "End run",
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  campaignId: { type: "string" },
+                  orgId: { type: "string" },
+                  success: { type: "boolean" },
+                },
+                required: ["campaignId", "orgId", "success"],
+              },
+            },
+          },
+        },
+      },
+    },
   },
 };
 
@@ -171,5 +270,280 @@ describe("validateWorkflowEndpoints", () => {
     const brokenPaths = result.invalidEndpoints.map((e) => e.path);
     expect(brokenPaths).toContain("/internal/gate-check");
     expect(brokenPaths).toContain("/internal/end-run");
+  });
+
+  it("returns fieldIssues array even when empty", () => {
+    const dag: DAG = {
+      nodes: [{ id: "wait", type: "wait", config: { seconds: 1 } }],
+      edges: [],
+    };
+    const result = validateWorkflowEndpoints(dag, new Map());
+    expect(result.fieldIssues).toEqual([]);
+  });
+});
+
+describe("field validation — input fields", () => {
+  it("detects unknown body field (clerkOrgId vs orgId regression)", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/gate-check" },
+          inputMapping: {
+            "body.campaignId": "$ref:flow_input.campaignId",
+            "body.clerkOrgId": "$ref:flow_input.clerkOrgId",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const specs = new Map([["campaign", CAMPAIGN_SPEC_WITH_SCHEMAS]]);
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    // clerkOrgId is unknown → warning
+    const warnings = result.fieldIssues.filter((i) => i.severity === "warning");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].field).toBe("clerkOrgId");
+    expect(warnings[0].reason).toContain("not in");
+
+    // orgId is required but missing → error
+    const errors = result.fieldIssues.filter((i) => i.severity === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe("orgId");
+    expect(errors[0].reason).toContain("Required");
+
+    expect(result.valid).toBe(false);
+  });
+
+  it("passes when all body fields match schema", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/gate-check" },
+          inputMapping: {
+            "body.campaignId": "$ref:flow_input.campaignId",
+            "body.orgId": "$ref:flow_input.orgId",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const specs = new Map([["campaign", CAMPAIGN_SPEC_WITH_SCHEMAS]]);
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    expect(result.valid).toBe(true);
+    expect(result.fieldIssues).toHaveLength(0);
+  });
+
+  it("detects missing required field from config.body", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "end-run",
+          type: "http.call",
+          config: {
+            service: "campaign",
+            method: "POST",
+            path: "/end-run",
+            body: { success: true },
+          },
+          inputMapping: {
+            "body.campaignId": "$ref:flow_input.campaignId",
+            // orgId missing!
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const specs = new Map([["campaign", CAMPAIGN_SPEC_WITH_SCHEMAS]]);
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    expect(result.valid).toBe(false);
+    const errors = result.fieldIssues.filter((i) => i.severity === "error");
+    expect(errors.some((e) => e.field === "orgId")).toBe(true);
+  });
+
+  it("extracts body fields from both config.body and inputMapping", () => {
+    const node = {
+      id: "test",
+      type: "http.call" as const,
+      config: {
+        body: { success: true, tag: "cold-email" },
+      },
+      inputMapping: {
+        "body.campaignId": "$ref:flow_input.campaignId",
+        "body.metadata.emailId": "$ref:email-gen.output.id",
+      },
+    };
+
+    const fields = extractBodyFields(node);
+    expect(fields).toContain("success");
+    expect(fields).toContain("tag");
+    expect(fields).toContain("campaignId");
+    expect(fields).toContain("metadata");
+    expect(fields).not.toContain("emailId"); // nested under metadata
+  });
+
+  it("skips body validation when body is passed as whole object", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "forward",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/gate-check" },
+          inputMapping: {
+            body: "$ref:some-node.output",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const specs = new Map([["campaign", CAMPAIGN_SPEC_WITH_SCHEMAS]]);
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    // No field issues because body is opaque
+    expect(result.fieldIssues).toHaveLength(0);
+  });
+
+  it("skips field validation when no requestBody schema exists", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/gate-check" },
+          inputMapping: {
+            "body.anything": "$ref:flow_input.anything",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    // Spec without requestBody schema
+    const specs = new Map([["campaign", CAMPAIGN_SPEC]]);
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    expect(result.fieldIssues).toHaveLength(0);
+  });
+});
+
+describe("field validation — output fields", () => {
+  it("detects referenced output field not in response schema", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "start-run",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/start-run" },
+          inputMapping: {
+            "body.campaignId": "$ref:flow_input.campaignId",
+            "body.orgId": "$ref:flow_input.orgId",
+          },
+        },
+        {
+          id: "next-step",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/gate-check" },
+          inputMapping: {
+            "body.campaignId": "$ref:start-run.output.campaignId",
+            "body.orgId": "$ref:start-run.output.nonexistentField",
+          },
+        },
+      ],
+      edges: [{ from: "start-run", to: "next-step" }],
+    };
+
+    const specs = new Map([["campaign", CAMPAIGN_SPEC_WITH_SCHEMAS]]);
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    const outputWarnings = result.fieldIssues.filter(
+      (i) => i.reason.includes("Output field") && i.reason.includes("nonexistentField"),
+    );
+    expect(outputWarnings).toHaveLength(1);
+    expect(outputWarnings[0].severity).toBe("warning");
+  });
+
+  it("passes when output fields exist in response schema", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "start-run",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/start-run" },
+          inputMapping: {
+            "body.campaignId": "$ref:flow_input.campaignId",
+            "body.orgId": "$ref:flow_input.orgId",
+          },
+        },
+        {
+          id: "next-step",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/gate-check" },
+          inputMapping: {
+            "body.campaignId": "$ref:start-run.output.runId",
+            "body.orgId": "$ref:start-run.output.brandId",
+          },
+        },
+      ],
+      edges: [{ from: "start-run", to: "next-step" }],
+    };
+
+    const specs = new Map([["campaign", CAMPAIGN_SPEC_WITH_SCHEMAS]]);
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    const outputIssues = result.fieldIssues.filter((i) => i.reason.includes("Output field"));
+    expect(outputIssues).toHaveLength(0);
+  });
+
+  it("handles whole-output reference (no specific field)", () => {
+    const refs = extractOutputRefs(
+      {
+        nodes: [
+          { id: "source", type: "http.call" },
+          {
+            id: "consumer",
+            type: "http.call",
+            inputMapping: { body: "$ref:source.output" },
+          },
+        ],
+        edges: [],
+      },
+      "source",
+    );
+
+    // Whole output → no specific field to validate
+    expect(refs).toHaveLength(0);
+  });
+
+  it("extracts output refs with hyphenated node IDs", () => {
+    const refs = extractOutputRefs(
+      {
+        nodes: [
+          { id: "start-run", type: "http.call" },
+          {
+            id: "next",
+            type: "http.call",
+            inputMapping: {
+              "body.id": "$ref:start-run.output.runId",
+              "body.brand": "$ref:start-run.output.brandId",
+            },
+          },
+        ],
+        edges: [],
+      },
+      "start-run",
+    );
+
+    expect(refs).toHaveLength(2);
+    expect(refs.map((r) => r.field)).toContain("runId");
+    expect(refs.map((r) => r.field)).toContain("brandId");
   });
 });


### PR DESCRIPTION
## Summary
- **Deploy logging**: entry/per-workflow/summary logs with signature matching details. Shows exactly why each workflow is created vs updated — makes multiplication visible on Railway.
- **Body field validation**: for every http.call node, validates body fields against the endpoint's OpenAPI requestBody schema from the API registry. Missing required fields → error (blocks deploy). Unknown fields → warning (logged). Also validates downstream output references against response schemas.
- **Wired into 3 places**: deploy route (blocks on errors), generate flow (retries with LLM feedback), startup validator (logs field issues)

## Test plan
- [x] 17 tests for OpenAPI schema resolver ($ref, allOf, oneOf, edge cases)
- [x] 11 new tests for field validation (clerkOrgId regression, missing required, unknown fields, output refs)
- [x] All 340 tests pass
- [x] Build compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)