### PR TITLE
fix: add concurrency guard to prevent duplicate campaign workflow runs

### DIFF
--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { workflows, workflowRuns } from "../db/schema.js";
 import { requireApiKey } from "../middleware/auth.js";
@@ -103,6 +103,33 @@ router.post(
         return;
       }
 
+      // Concurrency guard: reject if there's already an active run for this campaign+workflow
+      const campaignId = (body.inputs?.campaignId as string | undefined) ?? workflow.campaignId;
+      if (campaignId) {
+        const [activeRun] = await db
+          .select({ id: workflowRuns.id })
+          .from(workflowRuns)
+          .where(
+            and(
+              eq(workflowRuns.campaignId, campaignId),
+              eq(workflowRuns.workflowId, workflow.id),
+              inArray(workflowRuns.status, ["queued", "running"]),
+            )
+          )
+          .limit(1);
+
+        if (activeRun) {
+          console.warn(
+            `[workflow-service] Rejecting duplicate execution: workflow="${workflow.name}" campaign=${campaignId} already has active run ${activeRun.id}`,
+          );
+          res.status(409).json({
+            error: "A run is already active for this campaign",
+            activeRunId: activeRun.id,
+          });
+          return;
+        }
+      }
+
       const userId = res.locals.userId as string;
       const callerRunId = res.locals.runId as string;
 
@@ -146,15 +173,13 @@ router.post(
       }
 
       // Create workflow run in DB
-      // Prefer campaignId/subrequestId from caller inputs over workflow record
-      // (workflow record values are null for deployed workflows; callers pass them at runtime)
       const [run] = await db
         .insert(workflowRuns)
         .values({
           workflowId: workflow.id,
           orgId,
           userId,
-          campaignId: (body.inputs?.campaignId as string | undefined) ?? workflow.campaignId,
+          campaignId,
           subrequestId: (body.inputs?.subrequestId as string | undefined) ?? workflow.subrequestId,
           runId: ownRunId,
           windmillJobId,
@@ -222,6 +247,33 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
       return;
     }
 
+    // Concurrency guard: reject if there's already an active run for this campaign+workflow
+    const campaignId = (body.inputs?.campaignId as string | undefined) ?? workflow.campaignId;
+    if (campaignId) {
+      const [activeRun] = await db
+        .select({ id: workflowRuns.id })
+        .from(workflowRuns)
+        .where(
+          and(
+            eq(workflowRuns.campaignId, campaignId),
+            eq(workflowRuns.workflowId, workflow.id),
+            inArray(workflowRuns.status, ["queued", "running"]),
+          )
+        )
+        .limit(1);
+
+      if (activeRun) {
+        console.warn(
+          `[workflow-service] Rejecting duplicate execution: workflow="${workflow.name}" campaign=${campaignId} already has active run ${activeRun.id}`,
+        );
+        res.status(409).json({
+          error: "A run is already active for this campaign",
+          activeRunId: activeRun.id,
+        });
+        return;
+      }
+    }
+
     const executeUserId = res.locals.userId as string;
     const callerRunId = res.locals.runId as string;
 
@@ -262,14 +314,13 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
     }
 
     // Create workflow run in DB
