### PR TITLE
fix: upgrade workflows with warning-level field issues

### DIFF
--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -73,17 +73,19 @@ export async function validateAndUpgradeWorkflows(
     const dag = wf.dag as DAG;
     const result = validateWorkflowEndpoints(dag, specs);
 
-    const errorIssues = result.fieldIssues.filter((f) => f.severity === "error");
-    if (errorIssues.length > 0) {
-      console.warn(
-        `[workflow-service] Workflow "${wf.name}" (${wf.id}) has ${errorIssues.length} field error(s):`,
-        errorIssues.map((f) => f.reason).join("; "),
-      );
-    }
+    // Check for any issues: broken endpoints, field errors, or field warnings
+    const hasIssues = !result.valid || result.fieldIssues.length > 0;
 
-    if (result.valid) {
+    if (!hasIssues) {
       validCount++;
       continue;
+    }
+
+    if (result.fieldIssues.length > 0) {
+      console.warn(
+        `[workflow-service] Workflow "${wf.name}" (${wf.id}) has ${result.fieldIssues.length} field issue(s):`,
+        result.fieldIssues.map((f) => f.reason).join("; "),
+      );
     }
 
     if (result.invalidEndpoints.length > 0) {
@@ -93,20 +95,13 @@ export async function validateAndUpgradeWorkflows(
       );
     }
 
-    const fieldErrors = result.fieldIssues.filter((f) => f.severity === "error");
-    if (fieldErrors.length > 0 && result.invalidEndpoints.length === 0) {
-      console.warn(
-        `[workflow-service] Workflow "${wf.name}" (${wf.id}) has ${fieldErrors.length} field error(s) — attempting upgrade`,
-      );
-    }
-
-    // Attempt upgrade
+    // Attempt upgrade — pass ALL field issues (errors + warnings) so the LLM can fix everything
     try {
       const upgraded = await attemptUpgrade(
         wf,
         dag,
         result.invalidEndpoints,
-        result.fieldIssues.filter((f) => f.severity === "error"),
+        result.fieldIssues,
         database,
         windmillClient,
       );

--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -73,13 +73,11 @@ export async function validateAndUpgradeWorkflows(
     const dag = wf.dag as DAG;
     const result = validateWorkflowEndpoints(dag, specs);
 
-    if (result.fieldIssues.length > 0) {
-      const hasErrors = result.fieldIssues.some((f) => f.severity === "error");
-      // Use console.log for warning-only issues (avoids red/orange in Railway logs)
-      const log = hasErrors ? console.warn : console.log;
-      log(
-        `[workflow-service] Workflow "${wf.name}" (${wf.id}) has ${result.fieldIssues.length} field issue(s):`,
-        result.fieldIssues.map((f) => `${f.severity}: ${f.reason}`).join("; "),
+    const errorIssues = result.fieldIssues.filter((f) => f.severity === "error");
+    if (errorIssues.length > 0) {
+      console.warn(
+        `[workflow-service] Workflow "${wf.name}" (${wf.id}) has ${errorIssues.length} field error(s):`,
+        errorIssues.map((f) => f.reason).join("; "),
       );
     }
 

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -429,6 +429,107 @@ describe("validateAndUpgradeWorkflows", () => {
     expect(dbInserts[0].status).toBe("active");
   });
 
+  it("upgrades workflow with warning-only field issues (unknown body fields)", async () => {
+    // Workflow sends "bodyHtml" but schema expects "htmlBody" — this is a warning, not an error
+    const WARNING_ONLY_WORKFLOW = {
+      ...VALID_WORKFLOW,
+      id: "wf-warning",
+      name: "sales-email-cold-outreach-WarningOnly",
+      signatureName: "WarningOnly",
+      dag: {
+        nodes: [
+          {
+            id: "end-run",
+            type: "http.call",
+            config: { service: "campaign", method: "POST", path: "/end-run" },
+            inputMapping: {
+              "body.campaignId": "$ref:flow_input.campaignId",
+              "body.orgId": "$ref:flow_input.orgId",
+              "body.bodyHtml": "$ref:email-generate.output.bodyHtml",
+            },
+          },
+        ],
+        edges: [],
+      },
+    };
+
+    // Spec has campaignId and orgId as valid fields but NOT bodyHtml
+    const SPEC_WITH_KNOWN_FIELDS = {
+      paths: {
+        "/end-run": {
+          post: {
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["campaignId", "orgId"],
+                    properties: {
+                      campaignId: { type: "string" },
+                      orgId: { type: "string" },
+                      success: { type: "boolean" },
+                      leadFound: { type: "boolean" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    dbSelectResult = [WARNING_ONLY_WORKFLOW];
+    mockFetchSpecsForServices.mockResolvedValue(
+      new Map([["campaign", SPEC_WITH_KNOWN_FIELDS]]),
+    );
+
+    mockFetchPlatformAnthropicKey.mockResolvedValue({ key: "test-key", keySource: "platform" });
+    mockCreatePlatformRun.mockResolvedValue({ runId: "warning-run-1" });
+    mockClosePlatformRun.mockResolvedValue(undefined);
+
+    const fixedDag = {
+      nodes: [
+        {
+          id: "end-run",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/end-run" },
+          inputMapping: {
+            "body.campaignId": "$ref:flow_input.campaignId",
+            "body.orgId": "$ref:flow_input.orgId",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    mockUpgradeWorkflow.mockResolvedValue({
+      dag: fixedDag,
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      description: "Fixed workflow",
+    });
+
+    await validateAndUpgradeWorkflows({
+      db: createMockDb() as any,
+      windmillClient: null,
+    });
+
+    // Should attempt upgrade even though only warnings (no errors)
+    expect(mockUpgradeWorkflow).toHaveBeenCalledTimes(1);
+
+    // upgradeWorkflow should receive the warning-level field issues
+    const callArgs = mockUpgradeWorkflow.mock.calls[0];
+    expect(callArgs[1]).toEqual([]); // no invalid endpoints
+    expect(callArgs[2]).toEqual([   // fieldIssues includes warnings
+      expect.objectContaining({ nodeId: "end-run", field: "bodyHtml", severity: "warning" }),
+    ]);
+
+    // Should have inserted a new upgraded workflow
+    expect(dbInserts.length).toBe(1);
+  });
+
   it("throws when upgrade fails (LLM error) and closes platform run as failed", async () => {
     dbSelectResult = [BROKEN_WORKFLOW];
     mockFetchSpecsForServices.mockResolvedValue(


### PR DESCRIPTION
## Summary
- Warning-level field issues (unknown body fields, wrong field names like `bodyHtml` vs `htmlBody`) now trigger LLM-powered upgrades instead of being silently ignored
- ALL field issues (both errors and warnings) are passed to the LLM upgrade prompt with full context
- Added test for warning-only field issue upgrade scenario

## Test plan
- [x] Unit test: warning-only workflows trigger upgrade (`upgrades workflow with warning-only field issues`)
- [x] Existing tests pass (261/261)
- [x] TypeScript build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)