### PR TITLE
fix: use console.log for warning-only field issues

### DIFF
--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -74,7 +74,10 @@ export async function validateAndUpgradeWorkflows(
     const result = validateWorkflowEndpoints(dag, specs);
 
     if (result.fieldIssues.length > 0) {
-      console.warn(
+      const hasErrors = result.fieldIssues.some((f) => f.severity === "error");
+      // Use console.log for warning-only issues (avoids red/orange in Railway logs)
+      const log = hasErrors ? console.warn : console.log;
+      log(
         `[workflow-service] Workflow "${wf.name}" (${wf.id}) has ${result.fieldIssues.length} field issue(s):`,
         result.fieldIssues.map((f) => `${f.severity}: ${f.reason}`).join("; "),
       );


### PR DESCRIPTION
## Summary
- Warning-only field issues (extra body fields, unknown output refs) now use `console.log` instead of `console.warn`
- Only field issues containing actual errors (missing required fields) use `console.warn`
- Eliminates false-alarm red/orange lines in Railway logs for valid workflows

## Test plan
- [x] All 260 tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)