### PR TITLE
fix: sync all Windmill flows on startup

### DIFF
--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -145,6 +145,30 @@ export async function validateAndUpgradeWorkflows(
       `[workflow-service] ${failedCount} workflow(s) have broken endpoints that could not be auto-upgraded. Fix the workflows or provide the platform Anthropic key, then restart.`,
     );
   }
+
+  // 5. Sync all active workflows to Windmill — ensures DB DAG changes
+  //    (e.g. new inputMapping fields) are reflected in Windmill flows.
+  //    Re-fetch active workflows since upgrades may have changed them.
+  if (windmillClient) {
+    const currentActive = await database
+      .select()
+      .from(workflows)
+      .where(eq(workflows.status, "active"));
+
+    let synced = 0;
+    for (const wf of currentActive) {
+      try {
+        await syncFlowToWindmill(wf, windmillClient);
+        synced++;
+      } catch (err) {
+        console.warn(
+          `[workflow-service] Failed to sync flow for "${wf.name}":`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+    console.log(`[workflow-service] Synced ${synced}/${currentActive.length} flows to Windmill`);
+  }
 }
 
 async function attemptUpgrade(
@@ -308,6 +332,37 @@ async function attemptUpgrade(
       }
     }
     throw err;
+  }
+}
+
+async function syncFlowToWindmill(
+  wf: Workflow,
+  windmillClient: WindmillClient,
+): Promise<void> {
+  const dag = wf.dag as DAG;
+  const openFlow = dagToOpenFlow(dag, wf.name);
+  const flowPath = `f/workflows/${wf.orgId}/${wf.name.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
+
+  try {
+    await windmillClient.updateFlow(flowPath, {
+      summary: wf.name,
+      description: wf.description ?? "",
+      value: openFlow.value,
+      schema: openFlow.schema,
+    });
+  } catch (updateErr) {
+    const msg = updateErr instanceof Error ? updateErr.message : String(updateErr);
+    if (msg.includes("not found") || msg.includes("404")) {
+      await windmillClient.createFlow({
+        path: flowPath,
+        summary: wf.name,
+        description: wf.description ?? "",
+        value: openFlow.value,
+        schema: openFlow.schema,
+      });
+    } else {
+      throw updateErr;
+    }
   }
 }
 

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -155,20 +155,18 @@ describe("validateAndUpgradeWorkflows", () => {
       select: () => ({
         from: () => {
           selectCallCount++;
-          const currentCount = selectCallCount;
 
-          const getData = () => {
-            if (currentCount === 1) {
-              return Promise.resolve(dbSelectResult);
-            }
-            return Promise.resolve(
+          // Non-where calls after the first return signatureName-only (for collision detection)
+          const signatureData = () =>
+            Promise.resolve(
               dbSelectResult.map((r) => ({ signatureName: (r as Record<string, unknown>).signatureName })),
             );
-          };
 
-          // Return a thenable with .where() — supports both `await db.select().from()` and `.from().where()`
-          const promise = getData();
-          (promise as any).where = () => getData();
+          // .where() calls always return full workflow objects (active workflows query + sync query)
+          const fullData = () => Promise.resolve(dbSelectResult);
+
+          const promise = signatureData();
+          (promise as any).where = () => fullData();
           return promise;
         },
       }),
@@ -223,6 +221,42 @@ describe("validateAndUpgradeWorkflows", () => {
 
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining("1 valid"),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it("syncs all active workflows to Windmill on startup", async () => {
+    dbSelectResult = [VALID_WORKFLOW];
+    mockFetchSpecsForServices.mockResolvedValue(
+      new Map([["campaign", CAMPAIGN_SPEC]]),
+    );
+
+    const mockUpdateFlow = vi.fn().mockResolvedValue(undefined);
+    const mockCreateFlow = vi.fn();
+
+    const consoleSpy = vi.spyOn(console, "log");
+
+    await validateAndUpgradeWorkflows({
+      db: createMockDb() as any,
+      windmillClient: {
+        updateFlow: mockUpdateFlow,
+        createFlow: mockCreateFlow,
+      } as any,
+    });
+
+    // Should have synced the valid workflow's flow to Windmill
+    expect(mockUpdateFlow).toHaveBeenCalledTimes(1);
+    expect(mockUpdateFlow).toHaveBeenCalledWith(
+      expect.stringContaining("f/workflows/org-1/"),
+      expect.objectContaining({
+        summary: VALID_WORKFLOW.name,
+        value: expect.any(Object),
+        schema: expect.any(Object),
+      }),
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Synced 1/1 flows to Windmill"),
     );
     consoleSpy.mockRestore();
   });
@@ -595,8 +629,8 @@ describe("validateAndUpgradeWorkflows", () => {
       } as any,
     });
 
-    // Should have called updateFlow only — no createFlow needed
-    expect(mockUpdateFlow).toHaveBeenCalledTimes(1);
+    // Should have called updateFlow during upgrade + once during sync
+    expect(mockUpdateFlow).toHaveBeenCalledTimes(2);
     expect(mockCreateFlow).not.toHaveBeenCalled();
 
     // The new workflow should still be inserted in the DB
@@ -643,9 +677,9 @@ describe("validateAndUpgradeWorkflows", () => {
       } as any,
     });
 
-    // Should have tried updateFlow first, then fallen back to createFlow
-    expect(mockUpdateFlow).toHaveBeenCalledTimes(1);
-    expect(mockCreateFlow).toHaveBeenCalledTimes(1);
+    // Should have tried updateFlow first, then fallen back to createFlow (upgrade + sync)
+    expect(mockUpdateFlow).toHaveBeenCalledTimes(2);
+    expect(mockCreateFlow).toHaveBeenCalledTimes(2);
 
     expect(dbInserts.length).toBe(1);
     expect(dbInserts[0].status).toBe("active");


### PR DESCRIPTION
## Summary
- Startup validator now syncs ALL active workflows' flows to Windmill after validation
- Ensures DB DAG changes (like adding `params.brandId`) are reflected in Windmill flows
- Fixes "fetch() URL is invalid" errors caused by Windmill flows missing `params` input_transforms

## Context
After PR #99 added path param support and we fixed DAGs in the database, the Windmill flows still had old `input_transforms` without `params`. The http-call script received `params = undefined` and couldn't resolve `{brandId}` in the URL.

## Test plan
- [x] New test: "syncs all active workflows to Windmill on startup"
- [x] Updated assertions for upgrade+sync call counts
- [x] All 265 tests pass
- [x] TypeScript build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)