### PR TITLE
fix: auto-deploy node scripts to Windmill on startup

### DIFF
--- a/scripts/deploy-nodes.ts
+++ b/scripts/deploy-nodes.ts
@@ -1,81 +1,17 @@
 /**
- * Deploy all node scripts to Windmill.
- *
- * Reads every scripts/nodes/*.ts file, maps the filename to the
- * Windmill script path (f/nodes/<name_with_underscores>), then
- * creates or updates each script via the Windmill API.
+ * CLI wrapper for deploying node scripts to Windmill.
  *
  * Usage:
  *   WINDMILL_SERVER_URL=... WINDMILL_SERVER_API_KEY=... npx tsx scripts/deploy-nodes.ts
  *
- * Or with a .env file already loaded.
+ * The core logic lives in src/lib/deploy-nodes.ts (also called on service startup).
  */
 
-import fs from "node:fs";
-import path from "node:path";
 import { WindmillClient } from "../src/lib/windmill-client.js";
+import { deployNodes } from "../src/lib/deploy-nodes.js";
 
-function filenameToWindmillPath(filename: string): string {
-  const name = filename.replace(/\.ts$/, "").replace(/-/g, "_");
-  return `f/nodes/${name}`;
-}
+export { deployNodes } from "../src/lib/deploy-nodes.js";
 
-function filenameToSummary(filename: string): string {
-  return filename
-    .replace(/\.ts$/, "")
-    .split("-")
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(" ");
-}
-
-export async function deployNodes(client: WindmillClient): Promise<
-  { path: string; action: "created" | "updated" }[]
-> {
-  const nodesDir = path.resolve(import.meta.dirname ?? __dirname, "nodes");
-  const files = fs.readdirSync(nodesDir).filter((f) => f.endsWith(".ts"));
-
-  const results: { path: string; action: "created" | "updated" }[] = [];
-
-  for (const file of files) {
-    const content = fs.readFileSync(path.join(nodesDir, file), "utf-8");
-    const wmPath = filenameToWindmillPath(file);
-    const summary = filenameToSummary(file);
-
-    const existing = await client.getScript(wmPath);
-
-    if (existing) {
-      // Content unchanged — skip
-      if (existing.content.trim() === content.trim()) {
-        console.log(`  skip  ${wmPath} (unchanged)`);
-        continue;
-      }
-      await client.createScript({
-        path: wmPath,
-        summary,
-        description: "",
-        content,
-        language: "bun",
-        parent_hash: existing.hash,
-      });
-      results.push({ path: wmPath, action: "updated" });
-      console.log(`  update ${wmPath}`);
-    } else {
-      await client.createScript({
-        path: wmPath,
-        summary,
-        description: "",
-        content,
-        language: "bun",
-      });
-      results.push({ path: wmPath, action: "created" });
-      console.log(`  create ${wmPath}`);
-    }
-  }
-
-  return results;
-}
-
-// --- CLI entry point (skipped when imported as module in tests) ---
 const isCLI = process.argv[1]?.endsWith("deploy-nodes.ts");
 
 async function cliMain() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { getWindmillClient } from "./lib/windmill-client.js";
 import { JobPoller } from "./lib/job-poller.js";
 import { requireIdentity } from "./middleware/auth.js";
 import { checkApiRegistryHealth, validateAndUpgradeWorkflows } from "./lib/startup-validator.js";
+import { deployNodes } from "./lib/deploy-nodes.js";
 import healthRoutes from "./routes/health.js";
 import workflowsRoutes from "./routes/workflows.js";
 import workflowRunsRoutes from "./routes/workflow-runs.js";
