### PR TITLE
fix: copy scripts/nodes into Docker image for startup deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ FROM node:20-alpine
 WORKDIR /app
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/drizzle ./drizzle
+COPY --from=builder /app/scripts/nodes ./scripts/nodes
 COPY --from=builder /app/package*.json ./
 COPY --from=builder /app/openapi.json ./openapi.json
 RUN npm ci --omit=dev


### PR DESCRIPTION
## Summary

- PR #91 added auto-deploy of node scripts on startup, but the Dockerfile didn't copy `scripts/nodes/` into the container
- Adds `COPY --from=builder /app/scripts/nodes ./scripts/nodes` so the startup deploy can read the `.ts` files

## Test plan

- [x] Build succeeds locally
- [ ] Railway deploy starts without ENOENT crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)