### PR TITLE
feat: add path parameter support to http-call script

### DIFF
--- a/scripts/nodes/http-call.ts
+++ b/scripts/nodes/http-call.ts
@@ -17,6 +17,7 @@ export async function main(
   orgId?: string,
   userId?: string,
   runId?: string,
+  params?: Record<string, string>,
 ) {
   // Convert service name to env var prefix: "transactional-email" → "TRANSACTIONAL_EMAIL"
   const envPrefix = service.toUpperCase().replace(/-/g, "_");
@@ -34,8 +35,16 @@ export async function main(
     );
   }
 
+  // Resolve path parameters: "/brands/{brandId}/profile" + params.brandId → "/brands/abc/profile"
+  let resolvedPath = path;
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      resolvedPath = resolvedPath.replace(`{${key}}`, encodeURIComponent(String(value)));
+    }
+  }
+
   // Build URL with query params
-  let url = `${baseUrl}${path}`;
+  let url = `${baseUrl}${resolvedPath}`;
   if (query && Object.keys(query).length > 0) {
     const params = new URLSearchParams(query);
     url += `?${params}`;

--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -148,6 +148,7 @@ Use "http.call" for all service calls. Config:
 - path (string): endpoint path
 - body (object, optional): static request body parts
 - query (object, optional): query params
+- params (object, optional): path parameters — keys match \`\{placeholder\}\` in the path
 
 Example:
 {
@@ -176,6 +177,9 @@ Dot-notation keys create nested objects:
 - "body.metadata.source": "$ref:flow_input.source" → body: { metadata: { source: ... } }
 
 Static body fields go in config.body, dynamic overrides go in inputMapping with dot-notation.
+
+For path parameters (e.g. \`/brands/{brandId}/sales-profile\`), use \`params.*\` in inputMapping:
+- "params.brandId": "$ref:start-run.output.brandId" → replaces {brandId} in the path
 
 ## Special Config Keys (stripped before passing to script)
 
@@ -247,8 +251,8 @@ Campaign service orchestrates workflow execution with budget constraints. Key co
     {
       "id": "brand-profile",
       "type": "http.call",
-      "config": { "service": "brand", "method": "POST", "path": "/sales-profile" },
-      "inputMapping": { "body.brandId": "$ref:start-run.output.brandId" }
+      "config": { "service": "brand", "method": "POST", "path": "/brands/{brandId}/sales-profile" },
+      "inputMapping": { "params.brandId": "$ref:start-run.output.brandId" }
     },
     {
       "id": "email-generate",

--- a/tests/unit/http-call.test.ts
+++ b/tests/unit/http-call.test.ts
@@ -138,6 +138,63 @@ describe("http-call script", () => {
     expect(options.headers["x-run-id"]).toBe("run-uuid");
   });
 
+  describe("path params", () => {
+    it("replaces {placeholders} in path with params values", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ profile: {} }));
+
+      const brandServiceEnvs = {
+        ...serviceEnvs,
+        BRAND_SERVICE_URL: "https://brand.example.com",
+        BRAND_SERVICE_API_KEY: "brand-key-789",
+      };
+
+      await main(
+        "brand", "POST", "/brands/{brandId}/sales-profile",
+        { workflowName: "test" },
+        undefined,
+        brandServiceEnvs,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { brandId: "brand-uuid-123" },
+      );
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://brand.example.com/brands/brand-uuid-123/sales-profile");
+    });
+
+    it("replaces multiple path params", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      await main(
+        "campaign", "GET", "/orgs/{orgId}/campaigns/{campaignId}",
+        undefined,
+        undefined,
+        serviceEnvs,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { orgId: "org-1", campaignId: "camp-2" },
+      );
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://campaign.example.com/orgs/org-1/campaigns/camp-2");
+    });
+
+    it("works without params (backward compat)", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      await main("campaign", "GET", "/status", undefined, undefined, serviceEnvs);
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://campaign.example.com/status");
+    });
+  });
+
   describe("validateResponse", () => {
     it("passes when response field matches expected value", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({ allowed: true, reason: "ok" }));


### PR DESCRIPTION
## Summary
- http-call Windmill script now resolves `{placeholder}` tokens in URL paths using a new `params` input
- LLM prompt updated to document the `params.*` convention for path parameters with example
- Also fixed all 12 active workflow DAGs in the database: replaced `path.brandId` → `params.brandId` and added missing mappings

## Test plan
- [x] Unit tests: path param resolution (single and multiple params)
- [x] Backward compatibility test: works without params
- [x] All 264 tests pass
- [x] Database verified: zero active workflows with unresolved `{brandId}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)