### PR TITLE
fix: revert concurrency guard that blocks campaign loop

### DIFF
--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { eq, and, inArray } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { workflows, workflowRuns } from "../db/schema.js";
 import { requireApiKey } from "../middleware/auth.js";
@@ -103,33 +103,6 @@ router.post(
         return;
       }
 
-      // Concurrency guard: reject if there's already an active run for this campaign+workflow
-      const campaignId = (body.inputs?.campaignId as string | undefined) ?? workflow.campaignId;
-      if (campaignId) {
-        const [activeRun] = await db
-          .select({ id: workflowRuns.id })
-          .from(workflowRuns)
-          .where(
-            and(
-              eq(workflowRuns.campaignId, campaignId),
-              eq(workflowRuns.workflowId, workflow.id),
-              inArray(workflowRuns.status, ["queued", "running"]),
-            )
-          )
-          .limit(1);
-
-        if (activeRun) {
-          console.warn(
-            `[workflow-service] Rejecting duplicate execution: workflow="${workflow.name}" campaign=${campaignId} already has active run ${activeRun.id}`,
-          );
-          res.status(409).json({
-            error: "A run is already active for this campaign",
-            activeRunId: activeRun.id,
-          });
-          return;
-        }
-      }
-
       const userId = res.locals.userId as string;
       const callerRunId = res.locals.runId as string;
 
@@ -173,13 +146,15 @@ router.post(
       }
 
       // Create workflow run in DB
+      // Prefer campaignId/subrequestId from caller inputs over workflow record
+      // (workflow record values are null for deployed workflows; callers pass them at runtime)
       const [run] = await db
         .insert(workflowRuns)
         .values({
           workflowId: workflow.id,
           orgId,
           userId,
-          campaignId,
+          campaignId: (body.inputs?.campaignId as string | undefined) ?? workflow.campaignId,
           subrequestId: (body.inputs?.subrequestId as string | undefined) ?? workflow.subrequestId,
           runId: ownRunId,
           windmillJobId,
@@ -247,33 +222,6 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
       return;
     }
 
-    // Concurrency guard: reject if there's already an active run for this campaign+workflow
-    const campaignId = (body.inputs?.campaignId as string | undefined) ?? workflow.campaignId;
-    if (campaignId) {
-      const [activeRun] = await db
-        .select({ id: workflowRuns.id })
-        .from(workflowRuns)
-        .where(
-          and(
-            eq(workflowRuns.campaignId, campaignId),
-            eq(workflowRuns.workflowId, workflow.id),
-            inArray(workflowRuns.status, ["queued", "running"]),
-          )
-        )
-        .limit(1);
-
-      if (activeRun) {
-        console.warn(
-          `[workflow-service] Rejecting duplicate execution: workflow="${workflow.name}" campaign=${campaignId} already has active run ${activeRun.id}`,
-        );
-        res.status(409).json({
-          error: "A run is already active for this campaign",
-          activeRunId: activeRun.id,
-        });
-        return;
-      }
-    }
-
     const executeUserId = res.locals.userId as string;
     const callerRunId = res.locals.runId as string;
 
@@ -314,13 +262,14 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
     }
 
     // Create workflow run in DB