@@ -55,6 +56,17 @@ if (process.env.NODE_ENV !== "test") {
       // Start job poller (only if Windmill is configured)
       const windmillClient = getWindmillClient();
       if (windmillClient) {
+        // Sync node scripts to Windmill — idempotent, skips unchanged scripts
+        try {
+          const deployed = await deployNodes(windmillClient);
+          if (deployed.length > 0) {
+            console.log(`[workflow-service] Deployed ${deployed.length} node script(s) to Windmill`);
+          }
+        } catch (err) {
+          console.error("[workflow-service] Failed to deploy node scripts to Windmill:", err);
+          process.exit(1);
+        }
+
         const poller = new JobPoller(db, windmillClient, workflowRuns);
         poller.start();
       } else {

--- a/src/lib/deploy-nodes.ts
+++ b/src/lib/deploy-nodes.ts
@@ -1,0 +1,76 @@
+/**
+ * Deploy all node scripts to Windmill.
+ *
+ * Reads every scripts/nodes/*.ts file, maps the filename to the
+ * Windmill script path (f/nodes/<name_with_underscores>), then
+ * creates or updates each script via the Windmill API.
+ *
+ * Idempotent: skips scripts whose content hasn't changed.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { WindmillClient } from "./windmill-client.js";
+
+function filenameToWindmillPath(filename: string): string {
+  const name = filename.replace(/\.ts$/, "").replace(/-/g, "_");
+  return `f/nodes/${name}`;
+}
+
+function filenameToSummary(filename: string): string {
+  return filename
+    .replace(/\.ts$/, "")
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export async function deployNodes(client: WindmillClient): Promise<
+  { path: string; action: "created" | "updated" }[]
+> {
+  // Resolve the nodes directory relative to the project root
+  const nodesDir = path.resolve(
+    import.meta.dirname ?? __dirname,
+    "../../scripts/nodes",
+  );
+  const files = fs.readdirSync(nodesDir).filter((f) => f.endsWith(".ts"));
+
+  const results: { path: string; action: "created" | "updated" }[] = [];
+
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(nodesDir, file), "utf-8");
+    const wmPath = filenameToWindmillPath(file);
+    const summary = filenameToSummary(file);
+
+    const existing = await client.getScript(wmPath);
+
+    if (existing) {
+      // Content unchanged — skip
+      if (existing.content.trim() === content.trim()) {
+        continue;
+      }
+      await client.createScript({
+        path: wmPath,
+        summary,
+        description: "",
+        content,
+        language: "bun",
+        parent_hash: existing.hash,
+      });
+      results.push({ path: wmPath, action: "updated" });
+      console.log(`[workflow-service] Updated node script: ${wmPath}`);
+    } else {
+      await client.createScript({
+        path: wmPath,
+        summary,
+        description: "",
+        content,
+        language: "bun",
+      });
+      results.push({ path: wmPath, action: "created" });
+      console.log(`[workflow-service] Created node script: ${wmPath}`);
+    }
+  }
+
+  return results;
+}

--- a/tests/unit/deploy-nodes.test.ts
+++ b/tests/unit/deploy-nodes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { deployNodes } from "../../scripts/deploy-nodes.js";
+import { deployNodes } from "../../src/lib/deploy-nodes.js";
 import type { WindmillClient } from "../../src/lib/windmill-client.js";
 
 function mockClient(scripts: Map<string, { hash: string; content: string }>) {

--- a/tests/unit/http-call.test.ts
+++ b/tests/unit/http-call.test.ts
@@ -110,6 +110,34 @@ describe("http-call script", () => {
     ).rejects.toThrow("Missing: UNKNOWN_SERVICE_URL");
   });
 
+  it("regression: identity headers are sent even with body containing orgId (gate-check scenario)", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ allowed: true }));
+
+    // Simulate what Windmill sends: body has orgId+campaignId, AND orgId/userId/runId as separate params
+    await main(
+      "campaign", "POST", "/gate-check",
+      { orgId: "org-from-body", campaignId: "campaign-uuid" },
+      undefined,
+      serviceEnvs,
+      undefined,
+      undefined,
+      "org-from-flow-input",
+      "user-uuid",
+      "run-uuid",
+    );
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://campaign.example.com/gate-check");
+    // Body should contain both fields
+    const sentBody = JSON.parse(options.body);
+    expect(sentBody.orgId).toBe("org-from-body");
+    expect(sentBody.campaignId).toBe("campaign-uuid");
+    // Identity headers must be present
+    expect(options.headers["x-org-id"]).toBe("org-from-flow-input");
+    expect(options.headers["x-user-id"]).toBe("user-uuid");
+    expect(options.headers["x-run-id"]).toBe("run-uuid");
+  });
+
   describe("validateResponse", () => {
     it("passes when response field matches expected value", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({ allowed: true, reason: "ok" }));


### PR DESCRIPTION
## Summary

- The http-call script in Windmill was stale since March 3 — missing `x-org-id`, `x-user-id`, `x-run-id` header injection. This caused **every campaign workflow run to fail** with `400: "expected string, received undefined"` because downstream services (campaign-service) require these identity headers.
- Node scripts are now auto-synced to Windmill on every service startup (idempotent, skips unchanged scripts). Service crashes if sync fails.
- Adds regression test verifying identity headers are sent alongside body fields in the gate-check scenario.

## Root cause

`scripts/deploy-nodes.ts` was a manual CLI script, never called on startup. When the http-call script was updated on March 3 to inject identity headers, the change was never pushed to Windmill. Zero workflow runs have succeeded since.

## Test plan

- [x] All 341 tests pass
- [x] Build succeeds
- [x] Regression test: `http-call.test.ts` verifies identity headers are sent even when body already contains orgId
- [ ] After deploy: verify campaign workflow runs succeed (gate-check no longer returns 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)