### PR TITLE
fix: rewrite path.* inputMapping to params.* for http.call nodes

### DIFF
--- a/scripts/nodes/http-call.ts
+++ b/scripts/nodes/http-call.ts
@@ -35,11 +35,14 @@ export async function main(
     );
   }
 
-  // Resolve path parameters: "/brands/{brandId}/profile" + params.brandId → "/brands/abc/profile"
+  // Resolve path parameters: "/brands/{brandId}/profile" or "/brands/:brandId/profile"
+  // + params.brandId → "/brands/abc/profile"
   let resolvedPath = path;
   if (params) {
     for (const [key, value] of Object.entries(params)) {
-      resolvedPath = resolvedPath.replace(`{${key}}`, encodeURIComponent(String(value)));
+      const encoded = encodeURIComponent(String(value));
+      resolvedPath = resolvedPath.replace(`{${key}}`, encoded);
+      resolvedPath = resolvedPath.replace(`:${key}`, encoded);
     }
   }
 

--- a/src/lib/dag-to-openflow.ts
+++ b/src/lib/dag-to-openflow.ts
@@ -353,9 +353,24 @@ function nodeToModule(node: DAGNode, dag: DAG): FlowModule | null {
     ? node.config.skipIf : undefined;
   const { retries: _r, stopAfterIf: _s, skipIf: _sk, ...scriptConfig } = node.config ?? {};
 
+  // For http.call nodes, rewrite "path.*" inputMapping keys to "params.*"
+  // so collapseDotNotation doesn't replace the scalar path string with an object.
+  let resolvedInputMapping = node.inputMapping;
+  if (node.type === "http.call" && resolvedInputMapping) {
+    const rewritten: Record<string, string> = {};
+    for (const [key, value] of Object.entries(resolvedInputMapping)) {
+      if (key.startsWith("path.")) {
+        rewritten[`params.${key.slice(5)}`] = value;
+      } else {
+        rewritten[key] = value;
+      }
+    }
+    resolvedInputMapping = rewritten;
+  }
+
   const inputTransforms = buildInputTransforms(
     Object.keys(scriptConfig).length > 0 ? scriptConfig : undefined,
-    node.inputMapping,
+    resolvedInputMapping,
   );
 
   // Auto-inject orgId, userId, runId, and serviceEnvs from flow_input unless explicitly mapped

--- a/src/lib/input-mapping.ts
+++ b/src/lib/input-mapping.ts
@@ -107,9 +107,17 @@ export function collapseDotNotation(
   for (const [root, children] of dotGroups) {
     // If there's a static base for this root key, we spread it first
     const staticBase = result[root]?.type === "static" ? result[root].value : undefined;
-    const baseObj = (staticBase && typeof staticBase === "object" && staticBase !== null)
-      ? staticBase as Record<string, unknown>
-      : undefined;
+
+    // If the static base is a scalar (string, number, etc.), don't replace it
+    // with a collapsed object — keep both the scalar and the dot-notation keys.
+    if (staticBase !== undefined && (typeof staticBase !== "object" || staticBase === null)) {
+      for (const { path, transform } of children) {
+        result[`${root}.${path}`] = transform;
+      }
+      continue;
+    }
+
+    const baseObj = staticBase as Record<string, unknown> | undefined;
 
     // Separate direct fields (body.field) from nested fields (body.metadata.field)
     const directFields = new Map<string, string>();

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -493,6 +493,25 @@ export const DAG_WITH_TWO_BRANCHES: DAG = {
   ],
 };
 
+export const DAG_WITH_PATH_PARAMS: DAG = {
+  nodes: [
+    {
+      id: "track-cost",
+      type: "http.call",
+      config: {
+        body: { amount: 0.1, costType: "email_send" },
+        path: "/runs/:id/costs",
+        method: "POST",
+        service: "runs",
+      },
+      inputMapping: {
+        "path.id": "$ref:start-run.output.runId",
+      },
+    },
+  ],
+  edges: [],
+};
+
 export const POLARITY_WELCOME_DAG: DAG = {
   nodes: [
     {

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -18,6 +18,7 @@ import {
   DAG_WITH_SKIP_IF,
   DAG_WITH_CONDITION_CHAIN,
   DAG_WITH_TWO_BRANCHES,
+  DAG_WITH_PATH_PARAMS,
 } from "../helpers/fixtures.js";
 
 describe("dagToOpenFlow", () => {
@@ -567,6 +568,27 @@ describe("dagToOpenFlow", () => {
       // Nested metadata should merge static source with dynamic emailGenerationId
       expect(expr).toContain('"source"');
       expect(expr).toContain("results.email_generate?.id");
+    }
+  });
+
+  it("regression: rewrites path.* inputMapping to params.* for http.call nodes", () => {
+    const result = dagToOpenFlow(DAG_WITH_PATH_PARAMS, "Track Cost");
+
+    const mod = result.value.modules[0];
+    expect(mod.id).toBe("track_cost");
+    if (mod.value.type === "script") {
+      const transforms = mod.value.input_transforms as Record<
+        string,
+        { type: string; value?: unknown; expr?: string }
+      >;
+      // path should remain the static string, NOT be replaced by an object
+      expect(transforms.path).toEqual({ type: "static", value: "/runs/:id/costs" });
+      // params should contain the dynamic path parameter
+      expect(transforms.params).toBeDefined();
+      expect(transforms.params.type).toBe("javascript");
+      expect(transforms.params.expr).toContain("results.start_run?.runId");
+      // body should still contain the static config
+      expect(transforms.body).toBeDefined();
     }
   });
 });

--- a/tests/unit/http-call.test.ts
+++ b/tests/unit/http-call.test.ts
@@ -185,6 +185,32 @@ describe("http-call script", () => {
       expect(url).toBe("https://campaign.example.com/orgs/org-1/campaigns/camp-2");
     });
 
+    it("replaces :param syntax in path with params values", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ tracked: true }));
+
+      const runsEnvs = {
+        ...serviceEnvs,
+        RUNS_SERVICE_URL: "https://runs.example.com",
+        RUNS_SERVICE_API_KEY: "runs-key-789",
+      };
+
+      await main(
+        "runs", "POST", "/runs/:id/costs",
+        { amount: 0.1, costType: "email_send" },
+        undefined,
+        runsEnvs,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { id: "run-uuid-456" },
+      );
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://runs.example.com/runs/run-uuid-456/costs");
+    });
+
     it("works without params (backward compat)", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
 

--- a/tests/unit/input-mapping.test.ts
+++ b/tests/unit/input-mapping.test.ts
@@ -155,6 +155,20 @@ describe("buildInputTransforms", () => {
     expect(result.body.expr).toContain("results.gen?.id");
   });
 
+  it("regression: does not replace scalar config with collapsed object", () => {
+    const result = buildInputTransforms(
+      { path: "/runs/:id/costs", service: "runs", method: "POST" },
+      { "path.id": "$ref:start-run.output.runId" },
+    );
+
+    // path should remain the scalar string — NOT be replaced by { id: expr }
+    expect(result.path).toEqual({ type: "static", value: "/runs/:id/costs" });
+    // The dot-notation key should be preserved as-is since root is scalar
+    expect(result["path.id"]).toBeDefined();
+    expect(result["path.id"].type).toBe("javascript");
+    expect(result["path.id"].expr).toContain("results.start_run?.runId");
+  });
+
   it("leaves non-dot-notation keys untouched", () => {
     const result = buildInputTransforms(
       { service: "stripe", method: "GET" },


### PR DESCRIPTION
## Summary
- **Root cause**: `collapseDotNotation` replaced the scalar `path` config string (`"/runs/:id/costs"`) with an object `{ id: <runId> }` when `path.id` appeared in inputMapping, producing `[object Object]` in the URL → `fetch() URL is invalid`
- **Fix 1**: `dag-to-openflow.ts` rewrites `path.*` inputMapping keys to `params.*` for `http.call` nodes before transform building
- **Fix 2**: `http-call.ts` now supports `:param` syntax in addition to `{param}` for path parameter resolution
- **Fix 3**: `collapseDotNotation` no longer replaces scalar root values with collapsed objects (defense in depth)

## Test plan
- [x] Regression test in `dag-to-openflow.test.ts`: verifies `path.*` is rewritten to `params.*` and path string is preserved
- [x] Regression test in `input-mapping.test.ts`: verifies scalar config roots are not replaced by collapsed objects
- [x] Regression test in `http-call.test.ts`: verifies `:param` syntax resolves correctly
- [x] All 278 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)