### PR TITLE
feat: add domain field to required-providers

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -381,6 +381,24 @@
           "path"
         ]
       },
+      "ProviderInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Provider name (e.g. 'anthropic', 'apollo')."
+          },
+          "domain": {
+            "type": "string",
+            "nullable": true,
+            "description": "Provider's primary domain for logo lookup (e.g. 'anthropic.com'). Null if unknown."
+          }
+        },
+        "required": [
+          "name",
+          "domain"
+        ]
+      },
       "ProviderRequirementsResponse": {
         "type": "object",
         "properties": {
@@ -401,9 +419,9 @@
           "providers": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/ProviderInfo"
             },
-            "description": "Unique provider names required by this workflow (e.g. ['apollo', 'firecrawl'])."
+            "description": "Providers required by this workflow, with domain info for logo lookup."
           }
         },
         "required": [

--- a/src/lib/provider-domains.ts
+++ b/src/lib/provider-domains.ts
@@ -1,0 +1,36 @@
+/**
+ * Maps provider names (as returned by key-service) to their primary domain.
+ * Used by the dashboard to display provider logos via logo.dev.
+ *
+ * Add new entries here when a new third-party provider is integrated.
+ */
+export const PROVIDER_DOMAINS: Record<string, string> = {
+  anthropic: "anthropic.com",
+  openai: "openai.com",
+  apollo: "apollo.io",
+  instantly: "instantly.ai",
+  stripe: "stripe.com",
+  twilio: "twilio.com",
+  postmark: "postmarkapp.com",
+  firecrawl: "firecrawl.dev",
+  ahrefs: "ahrefs.com",
+  linkedin: "linkedin.com",
+  google: "google.com",
+  meta: "meta.com",
+};
+
+export interface ProviderWithDomain {
+  name: string;
+  domain: string | null;
+}
+
+/**
+ * Enrich a list of provider names with their known domains.
+ * Returns null for domain when no mapping exists.
+ */
+export function enrichProvidersWithDomains(providers: string[]): ProviderWithDomain[] {
+  return providers.map((name) => ({
+    name,
+    domain: PROVIDER_DOMAINS[name] ?? null,
+  }));
+}

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -23,6 +23,7 @@ import { extractHttpEndpoints } from "../lib/extract-http-endpoints.js";
 import { validateWorkflowEndpoints } from "../lib/validate-workflow-endpoints.js";
 import { fetchSpecsForServices } from "../lib/api-registry-client.js";
 import { fetchProviderRequirements, fetchAnthropicKey } from "../lib/key-service-client.js";
+import { enrichProvidersWithDomains } from "../lib/provider-domains.js";
 import { fetchRunCosts, fetchEmailStats } from "../lib/stats-client.js";
 
 const router = Router();
@@ -875,7 +876,7 @@ router.get("/workflows/:id/required-providers", requireApiKey, async (req, res) 
     res.json({
       endpoints,
       requirements: result.requirements,
-      providers: result.providers,
+      providers: enrichProvidersWithDomains(result.providers),
     });
   } catch (err) {
     if (err instanceof Error && err.message.startsWith("key-service error:")) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -398,6 +398,15 @@ export const ServiceEndpointSchema = z
   })
   .openapi("ServiceEndpoint");
 