-    // Prefer campaignId/subrequestId from caller inputs over workflow record
     const [run] = await db
       .insert(workflowRuns)
       .values({
         workflowId: workflow.id,
         orgId,
         userId: executeUserId,
-        campaignId: (body.inputs?.campaignId as string | undefined) ?? workflow.campaignId,
+        campaignId,
         subrequestId: (body.inputs?.subrequestId as string | undefined) ?? workflow.subrequestId,
         runId: ownRunId,
         windmillJobId,

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -7,6 +7,16 @@ const mockRuns: Record<string, unknown>[] = [];
 // Optional queue: when populated, select().from().where() shifts from it
 const mockSelectResponses: Record<string, unknown>[][] = [];
 
+// Helper: creates a thenable query result that also supports .limit()
+function mockQueryResult(data: Record<string, unknown>[]) {
+  const obj = {
+    then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) =>
+      Promise.resolve(data).then(resolve, reject),
+    limit: () => obj,
+  };
+  return obj;
+}
+
 vi.mock("../../src/db/index.js", () => ({
   db: {
     insert: () => ({
@@ -29,12 +39,12 @@ vi.mock("../../src/db/index.js", () => ({
       from: (table: unknown) => ({
         where: () => {
           if (mockSelectResponses.length > 0) {
-            return Promise.resolve(mockSelectResponses.shift()!);
+            return mockQueryResult(mockSelectResponses.shift()!);
           }
           // Simple mock: return first matching item
-          if (mockWorkflows.length > 0) return Promise.resolve([mockWorkflows[0]]);
-          if (mockRuns.length > 0) return Promise.resolve([mockRuns[0]]);
-          return Promise.resolve([]);
+          if (mockWorkflows.length > 0) return mockQueryResult([mockWorkflows[0]]);
+          if (mockRuns.length > 0) return mockQueryResult([mockRuns[0]]);
+          return mockQueryResult([]);
         },
       }),
     }),
@@ -242,16 +252,19 @@ describe("POST /workflows/:id/execute", () => {
   });
 
   it("stores campaignId from inputs, not from workflow record", async () => {
-    mockWorkflows.push({
-      id: "wf-1",
-      orgId: "org-1",
-      name: "Test Flow",
-      campaignId: null,
-      subrequestId: null,
-      windmillFlowPath: "f/workflows/org_1/test_flow",
-      windmillWorkspace: "prod",
-      dag: VALID_LINEAR_DAG,
-    });
+    mockSelectResponses.push(
+      [{  // 1. workflow lookup
+        id: "wf-1",
+        orgId: "org-1",
+        name: "Test Flow",
+        campaignId: null,
+        subrequestId: null,
+        windmillFlowPath: "f/workflows/org_1/test_flow",
+        windmillWorkspace: "prod",
+        dag: VALID_LINEAR_DAG,
+      }],
+      [],  // 2. concurrency check → no active run
+    );
 
     const res = await request
       .post("/workflows/wf-1/execute")
@@ -264,16 +277,19 @@ describe("POST /workflows/:id/execute", () => {
   });
 
   it("falls back to workflow record campaignId when not in inputs", async () => {
-    mockWorkflows.push({
-      id: "wf-1",
-      orgId: "org-1",
-      name: "Test Flow",
-      campaignId: "camp-from-wf",
-      subrequestId: "sub-from-wf",
-      windmillFlowPath: "f/workflows/org_1/test_flow",
-      windmillWorkspace: "prod",
-      dag: VALID_LINEAR_DAG,
-    });
+    mockSelectResponses.push(
+      [{  // 1. workflow lookup
+        id: "wf-1",
+        orgId: "org-1",
+        name: "Test Flow",
+        campaignId: "camp-from-wf",
+        subrequestId: "sub-from-wf",
+        windmillFlowPath: "f/workflows/org_1/test_flow",
+        windmillWorkspace: "prod",
+        dag: VALID_LINEAR_DAG,
+      }],
+      [],  // 2. concurrency check → no active run
+    );
 
     const res = await request
       .post("/workflows/wf-1/execute")
@@ -283,6 +299,54 @@ describe("POST /workflows/:id/execute", () => {
     expect(res.status).toBe(201);
     expect(res.body.campaignId).toBe("camp-from-wf");
     expect(res.body.subrequestId).toBe("sub-from-wf");
+  });
+
+  it("rejects execution when an active run already exists for the same campaign", async () => {
+    mockSelectResponses.push(
+      [{  // 1. workflow lookup
+        id: "wf-1",
+        orgId: "org-1",
+        name: "Test Flow",
+        campaignId: null,
+        windmillFlowPath: "f/workflows/org_1/test_flow",
+        windmillWorkspace: "prod",
+        dag: VALID_LINEAR_DAG,
+      }],
+      [{  // 2. concurrency check → active run exists
+        id: "existing-run-1",
+      }],
+    );
+
+    const res = await request
+      .post("/workflows/wf-1/execute")
+      .set(AUTH)
+      .send({ inputs: { campaignId: "camp-dup" } });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain("already active");
+    expect(res.body.activeRunId).toBe("existing-run-1");
+    expect(mockRunFlow).not.toHaveBeenCalled();
+    expect(mockCreateRun).not.toHaveBeenCalled();
+  });
+
+  it("skips concurrency guard when no campaignId is provided", async () => {
+    mockWorkflows.push({
+      id: "wf-1",
+      orgId: "org-1",
+      name: "Test Flow",
+      campaignId: null,
+      windmillFlowPath: "f/workflows/org_1/test_flow",
+      windmillWorkspace: "prod",
+      dag: VALID_LINEAR_DAG,
+    });
+
+    const res = await request
+      .post("/workflows/wf-1/execute")
+      .set(AUTH)
+      .send({ inputs: { key: "value" } });
+
+    expect(res.status).toBe(201);
+    expect(mockRunFlow).toHaveBeenCalled();
   });
 
   it("requires authentication", async () => {
@@ -374,15 +438,17 @@ describe("POST /workflows/by-name/:name/execute", () => {
   });
 
   it("cross-org: workflow deployed by org-A can be executed by org-B", async () => {
-    // Workflow deployed by a completely different org
-    mockWorkflows.push({
-      id: "wf-cross",
-      orgId: "8c734aed-45ac-4780-a4ee-1fdcbbedeab1",
-      name: "sales-email-cold-outreach-pharaoh",
-      windmillFlowPath: "f/workflows/deployer/sales_email_cold_outreach_pharaoh",
-      windmillWorkspace: "prod",
-      dag: VALID_LINEAR_DAG,
-    });
+    mockSelectResponses.push(
+      [{  // 1. active workflow lookup
+        id: "wf-cross",
+        orgId: "8c734aed-45ac-4780-a4ee-1fdcbbedeab1",
+        name: "sales-email-cold-outreach-pharaoh",
+        windmillFlowPath: "f/workflows/deployer/sales_email_cold_outreach_pharaoh",
+        windmillWorkspace: "prod",
+        dag: VALID_LINEAR_DAG,
+      }],
+      [],  // 2. concurrency check → no active run
+    );
 
     // Execute with a different org in headers
     const CROSS_ORG_AUTH = {
@@ -572,6 +638,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
         windmillWorkspace: "prod",
         dag: VALID_LINEAR_DAG,
       }],
+      [],  // 4. concurrency check → no active run
     );
 
     const res = await request
@@ -582,6 +649,34 @@ describe("POST /workflows/by-name/:name/execute", () => {
     expect(res.status).toBe(201);
     expect(res.body.campaignId).toBe("camp-runtime");
     expect(res.body.subrequestId).toBe("sub-runtime");
+  });
+
+  it("rejects execution when an active run already exists for the same campaign", async () => {
+    mockSelectResponses.push(
+      [{  // 1. active workflow lookup
+        id: "wf-1",
+        orgId: "org-1",
+        name: "campaign-flow",
+        campaignId: null,
+        windmillFlowPath: "f/workflows/org_1/campaign_flow",
+        windmillWorkspace: "prod",
+        dag: VALID_LINEAR_DAG,
+      }],
+      [{  // 2. concurrency check → active run exists
+        id: "existing-run-99",
+      }],
+    );
+
+    const res = await request
+      .post("/workflows/by-name/campaign-flow/execute")
+      .set(AUTH)
+      .send({ inputs: { campaignId: "camp-already-running" } });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain("already active");
+    expect(res.body.activeRunId).toBe("existing-run-99");
+    expect(mockRunFlow).not.toHaveBeenCalled();
+    expect(mockCreateRun).not.toHaveBeenCalled();
   });
 
   it("requires authentication", async () => {


### PR DESCRIPTION
## Summary
- Adds a concurrency guard to both execute endpoints (`POST /workflows/:id/execute` and `POST /workflows/by-name/:name/execute`)
- Before starting a new Windmill flow, checks if there's already a `queued` or `running` workflow_run for the same campaign+workflow — returns 409 if so
- Breaks the self-perpetuating race condition where both success and failure `end-run` paths re-trigger new overlapping workflow runs

## Root cause
The `end-run` node in campaign workflows makes a synchronous HTTP call to campaign-service `POST /end-run`, which re-triggers a new workflow execution. The new flow starts before the current Windmill flow is marked complete. When two concurrent runs exist (seeded by the track-cost cascade from PR #105), both complete and both trigger new runs, perpetuating the pair indefinitely.

## Test plan
- [x] Regression test: execute with campaignId when active run exists → 409
- [x] Regression test: execute without campaignId skips guard (non-campaign workflows unaffected)
- [x] All 368 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)