### PR TITLE
fix: use GET for brand sales-profile in prompt example

### DIFF
--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -251,7 +251,7 @@ Campaign service orchestrates workflow execution with budget constraints. Key co
     {
       "id": "brand-profile",
       "type": "http.call",
-      "config": { "service": "brand", "method": "POST", "path": "/brands/{brandId}/sales-profile" },
+      "config": { "service": "brand", "method": "GET", "path": "/brands/{brandId}/sales-profile" },
       "inputMapping": { "params.brandId": "$ref:start-run.output.brandId" }
     },
     {


### PR DESCRIPTION
## Summary
- Changed brand-profile example in prompt template from POST to GET
- POST creates a new profile (fails 409 if exists), GET reads the existing one
- Prevents LLM from copying the wrong HTTP method when generating new workflows
- Also fixed all 13 active DAGs in production database (POST → GET)

## Test plan
- [x] All 265 tests pass
- [x] Build passes
- [x] Verified brand service OpenAPI spec: GET/POST/PUT are clearly documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)