### PR TITLE
fix: forbid cost-tracking nodes in LLM-generated workflows

### DIFF
--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -235,6 +235,7 @@ Campaign service orchestrates workflow execution with budget constraints. Key co
 6. Use "condition" nodes for branching, not skipIf (skipIf only skips one step)
 7. The http.call node auto-injects orgId, userId, and serviceEnvs from flow_input — no need to map them
 8. Campaign workflows should use the chassis pattern: gate-check → start-run → ... → end-run, with onError → end-run-error
+9. NEVER include cost-tracking nodes in workflows. Cost tracking (run costs, usage metering) is handled internally by each downstream service — do NOT add steps that POST to runs-service /costs or any similar cost endpoint
 
 ## Example: Cold Email Outreach with Branching
 
@@ -420,6 +421,7 @@ ${issuesSection}
 - **Use the discovery tools to verify the correct endpoint and schema before fixing**
 - If you cannot find a replacement endpoint, keep the original and note it in the description
 - When fixing field errors, use \`$ref:flow_input.fieldName\` or \`$ref:node-id.output.fieldName\` for dynamic values in inputMapping
+- NEVER add cost-tracking nodes — cost tracking is handled internally by each downstream service
 
 Return the corrected DAG via the create_workflow tool.`;
 }

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -496,16 +496,15 @@ export const DAG_WITH_TWO_BRANCHES: DAG = {
 export const DAG_WITH_PATH_PARAMS: DAG = {
   nodes: [
     {
-      id: "track-cost",
+      id: "fetch-brand",
       type: "http.call",
       config: {
-        body: { amount: 0.1, costType: "email_send" },
-        path: "/runs/:id/costs",
-        method: "POST",
-        service: "runs",
+        path: "/brands/:brandId/sales-profile",
+        method: "GET",
+        service: "brand",
       },
       inputMapping: {
-        "path.id": "$ref:start-run.output.runId",
+        "path.brandId": "$ref:start-run.output.brandId",
       },
     },
   ],

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -572,23 +572,23 @@ describe("dagToOpenFlow", () => {
   });
 
   it("regression: rewrites path.* inputMapping to params.* for http.call nodes", () => {
-    const result = dagToOpenFlow(DAG_WITH_PATH_PARAMS, "Track Cost");
+    const result = dagToOpenFlow(DAG_WITH_PATH_PARAMS, "Fetch Brand");
 
     const mod = result.value.modules[0];
-    expect(mod.id).toBe("track_cost");
+    expect(mod.id).toBe("fetch_brand");
     if (mod.value.type === "script") {
       const transforms = mod.value.input_transforms as Record<
         string,
         { type: string; value?: unknown; expr?: string }
       >;
       // path should remain the static string, NOT be replaced by an object
-      expect(transforms.path).toEqual({ type: "static", value: "/runs/:id/costs" });
+      expect(transforms.path).toEqual({ type: "static", value: "/brands/:brandId/sales-profile" });
       // params should contain the dynamic path parameter
       expect(transforms.params).toBeDefined();
       expect(transforms.params.type).toBe("javascript");
-      expect(transforms.params.expr).toContain("results.start_run?.runId");
-      // body should still contain the static config
-      expect(transforms.body).toBeDefined();
+      expect(transforms.params.expr).toContain("results.start_run?.brandId");
+      // body should NOT exist since there's no static body config
+      expect(transforms.body).toBeUndefined();
     }
   });
 });

--- a/tests/unit/prompt-templates.test.ts
+++ b/tests/unit/prompt-templates.test.ts
@@ -38,4 +38,9 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain("body.variables.*");
     expect(prompt).toContain("variable-length");
   });
+
+  it("forbids cost-tracking nodes in workflows", () => {
+    expect(prompt).toContain("NEVER include cost-tracking nodes");
+    expect(prompt).toContain("handled internally by each downstream service");
+  });
 });


### PR DESCRIPTION
## Summary
- Added rule 9 to the generation system prompt: "NEVER include cost-tracking nodes in workflows"
- Added the same constraint to the upgrade system prompt
- Replaced the `track-cost` test fixture with a `fetch-brand` path-param example (no behavior change to the test — still validates `path.*` → `params.*` rewrite)
- Added regression test asserting the prompt contains the cost-tracking prohibition

## Context
The LLM generated a `track-cost` node in the `sales-email-cold-outreach-headwater` workflow that POSTs to `runs-service /v1/runs/{id}/costs` with `costType: "email_send"`. This cost type doesn't exist and the entire pattern is wrong — cost tracking is handled internally by each downstream service, not via workflow DAG nodes.

## Test plan
- [x] All 279 unit tests pass
- [x] New test asserts prompt contains cost-tracking prohibition
- [x] Path-param rewrite test updated to use non-cost-tracking fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)