### PR TITLE
fix: handle createFlow collision and move validation after listen

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,14 +73,20 @@ if (process.env.NODE_ENV !== "test") {
         console.log("Windmill not configured (WINDMILL_SERVER_URL / WINDMILL_SERVER_API_KEY missing) — job poller disabled");
       }
 
-      // Validate workflows before accepting traffic — crash if broken and unfixable
-      if (process.env.API_REGISTRY_SERVICE_URL && process.env.API_REGISTRY_SERVICE_API_KEY) {
-        await validateAndUpgradeWorkflows({ db, windmillClient });
-      }
-
       app.listen(Number(PORT), "::", () => {
         console.log(`workflow-service running on port ${PORT}`);
       });
+
+      // Validate & upgrade workflows AFTER listening — so the service can serve
+      // health checks and traffic while upgrades run (avoids Railway 502s)
+      if (process.env.API_REGISTRY_SERVICE_URL && process.env.API_REGISTRY_SERVICE_API_KEY) {
+        try {
+          await validateAndUpgradeWorkflows({ db, windmillClient });
+        } catch (err) {
+          console.error("[workflow-service] Workflow validation/upgrade failed:", err);
+          // Don't crash — workflows with issues are kept active and logged above
+        }
+      }
     } catch (err) {
       console.error("Startup failed:", err);
       process.exit(1);

--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -221,7 +221,23 @@ async function attemptUpgrade(
         });
         windmillFlowPath = flowPath;
       } catch (err) {
-        console.error("[workflow-service] Failed to create upgraded flow in Windmill:", err);
+        // Flow may already exist from a previous startup attempt — update instead
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("already exists")) {
+          try {
+            await windmillClient.updateFlow(flowPath, {
+              summary: stableName,
+              description: result.description,
+              value: openFlow.value,
+              schema: openFlow.schema,
+            });
+            windmillFlowPath = flowPath;
+          } catch (updateErr) {
+            console.error("[workflow-service] Failed to update existing flow in Windmill:", updateErr);
+          }
+        } else {
+          console.error("[workflow-service] Failed to create upgraded flow in Windmill:", err);
+        }
       }
     }
 

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -355,4 +355,104 @@ describe("validateAndUpgradeWorkflows", () => {
     const deprecations = dbUpdates.filter((u) => u.values.status === "deprecated");
     expect(deprecations.length).toBe(0);
   });
+
+  it("falls back to updateFlow when createFlow returns 'already exists'", async () => {
+    dbSelectResult = [BROKEN_WORKFLOW];
+    mockFetchSpecsForServices.mockResolvedValue(
+      new Map([["campaign", CAMPAIGN_SPEC]]),
+    );
+    mockFetchPlatformAnthropicKey.mockResolvedValue({ key: "test-key", keySource: "platform" });
+    mockCreatePlatformRun.mockResolvedValue({ runId: "run-1" });
+    mockClosePlatformRun.mockResolvedValue(undefined);
+
+    const fixedDag = {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/gate-check" },
+        },
+      ],
+      edges: [],
+    };
+
+    mockUpgradeWorkflow.mockResolvedValue({
+      dag: fixedDag,
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      description: "Fixed workflow",
+    });
+
+    const mockCreateFlow = vi.fn().mockRejectedValue(new Error("Flow f/workflows/org-1/flow already exists"));
+    const mockUpdateFlow = vi.fn().mockResolvedValue(undefined);
+
+    await validateAndUpgradeWorkflows({
+      db: createMockDb() as any,
+      windmillClient: {
+        createFlow: mockCreateFlow,
+        updateFlow: mockUpdateFlow,
+      } as any,
+    });
+
+    // Should have tried createFlow first, then fallen back to updateFlow
+    expect(mockCreateFlow).toHaveBeenCalledTimes(1);
+    expect(mockUpdateFlow).toHaveBeenCalledTimes(1);
+
+    // The new workflow should still be inserted in the DB
+    expect(dbInserts.length).toBe(1);
+    expect(dbInserts[0].status).toBe("active");
+  });
+
+  it("logs error for non-'already exists' createFlow failures without crashing", async () => {
+    dbSelectResult = [BROKEN_WORKFLOW];
+    mockFetchSpecsForServices.mockResolvedValue(
+      new Map([["campaign", CAMPAIGN_SPEC]]),
+    );
+    mockFetchPlatformAnthropicKey.mockResolvedValue({ key: "test-key", keySource: "platform" });
+    mockCreatePlatformRun.mockResolvedValue({ runId: "run-2" });
+    mockClosePlatformRun.mockResolvedValue(undefined);
+
+    const fixedDag = {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/gate-check" },
+        },
+      ],
+      edges: [],
+    };
+
+    mockUpgradeWorkflow.mockResolvedValue({
+      dag: fixedDag,
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      description: "Fixed workflow",
+    });
+
+    const mockCreateFlow = vi.fn().mockRejectedValue(new Error("Windmill API error: 500 Internal Server Error"));
+    const mockUpdateFlow = vi.fn();
+
+    const consoleSpy = vi.spyOn(console, "error");
+
+    await validateAndUpgradeWorkflows({
+      db: createMockDb() as any,
+      windmillClient: {
+        createFlow: mockCreateFlow,
+        updateFlow: mockUpdateFlow,
+      } as any,
+    });
+
+    // Should NOT have called updateFlow (error is not "already exists")
+    expect(mockUpdateFlow).not.toHaveBeenCalled();
+
+    // Should have logged the error
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to create upgraded flow"),
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- Falls back to `updateFlow` when Windmill `createFlow` returns "already exists" (occurs when service restarts mid-upgrade and the flow path was already created)
- Moves `validateAndUpgradeWorkflows` to run **after** `app.listen` so the service can serve health checks and traffic during potentially slow LLM-powered upgrades (fixes Railway 502s)
- Catches validation failures post-listen instead of crashing — broken workflows are kept active and logged

## Test plan
- [x] Unit test: createFlow "already exists" → falls back to updateFlow, workflow still inserted in DB
- [x] Unit test: non-"already exists" createFlow error → logs error, does not call updateFlow
- [x] All 258 existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)