### PR TITLE
fix: use updateFlow first to avoid noisy Windmill 400 errors

### DIFF
--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -223,32 +223,34 @@ async function attemptUpgrade(
     let windmillFlowPath: string | null = null;
 
     if (windmillClient) {
+      // Try updateFlow first (flow usually exists from previous startup).
+      // Only fall back to createFlow if the flow doesn't exist yet.
+      // This avoids Windmill logging noisy 400 "already exists" errors.
       try {
-        await windmillClient.createFlow({
-          path: flowPath,
+        await windmillClient.updateFlow(flowPath, {
           summary: stableName,
           description: result.description,
           value: openFlow.value,
           schema: openFlow.schema,
         });
         windmillFlowPath = flowPath;
-      } catch (err) {
-        // Flow may already exist from a previous startup attempt — update instead
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("already exists")) {
+      } catch (updateErr) {
+        const msg = updateErr instanceof Error ? updateErr.message : String(updateErr);
+        if (msg.includes("not found") || msg.includes("404")) {
           try {
-            await windmillClient.updateFlow(flowPath, {
+            await windmillClient.createFlow({
+              path: flowPath,
               summary: stableName,
               description: result.description,
               value: openFlow.value,
               schema: openFlow.schema,
             });
             windmillFlowPath = flowPath;
-          } catch (updateErr) {
-            console.error("[workflow-service] Failed to update existing flow in Windmill:", updateErr);
+          } catch (createErr) {
+            console.error("[workflow-service] Failed to create flow in Windmill:", createErr);
           }
         } else {
-          console.error("[workflow-service] Failed to create upgraded flow in Windmill:", err);
+          console.error("[workflow-service] Failed to update flow in Windmill:", updateErr);
         }
       }
     }

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -455,7 +455,7 @@ describe("validateAndUpgradeWorkflows", () => {
     expect(deprecations.length).toBe(0);
   });
 
-  it("falls back to updateFlow when createFlow returns 'already exists'", async () => {
+  it("updates existing flow via updateFlow (no createFlow needed)", async () => {
     dbSelectResult = [BROKEN_WORKFLOW];
     mockFetchSpecsForServices.mockResolvedValue(
       new Map([["campaign", CAMPAIGN_SPEC]]),
@@ -483,7 +483,7 @@ describe("validateAndUpgradeWorkflows", () => {
       description: "Fixed workflow",
     });
 
-    const mockCreateFlow = vi.fn().mockRejectedValue(new Error("Flow f/workflows/org-1/flow already exists"));
+    const mockCreateFlow = vi.fn();
     const mockUpdateFlow = vi.fn().mockResolvedValue(undefined);
 
     await validateAndUpgradeWorkflows({
@@ -494,16 +494,16 @@ describe("validateAndUpgradeWorkflows", () => {
       } as any,
     });
 
-    // Should have tried createFlow first, then fallen back to updateFlow
-    expect(mockCreateFlow).toHaveBeenCalledTimes(1);
+    // Should have called updateFlow only — no createFlow needed
     expect(mockUpdateFlow).toHaveBeenCalledTimes(1);
+    expect(mockCreateFlow).not.toHaveBeenCalled();
 
     // The new workflow should still be inserted in the DB
     expect(dbInserts.length).toBe(1);
     expect(dbInserts[0].status).toBe("active");
   });
 
-  it("logs error for non-'already exists' createFlow failures without crashing", async () => {
+  it("falls back to createFlow when updateFlow returns 'not found'", async () => {
     dbSelectResult = [BROKEN_WORKFLOW];
     mockFetchSpecsForServices.mockResolvedValue(
       new Map([["campaign", CAMPAIGN_SPEC]]),
@@ -531,8 +531,55 @@ describe("validateAndUpgradeWorkflows", () => {
       description: "Fixed workflow",
     });
 
-    const mockCreateFlow = vi.fn().mockRejectedValue(new Error("Windmill API error: 500 Internal Server Error"));
-    const mockUpdateFlow = vi.fn();
+    const mockUpdateFlow = vi.fn().mockRejectedValue(new Error("Flow not found"));
+    const mockCreateFlow = vi.fn().mockResolvedValue(undefined);
+
+    await validateAndUpgradeWorkflows({
+      db: createMockDb() as any,
+      windmillClient: {
+        createFlow: mockCreateFlow,
+        updateFlow: mockUpdateFlow,
+      } as any,
+    });
+
+    // Should have tried updateFlow first, then fallen back to createFlow
+    expect(mockUpdateFlow).toHaveBeenCalledTimes(1);
+    expect(mockCreateFlow).toHaveBeenCalledTimes(1);
+
+    expect(dbInserts.length).toBe(1);
+    expect(dbInserts[0].status).toBe("active");
+  });
+
+  it("logs error for non-'not found' updateFlow failures without crashing", async () => {
+    dbSelectResult = [BROKEN_WORKFLOW];
+    mockFetchSpecsForServices.mockResolvedValue(
+      new Map([["campaign", CAMPAIGN_SPEC]]),
+    );
+    mockFetchPlatformAnthropicKey.mockResolvedValue({ key: "test-key", keySource: "platform" });
+    mockCreatePlatformRun.mockResolvedValue({ runId: "run-3" });
+    mockClosePlatformRun.mockResolvedValue(undefined);
+
+    const fixedDag = {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/gate-check" },
+        },
+      ],
+      edges: [],
+    };
+
+    mockUpgradeWorkflow.mockResolvedValue({
+      dag: fixedDag,
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      description: "Fixed workflow",
+    });
+
+    const mockUpdateFlow = vi.fn().mockRejectedValue(new Error("Windmill API error: 500 Internal Server Error"));
+    const mockCreateFlow = vi.fn();
 
     const consoleSpy = vi.spyOn(console, "error");
 
@@ -544,12 +591,12 @@ describe("validateAndUpgradeWorkflows", () => {
       } as any,
     });
 
-    // Should NOT have called updateFlow (error is not "already exists")
-    expect(mockUpdateFlow).not.toHaveBeenCalled();
+    // Should NOT have called createFlow (error is not "not found")
+    expect(mockCreateFlow).not.toHaveBeenCalled();
 
     // Should have logged the error
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to create upgraded flow"),
+      expect.stringContaining("Failed to update flow"),
       expect.any(Error),
     );
     consoleSpy.mockRestore();


### PR DESCRIPTION
## Summary
- Swaps the Windmill flow deployment order: `updateFlow` first, `createFlow` as fallback on "not found"
- Eliminates the red `ERROR` lines in Windmill logs from `createFlow` → 400 "already exists" that made prod logs look broken when everything was actually handled correctly

## Test plan
- [x] Test: updateFlow succeeds → no createFlow called
- [x] Test: updateFlow returns "not found" → falls back to createFlow
- [x] Test: updateFlow returns other error → logs error, no createFlow
- [x] All 260 tests pass, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)