### PR TITLE
fix: pass field errors to LLM upgrade and move validation after listen

### DIFF
--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -312,16 +312,46 @@ ${styleDirective ? `## Style Directive\n\n${styleDirective}\n\n` : ""}Generate a
 export interface BuildUpgradeSystemPromptOptions {
   currentDag: Record<string, unknown>;
   invalidEndpoints: Array<{ service: string; method: string; path: string; reason: string }>;
+  fieldErrors?: Array<{ nodeId: string; service: string; method: string; path: string; field: string; reason: string }>;
 }
 
 export function buildUpgradeSystemPrompt(options: BuildUpgradeSystemPromptOptions): string {
-  const { currentDag, invalidEndpoints } = options;
+  const { currentDag, invalidEndpoints, fieldErrors = [] } = options;
 
   const brokenList = invalidEndpoints
     .map((ep) => `- ${ep.method} ${ep.service}${ep.path} — ${ep.reason}`)
     .join("\n");
 
-  return `You are a workflow maintenance engineer. Your job is to FIX a broken workflow DAG by correcting invalid endpoint paths.
+  const fieldErrorList = fieldErrors
+    .map((f) => `- Node "${f.nodeId}": ${f.reason}`)
+    .join("\n");
+
+  const hasBrokenEndpoints = invalidEndpoints.length > 0;
+  const hasFieldErrors = fieldErrors.length > 0;
+
+  let issuesSection = "";
+
+  if (hasBrokenEndpoints) {
+    issuesSection += `## Broken Endpoints
+
+The following endpoints in this DAG are invalid — they no longer exist in the upstream service:
+
+${brokenList}
+`;
+  }
+
+  if (hasFieldErrors) {
+    issuesSection += `${hasBrokenEndpoints ? "\n" : ""}## Field Errors
+
+The following nodes send incorrect body fields to their endpoints (missing required fields or sending unknown fields):
+
+${fieldErrorList}
+
+To fix field errors, update the node's \`inputMapping\` (add missing \`body.*\` entries or remove incorrect ones) and/or \`config.body\` to match the endpoint's actual request schema. Use get_service_endpoints to check the correct schema.
+`;
+  }
+
+  return `You are a workflow maintenance engineer. Your job is to FIX a broken workflow DAG by correcting endpoint paths and body field mappings.
 
 ## Current DAG (DO NOT change business logic)
 
@@ -329,27 +359,23 @@ export function buildUpgradeSystemPrompt(options: BuildUpgradeSystemPromptOption
 ${JSON.stringify(currentDag, null, 2)}
 \`\`\`
 
-## Broken Endpoints
-
-The following endpoints in this DAG are invalid — they no longer exist in the upstream service:
-
-${brokenList}
-
+${issuesSection}
 ## Your Task
 
 1. Call list_services to see all available services
-2. Call get_service_endpoints for EACH service that has a broken endpoint — find the correct path
+2. Call get_service_endpoints for EACH service that has a broken endpoint or field error — find the correct path and request schema
 3. Call create_workflow with a corrected DAG
 
 ## CRITICAL RULES
 
-- **Preserve ALL business logic exactly**: same node IDs, same edges, same conditions, same inputMapping, same retries, same onError
-- **Only change what's broken**: update config.path (and config.service or config.method if needed) on the affected nodes
+- **Preserve ALL business logic exactly**: same node IDs, same edges, same conditions, same retries, same onError
+- **Only change what's broken**: update config.path, config.body, or inputMapping on the affected nodes
 - **Do NOT add, remove, or reorder nodes or edges**
-- **Do NOT change inputMapping, conditions, stopAfterIf, skipIf, or any other config keys**
+- **Do NOT change conditions, stopAfterIf, skipIf, or any non-broken config keys**
 - **Keep the same category, channel, audienceType, and description**
-- **Use the discovery tools to verify the correct endpoint exists before fixing**
+- **Use the discovery tools to verify the correct endpoint and schema before fixing**
 - If you cannot find a replacement endpoint, keep the original and note it in the description
+- When fixing field errors, use \`$ref:flow_input.fieldName\` or \`$ref:node-id.output.fieldName\` for dynamic values in inputMapping
 
 Return the corrected DAG via the create_workflow tool.`;
 }

--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -7,7 +7,7 @@ import {
   fetchServiceList,
   fetchSpecsForServices,
 } from "./api-registry-client.js";
-import { validateWorkflowEndpoints } from "./validate-workflow-endpoints.js";
+import { validateWorkflowEndpoints, type FieldValidationIssue } from "./validate-workflow-endpoints.js";
 import { upgradeWorkflow } from "./workflow-upgrader.js";
 import { dagToOpenFlow } from "./dag-to-openflow.js";
 import { computeDAGSignature } from "./dag-signature.js";
@@ -85,10 +85,19 @@ export async function validateAndUpgradeWorkflows(
       continue;
     }
 
-    console.warn(
-      `[workflow-service] Workflow "${wf.name}" (${wf.id}) has ${result.invalidEndpoints.length} broken endpoint(s):`,
-      result.invalidEndpoints.map((ep) => `${ep.method} ${ep.service}${ep.path}`).join(", "),
-    );
+    if (result.invalidEndpoints.length > 0) {
+      console.warn(
+        `[workflow-service] Workflow "${wf.name}" (${wf.id}) has ${result.invalidEndpoints.length} broken endpoint(s):`,
+        result.invalidEndpoints.map((ep) => `${ep.method} ${ep.service}${ep.path}`).join(", "),
+      );
+    }
+
+    const fieldErrors = result.fieldIssues.filter((f) => f.severity === "error");
+    if (fieldErrors.length > 0 && result.invalidEndpoints.length === 0) {
+      console.warn(
+        `[workflow-service] Workflow "${wf.name}" (${wf.id}) has ${fieldErrors.length} field error(s) — attempting upgrade`,
+      );
+    }
 
     // Attempt upgrade
     try {
@@ -96,6 +105,7 @@ export async function validateAndUpgradeWorkflows(
         wf,
         dag,
         result.invalidEndpoints,
+        result.fieldIssues.filter((f) => f.severity === "error"),
         database,
         windmillClient,
       );
@@ -145,6 +155,7 @@ async function attemptUpgrade(
   wf: Workflow,
   dag: DAG,
   invalidEndpoints: Array<{ service: string; method: string; path: string; reason: string }>,
+  fieldErrors: FieldValidationIssue[],
   database: Database,
   windmillClient: WindmillClient | null,
 ): Promise<string | null> {
@@ -181,6 +192,7 @@ async function attemptUpgrade(
     const result = await upgradeWorkflow(
       dag,
       invalidEndpoints,
+      fieldErrors,
       anthropicApiKey,
       undefined,
       {

--- a/src/lib/workflow-upgrader.ts
+++ b/src/lib/workflow-upgrader.ts
@@ -10,7 +10,7 @@ import {
   fetchServiceSpec,
 } from "./api-registry-client.js";
 import type { IdentityHeaders } from "./key-service-client.js";
-import type { InvalidEndpoint } from "./validate-workflow-endpoints.js";
+import type { InvalidEndpoint, FieldValidationIssue } from "./validate-workflow-endpoints.js";
 
 const MAX_RETRIES = 2;
 const MAX_AGENT_TURNS = 10;
@@ -60,6 +60,7 @@ export interface UpgradeWorkflowResult {
 export async function upgradeWorkflow(
   currentDag: DAG,
   invalidEndpoints: InvalidEndpoint[],
+  fieldErrors: FieldValidationIssue[],
   anthropicApiKey: string,
   identity: IdentityHeaders | undefined,
   metadata: { category: string; channel: string; audienceType: string; description: string },
@@ -69,11 +70,12 @@ export async function upgradeWorkflow(
   const systemPrompt = buildUpgradeSystemPrompt({
     currentDag: currentDag as unknown as Record<string, unknown>,
     invalidEndpoints,
+    fieldErrors,
   });
 
   const tools = AGENTIC_TOOLS;
 
-  const userMessage = `Fix this workflow. The category is "${metadata.category}", channel is "${metadata.channel}", audienceType is "${metadata.audienceType}". Description: "${metadata.description}". Only fix the broken endpoints listed above.`;
+  const userMessage = `Fix this workflow. The category is "${metadata.category}", channel is "${metadata.channel}", audienceType is "${metadata.audienceType}". Description: "${metadata.description}". Fix the broken endpoints and field errors listed above.`;
 
   const messages: Anthropic.Messages.MessageParam[] = [
     { role: "user", content: userMessage },

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -293,7 +293,8 @@ describe("validateAndUpgradeWorkflows", () => {
     // Should have called upgradeWorkflow with the platform key and no identity
     expect(mockUpgradeWorkflow).toHaveBeenCalledWith(
       BROKEN_WORKFLOW.dag,
-      expect.any(Array),
+      expect.any(Array), // invalidEndpoints
+      expect.any(Array), // fieldErrors
       "test-platform-key",
       undefined,
       expect.objectContaining({ category: "sales" }),
@@ -328,6 +329,104 @@ describe("validateAndUpgradeWorkflows", () => {
       "[workflow-service] No active workflows to validate",
     );
     consoleSpy.mockRestore();
+  });
+
+  it("upgrades workflow with field errors even when all endpoints are valid", async () => {
+    // Workflow has a valid endpoint path but is missing a required body field
+    const FIELD_ISSUES_WORKFLOW = {
+      ...VALID_WORKFLOW,
+      id: "wf-field",
+      name: "sales-email-cold-outreach-FieldIssue",
+      signatureName: "FieldIssue",
+      dag: {
+        nodes: [
+          {
+            id: "end-run",
+            type: "http.call",
+            config: { service: "campaign", method: "POST", path: "/end-run" },
+            // Missing required "orgId" in body
+            inputMapping: { "body.status": "$ref:flow_input.status" },
+          },
+        ],
+        edges: [],
+      },
+    };
+
+    // Spec declares orgId as required for /end-run
+    const SPEC_WITH_REQUIRED = {
+      paths: {
+        "/end-run": {
+          post: {
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["orgId", "status"],
+                    properties: {
+                      orgId: { type: "string" },
+                      status: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    dbSelectResult = [FIELD_ISSUES_WORKFLOW];
+    mockFetchSpecsForServices.mockResolvedValue(
+      new Map([["campaign", SPEC_WITH_REQUIRED]]),
+    );
+
+    mockFetchPlatformAnthropicKey.mockResolvedValue({ key: "test-key", keySource: "platform" });
+    mockCreatePlatformRun.mockResolvedValue({ runId: "field-run-1" });
+    mockClosePlatformRun.mockResolvedValue(undefined);
+
+    const fixedDag = {
+      nodes: [
+        {
+          id: "end-run",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/end-run" },
+          inputMapping: {
+            "body.status": "$ref:flow_input.status",
+            "body.orgId": "$ref:flow_input.orgId",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    mockUpgradeWorkflow.mockResolvedValue({
+      dag: fixedDag,
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      description: "Fixed workflow",
+    });
+
+    await validateAndUpgradeWorkflows({
+      db: createMockDb() as any,
+      windmillClient: null,
+    });
+
+    // Should attempt upgrade with field errors passed through
+    expect(mockFetchPlatformAnthropicKey).toHaveBeenCalledTimes(1);
+    expect(mockUpgradeWorkflow).toHaveBeenCalledTimes(1);
+
+    // upgradeWorkflow should receive empty invalidEndpoints but non-empty fieldErrors
+    const callArgs = mockUpgradeWorkflow.mock.calls[0];
+    expect(callArgs[1]).toEqual([]); // invalidEndpoints
+    expect(callArgs[2]).toEqual([   // fieldErrors
+      expect.objectContaining({ nodeId: "end-run", field: "orgId", severity: "error" }),
+    ]);
+
+    // Should have inserted a new upgraded workflow
+    expect(dbInserts.length).toBe(1);
+    expect(dbInserts[0].status).toBe("active");
   });
 
   it("throws when upgrade fails (LLM error) and closes platform run as failed", async () => {

--- a/tests/unit/workflow-upgrader.test.ts
+++ b/tests/unit/workflow-upgrader.test.ts
@@ -108,6 +108,7 @@ describe("upgradeWorkflow", () => {
     const result = await upgradeWorkflow(
       BROKEN_DAG,
       [{ service: "campaign", method: "POST", path: "/internal/gate-check", reason: "not found" }],
+      [],
       "fake-key",
       IDENTITY,
       METADATA,
@@ -163,6 +164,7 @@ describe("upgradeWorkflow", () => {
     const result = await upgradeWorkflow(
       BROKEN_DAG,
       [{ service: "campaign", method: "POST", path: "/internal/gate-check", reason: "not found" }],
+      [],
       "fake-key",
       IDENTITY,
       METADATA,
@@ -207,6 +209,7 @@ describe("upgradeWorkflow", () => {
       upgradeWorkflow(
         BROKEN_DAG,
         [{ service: "campaign", method: "POST", path: "/internal/gate-check", reason: "not found" }],
+        [],
         "fake-key",
         IDENTITY,
         METADATA,


### PR DESCRIPTION
## Summary
- Passes field validation errors (missing required body fields, unknown fields) to the LLM upgrade prompt — previously only broken endpoint paths were communicated, so field-only issues resulted in blind upgrades
- Updates the upgrade system prompt with a dedicated "Field Errors" section and instructions for fixing `inputMapping`/`config.body`
- Moves `validateAndUpgradeWorkflows` after `app.listen` so health checks and traffic are served during slow LLM upgrades (fixes Railway 502s)
- Handles Windmill `createFlow` "already exists" collision by falling back to `updateFlow`

## Test plan
- [x] New test: workflow with field errors (missing required `orgId`) triggers upgrade with field errors passed to LLM
- [x] Existing tests updated for new `upgradeWorkflow` signature (added `fieldErrors` param)
- [x] All 259 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)