+    // Prefer campaignId/subrequestId from caller inputs over workflow record
     const [run] = await db
       .insert(workflowRuns)
       .values({
         workflowId: workflow.id,
         orgId,
         userId: executeUserId,
-        campaignId,
+        campaignId: (body.inputs?.campaignId as string | undefined) ?? workflow.campaignId,
         subrequestId: (body.inputs?.subrequestId as string | undefined) ?? workflow.subrequestId,
         runId: ownRunId,
         windmillJobId,

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -252,19 +252,16 @@ describe("POST /workflows/:id/execute", () => {
   });
 
   it("stores campaignId from inputs, not from workflow record", async () => {
-    mockSelectResponses.push(
-      [{  // 1. workflow lookup
-        id: "wf-1",
-        orgId: "org-1",
-        name: "Test Flow",
-        campaignId: null,
-        subrequestId: null,
-        windmillFlowPath: "f/workflows/org_1/test_flow",
-        windmillWorkspace: "prod",
-        dag: VALID_LINEAR_DAG,
-      }],
-      [],  // 2. concurrency check → no active run
-    );
+    mockWorkflows.push({
+      id: "wf-1",
+      orgId: "org-1",
+      name: "Test Flow",
+      campaignId: null,
+      subrequestId: null,
+      windmillFlowPath: "f/workflows/org_1/test_flow",
+      windmillWorkspace: "prod",
+      dag: VALID_LINEAR_DAG,
+    });
 
     const res = await request
       .post("/workflows/wf-1/execute")
@@ -277,19 +274,16 @@ describe("POST /workflows/:id/execute", () => {
   });
 
   it("falls back to workflow record campaignId when not in inputs", async () => {
-    mockSelectResponses.push(
-      [{  // 1. workflow lookup
-        id: "wf-1",
-        orgId: "org-1",
-        name: "Test Flow",
-        campaignId: "camp-from-wf",
-        subrequestId: "sub-from-wf",
-        windmillFlowPath: "f/workflows/org_1/test_flow",
-        windmillWorkspace: "prod",
-        dag: VALID_LINEAR_DAG,
-      }],
-      [],  // 2. concurrency check → no active run
-    );
+    mockWorkflows.push({
+      id: "wf-1",
+      orgId: "org-1",
+      name: "Test Flow",
+      campaignId: "camp-from-wf",
+      subrequestId: "sub-from-wf",
+      windmillFlowPath: "f/workflows/org_1/test_flow",
+      windmillWorkspace: "prod",
+      dag: VALID_LINEAR_DAG,
+    });
 
     const res = await request
       .post("/workflows/wf-1/execute")
@@ -299,54 +293,6 @@ describe("POST /workflows/:id/execute", () => {
     expect(res.status).toBe(201);
     expect(res.body.campaignId).toBe("camp-from-wf");
     expect(res.body.subrequestId).toBe("sub-from-wf");
-  });
-
-  it("rejects execution when an active run already exists for the same campaign", async () => {
-    mockSelectResponses.push(
-      [{  // 1. workflow lookup
-        id: "wf-1",
-        orgId: "org-1",
-        name: "Test Flow",
-        campaignId: null,
-        windmillFlowPath: "f/workflows/org_1/test_flow",
-        windmillWorkspace: "prod",
-        dag: VALID_LINEAR_DAG,
-      }],
-      [{  // 2. concurrency check → active run exists
-        id: "existing-run-1",
-      }],
-    );
-
-    const res = await request
-      .post("/workflows/wf-1/execute")
-      .set(AUTH)
-      .send({ inputs: { campaignId: "camp-dup" } });
-
-    expect(res.status).toBe(409);
-    expect(res.body.error).toContain("already active");
-    expect(res.body.activeRunId).toBe("existing-run-1");
-    expect(mockRunFlow).not.toHaveBeenCalled();
-    expect(mockCreateRun).not.toHaveBeenCalled();
-  });
-
-  it("skips concurrency guard when no campaignId is provided", async () => {
-    mockWorkflows.push({
-      id: "wf-1",
-      orgId: "org-1",
-      name: "Test Flow",
-      campaignId: null,
-      windmillFlowPath: "f/workflows/org_1/test_flow",
-      windmillWorkspace: "prod",
-      dag: VALID_LINEAR_DAG,
-    });
-
-    const res = await request
-      .post("/workflows/wf-1/execute")
-      .set(AUTH)
-      .send({ inputs: { key: "value" } });
-
-    expect(res.status).toBe(201);
-    expect(mockRunFlow).toHaveBeenCalled();
   });
 
   it("requires authentication", async () => {
@@ -438,17 +384,15 @@ describe("POST /workflows/by-name/:name/execute", () => {
   });
 
   it("cross-org: workflow deployed by org-A can be executed by org-B", async () => {
-    mockSelectResponses.push(
-      [{  // 1. active workflow lookup
-        id: "wf-cross",
-        orgId: "8c734aed-45ac-4780-a4ee-1fdcbbedeab1",
-        name: "sales-email-cold-outreach-pharaoh",
-        windmillFlowPath: "f/workflows/deployer/sales_email_cold_outreach_pharaoh",
-        windmillWorkspace: "prod",
-        dag: VALID_LINEAR_DAG,
-      }],
-      [],  // 2. concurrency check → no active run
-    );
+    // Workflow deployed by a completely different org
+    mockWorkflows.push({
+      id: "wf-cross",
+      orgId: "8c734aed-45ac-4780-a4ee-1fdcbbedeab1",
+      name: "sales-email-cold-outreach-pharaoh",
+      windmillFlowPath: "f/workflows/deployer/sales_email_cold_outreach_pharaoh",
+      windmillWorkspace: "prod",
+      dag: VALID_LINEAR_DAG,
+    });
 
     // Execute with a different org in headers
     const CROSS_ORG_AUTH = {
@@ -638,7 +582,6 @@ describe("POST /workflows/by-name/:name/execute", () => {
         windmillWorkspace: "prod",
         dag: VALID_LINEAR_DAG,
       }],
-      [],  // 4. concurrency check → no active run
     );
 
     const res = await request
@@ -649,34 +592,6 @@ describe("POST /workflows/by-name/:name/execute", () => {
     expect(res.status).toBe(201);
     expect(res.body.campaignId).toBe("camp-runtime");
     expect(res.body.subrequestId).toBe("sub-runtime");
-  });
-
-  it("rejects execution when an active run already exists for the same campaign", async () => {
-    mockSelectResponses.push(
-      [{  // 1. active workflow lookup
-        id: "wf-1",
-        orgId: "org-1",
-        name: "campaign-flow",
-        campaignId: null,
-        windmillFlowPath: "f/workflows/org_1/campaign_flow",
-        windmillWorkspace: "prod",
-        dag: VALID_LINEAR_DAG,
-      }],
-      [{  // 2. concurrency check → active run exists
-        id: "existing-run-99",
-      }],
-    );
-
-    const res = await request
-      .post("/workflows/by-name/campaign-flow/execute")
-      .set(AUTH)
-      .send({ inputs: { campaignId: "camp-already-running" } });
-
-    expect(res.status).toBe(409);
-    expect(res.body.error).toContain("already active");
-    expect(res.body.activeRunId).toBe("existing-run-99");
-    expect(mockRunFlow).not.toHaveBeenCalled();
-    expect(mockCreateRun).not.toHaveBeenCalled();
   });
 
   it("requires authentication", async () => {


### PR DESCRIPTION
## Summary
- Reverts the concurrency guard from PR #106
- The guard blocked ALL end-run re-triggers because end-run executes inside the Windmill flow (flow is still "running"), preventing the next lead from being processed
- The original parallel-runs issue was caused by the track-cost cascade (fixed in PR #105), not by missing concurrency control

## Root cause of the revert
The campaign loop works by: workflow completes → `end-run` step calls campaign-service → campaign-service re-triggers next workflow run. Since `end-run` is a step inside the Windmill flow, the current run is always still "active" when the re-trigger happens. The guard rejected 100% of legitimate re-triggers, effectively freezing all campaigns.

## Test plan
- [x] All 365 tests pass
- [x] Verified in prod logs: guard was blocking legitimate re-triggers (phil@cmroofing.ca campaign stuck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)