+export const ProviderInfoSchema = z
+  .object({
+    name: z.string().describe("Provider name (e.g. 'anthropic', 'apollo')."),
+    domain: z.string().nullable().describe(
+      "Provider's primary domain for logo lookup (e.g. 'anthropic.com'). Null if unknown."
+    ),
+  })
+  .openapi("ProviderInfo");
+
 export const ProviderRequirementsResponseSchema = z
   .object({
     endpoints: z.array(ServiceEndpointSchema).describe(
@@ -406,8 +415,8 @@ export const ProviderRequirementsResponseSchema = z
     requirements: z.array(z.unknown()).describe(
       "Provider requirements returned by key-service."
     ),
-    providers: z.array(z.string()).describe(
-      "Unique provider names required by this workflow (e.g. ['apollo', 'firecrawl'])."
+    providers: z.array(ProviderInfoSchema).describe(
+      "Providers required by this workflow, with domain info for logo lookup."
     ),
   })
   .openapi("ProviderRequirementsResponse");

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -563,7 +563,10 @@ describe("GET /workflows/:id/required-providers", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.endpoints).toHaveLength(2);
-    expect(res.body.providers).toEqual(["client", "transactional-email"]);
+    expect(res.body.providers).toEqual([
+      { name: "client", domain: null },
+      { name: "transactional-email", domain: null },
+    ]);
     expect(mockFetchProviderRequirements).toHaveBeenCalledWith(
       [
         { service: "client", method: "POST", path: "/users" },
@@ -571,6 +574,35 @@ describe("GET /workflows/:id/required-providers", () => {
       ],
       { orgId: "org-1", userId: "user-1", runId: "run-caller-1" },
     );
+  });
+
+  it("enriches providers with domain info for known providers", async () => {
+    mockDbRows.push({
+      id: "wf-http",
+      orgId: "org-1",
+      name: "HTTP Flow",
+      dag: DAG_WITH_HTTP_CALL_CHAIN,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    mockFetchProviderRequirements.mockResolvedValue({
+      requirements: [
+        { provider: "anthropic", fields: ["apiKey"] },
+        { provider: "apollo", fields: ["apiKey"] },
+      ],
+      providers: ["anthropic", "apollo"],
+    });
+
+    const res = await request
+      .get("/workflows/wf-http/required-providers")
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.providers).toEqual([
+      { name: "anthropic", domain: "anthropic.com" },
+      { name: "apollo", domain: "apollo.io" },
+    ]);
   });
 
   it("returns empty providers for workflows with no http.call nodes", async () => {

--- a/tests/unit/provider-domains.test.ts
+++ b/tests/unit/provider-domains.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import {
+  enrichProvidersWithDomains,
+  PROVIDER_DOMAINS,
+} from "../../src/lib/provider-domains.js";
+
+describe("enrichProvidersWithDomains", () => {
+  it("enriches known providers with their domain", () => {
+    const result = enrichProvidersWithDomains(["anthropic", "apollo", "instantly"]);
+    expect(result).toEqual([
+      { name: "anthropic", domain: "anthropic.com" },
+      { name: "apollo", domain: "apollo.io" },
+      { name: "instantly", domain: "instantly.ai" },
+    ]);
+  });
+
+  it("returns null domain for unknown providers", () => {
+    const result = enrichProvidersWithDomains(["client", "transactional-email"]);
+    expect(result).toEqual([
+      { name: "client", domain: null },
+      { name: "transactional-email", domain: null },
+    ]);
+  });
+
+  it("handles mix of known and unknown providers", () => {
+    const result = enrichProvidersWithDomains(["anthropic", "some-internal-service"]);
+    expect(result).toEqual([
+      { name: "anthropic", domain: "anthropic.com" },
+      { name: "some-internal-service", domain: null },
+    ]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(enrichProvidersWithDomains([])).toEqual([]);
+  });
+
+  it("covers all expected third-party providers", () => {
+    const expectedProviders = [
+      "anthropic",
+      "openai",
+      "apollo",
+      "instantly",
+      "stripe",
+      "twilio",
+      "postmark",
+      "firecrawl",
+      "ahrefs",
+      "linkedin",
+      "google",
+      "meta",
+    ];
+    for (const provider of expectedProviders) {
+      expect(PROVIDER_DOMAINS[provider]).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Enriches `GET /workflows/{id}/required-providers` response: `providers` array now returns `{ name, domain }` objects instead of plain strings
- Adds static `PROVIDER_DOMAINS` mapping (anthropic.com, apollo.io, instantly.ai, stripe.com, etc.) for logo.dev integration
- Unknown providers return `domain: null` — safe for the dashboard to handle gracefully

## Test plan
- [x] Unit tests for `enrichProvidersWithDomains` (known, unknown, mixed, empty)
- [x] Integration test verifying known providers get enriched with domains
- [x] Existing integration tests updated for new response shape
- [x] All 361 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)