### PR TITLE
fix: align prompt template with content-generation breaking changes

### DIFF
--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -202,6 +202,19 @@ ${nodeTypes}
 
 Prefer "http.call" over legacy named types for new workflows.
 
+## Content Generation + Email Send Pattern
+
+When using content-generation service (\`POST /generate\`):
+- \`body.type\` MUST be "cold-email" (matches the registered prompt type) — do NOT use "email", "cold_outreach", or other variants
+- Pass lead/brand data as \`body.variables.*\` (variable substitution into the prompt template)
+- Include tracking fields: \`body.brandId\`, \`body.campaignId\`, \`body.leadId\`, \`body.workflowName\`, \`body.apolloEnrichmentId\`
+- Response contains \`subject\` (string) and \`sequence\` (array of { step, bodyHtml, bodyText, daysSinceLastStep })
+
+When sending via email-gateway (\`POST /send\` with \`type: "broadcast"\`):
+- Pass the ENTIRE \`sequence\` array from content-generation output: \`"body.sequence": "$ref:email-generate.output.sequence"\`
+- Required fields: \`to\`, \`subject\`, \`sequence\`, \`recipientFirstName\`, \`recipientLastName\`, \`recipientCompany\`
+- The sequence is variable-length (LLM determines how many follow-up steps) — always pass it as-is
+
 ## Campaign Execution Model
 
 Campaign service orchestrates workflow execution with budget constraints. Key concepts:
@@ -257,15 +270,42 @@ Campaign service orchestrates workflow execution with budget constraints. Key co
     {
       "id": "email-generate",
       "type": "http.call",
-      "config": { "service": "content-generation", "method": "POST", "path": "/generate" },
-      "inputMapping": { "body.lead": "$ref:fetch-lead.output.lead", "body.brandProfile": "$ref:brand-profile.output" },
+      "config": { "service": "content-generation", "method": "POST", "path": "/generate", "body": { "type": "cold-email", "includeAiDisclaimer": true } },
+      "inputMapping": {
+        "body.brandId": "$ref:start-run.output.brandId",
+        "body.campaignId": "$ref:flow_input.campaignId",
+        "body.leadId": "$ref:fetch-lead.output.lead.leadId",
+        "body.workflowName": "$ref:start-run.output.workflowName",
+        "body.apolloEnrichmentId": "$ref:fetch-lead.output.lead.externalId",
+        "body.variables.leadEmail": "$ref:fetch-lead.output.lead.data.email",
+        "body.variables.leadFirstName": "$ref:fetch-lead.output.lead.data.firstName",
+        "body.variables.leadLastName": "$ref:fetch-lead.output.lead.data.lastName",
+        "body.variables.leadTitle": "$ref:fetch-lead.output.lead.data.title",
+        "body.variables.leadCompanyName": "$ref:fetch-lead.output.lead.data.organizationName",
+        "body.variables.leadCompanyDomain": "$ref:fetch-lead.output.lead.data.organizationDomain",
+        "body.variables.clientBrandUrl": "$ref:start-run.output.brandUrl",
+        "body.variables.clientCompanyOverview": "$ref:brand-profile.output.profile.companyOverview",
+        "body.variables.clientValueProposition": "$ref:brand-profile.output.profile.valueProposition",
+        "body.variables.clientTargetAudience": "$ref:brand-profile.output.profile.targetAudience"
+      },
       "retries": 0
     },
     {
       "id": "email-send",
       "type": "http.call",
-      "config": { "service": "email-gateway", "method": "POST", "path": "/send" },
-      "inputMapping": { "body.to": "$ref:fetch-lead.output.lead.data.email", "body.subject": "$ref:email-generate.output.subject", "body.bodyHtml": "$ref:email-generate.output.bodyHtml" },
+      "config": { "service": "email-gateway", "method": "POST", "path": "/send", "body": { "type": "broadcast", "tag": "cold-email" }, "validateResponse": { "field": "success", "equals": true } },
+      "inputMapping": {
+        "body.to": "$ref:fetch-lead.output.lead.data.email",
+        "body.subject": "$ref:email-generate.output.subject",
+        "body.sequence": "$ref:email-generate.output.sequence",
+        "body.leadId": "$ref:fetch-lead.output.lead.leadId",
+        "body.brandId": "$ref:start-run.output.brandId",
+        "body.campaignId": "$ref:flow_input.campaignId",
+        "body.workflowName": "$ref:start-run.output.workflowName",
+        "body.recipientFirstName": "$ref:fetch-lead.output.lead.data.firstName",
+        "body.recipientLastName": "$ref:fetch-lead.output.lead.data.lastName",
+        "body.recipientCompany": "$ref:fetch-lead.output.lead.data.organizationName"
+      },
       "retries": 0
     },
     {

--- a/tests/unit/prompt-templates.test.ts
+++ b/tests/unit/prompt-templates.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { buildSystemPrompt } from "../../src/lib/prompt-templates.js";
+
+describe("buildSystemPrompt", () => {
+  const prompt = buildSystemPrompt();
+
+  it("uses cold-email as the canonical prompt type for content-generation", () => {
+    // The example DAG should use "cold-email" as the prompt type, not "email" or "cold_outreach"
+    expect(prompt).toContain('"type": "cold-email"');
+    expect(prompt).not.toMatch(/"type":\s*"email"/);
+    expect(prompt).not.toContain('"type": "cold_outreach"');
+  });
+
+  it("passes sequence array to email-gateway (not bodyHtml)", () => {
+    // email-send node should reference sequence, not bodyHtml
+    expect(prompt).toContain("$ref:email-generate.output.sequence");
+    expect(prompt).not.toContain("$ref:email-generate.output.bodyHtml");
+  });
+
+  it("includes required content-generation fields in the example", () => {
+    // content-generation POST /generate requires type and variables
+    expect(prompt).toContain("body.variables.leadEmail");
+    expect(prompt).toContain("body.brandId");
+    expect(prompt).toContain("body.campaignId");
+    expect(prompt).toContain("body.leadId");
+  });
+
+  it("includes required email-gateway broadcast fields in the example", () => {
+    // broadcast send requires recipientFirstName, recipientLastName, recipientCompany
+    expect(prompt).toContain("body.recipientFirstName");
+    expect(prompt).toContain("body.recipientLastName");
+    expect(prompt).toContain("body.recipientCompany");
+  });
+
+  it("documents the content-generation + email send pattern", () => {
+    expect(prompt).toContain("Content Generation + Email Send Pattern");
+    expect(prompt).toContain('body.type` MUST be "cold-email"');
+    expect(prompt).toContain("body.variables.*");
+    expect(prompt).toContain("variable-length");
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed the example DAG in `prompt-templates.ts` to match the actual content-generation (`POST /generate`) and email-gateway (`POST /send`) API specs
- Added documentation section "Content Generation + Email Send Pattern" that guides the LLM to use `body.type: "cold-email"`, `body.variables.*` pattern, and pass `sequence` array (not `bodyHtml`)
- Standardized all 13 active workflow DAGs in prod DB from inconsistent types (`"email"`, `"cold_outreach"`) to canonical `"cold-email"`
- Added regression tests ensuring prompt template correctness

## Context
Content-generation PR #47 introduced breaking changes: prompts must be registered at startup, sequence is variable-length, removed `/generate/content` and `/generate/calendar`. The 404 "No prompt found for type=cold-email" errors are caused by mcpfactory not registering prompts — that's a client issue, not ours. But the inconsistent prompt types across LLM-generated workflows (3 different strings for the same thing) made the problem worse.

## Test plan
- [x] All 355 tests pass
- [x] New `prompt-templates.test.ts` verifies canonical type, sequence usage, required fields
- [ ] After merge + redeploy, verify Windmill flow sync picks up DB changes
- [ ] McpFactory must register `cold-email` prompt via `PUT /prompts` for the 404 to resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)