### PR TITLE
feat: auto-inject campaignId, brandId, workflowName into every node

### DIFF
--- a/scripts/nodes/http-call.ts
+++ b/scripts/nodes/http-call.ts
@@ -18,6 +18,9 @@ export async function main(
   userId?: string,
   runId?: string,
   params?: Record<string, string>,
+  campaignId?: string,
+  brandId?: string,
+  workflowName?: string,
 ) {
   // Convert service name to env var prefix: "transactional-email" → "TRANSACTIONAL_EMAIL"
   const envPrefix = service.toUpperCase().replace(/-/g, "_");
@@ -60,6 +63,9 @@ export async function main(
   if (orgId) reqHeaders["x-org-id"] = orgId;
   if (userId) reqHeaders["x-user-id"] = userId;
   if (runId) reqHeaders["x-run-id"] = runId;
+  if (campaignId) reqHeaders["x-campaign-id"] = campaignId;
+  if (brandId) reqHeaders["x-brand-id"] = brandId;
+  if (workflowName) reqHeaders["x-workflow-name"] = workflowName;
   // Caller-supplied headers can override identity headers
   if (headers) Object.assign(reqHeaders, headers);
   // Resolved x-api-key always takes precedence

--- a/src/lib/dag-to-openflow.ts
+++ b/src/lib/dag-to-openflow.ts
@@ -72,6 +72,9 @@ export function dagToOpenFlow(dag: DAG, name: string): OpenFlow {
     userId: { type: "string", description: "User identifier" },
     runId: { type: "string", description: "Runs-service run ID for this execution" },
     serviceEnvs: { type: "object", description: "Service URLs and API keys injected by workflow-service" },
+    campaignId: { type: "string", description: "Campaign identifier (auto-injected)" },
+    brandId: { type: "string", description: "Brand identifier (auto-injected)" },
+    workflowName: { type: "string", description: "Workflow name (auto-injected)" },
   };
   for (const node of dag.nodes) {
     if (!node.inputMapping) continue;
@@ -373,18 +376,20 @@ function nodeToModule(node: DAGNode, dag: DAG): FlowModule | null {
     resolvedInputMapping,
   );
 
-  // Auto-inject orgId, userId, runId, and serviceEnvs from flow_input unless explicitly mapped
-  if (!inputTransforms.orgId) {
-    inputTransforms.orgId = { type: "javascript", expr: "flow_input.orgId" };
-  }
-  if (!inputTransforms.userId) {
-    inputTransforms.userId = { type: "javascript", expr: "flow_input.userId" };
-  }
-  if (!inputTransforms.runId) {
-    inputTransforms.runId = { type: "javascript", expr: "flow_input.runId" };
-  }
-  if (!inputTransforms.serviceEnvs) {
-    inputTransforms.serviceEnvs = { type: "javascript", expr: "flow_input.serviceEnvs" };
+  // Auto-inject identity + tracking context from flow_input unless explicitly mapped
+  const autoInjects: Record<string, string> = {
+    orgId: "flow_input.orgId",
+    userId: "flow_input.userId",
+    runId: "flow_input.runId",
+    serviceEnvs: "flow_input.serviceEnvs",
+    campaignId: "flow_input.campaignId",
+    brandId: "flow_input.brandId",
+    workflowName: "flow_input.workflowName",
+  };
+  for (const [key, expr] of Object.entries(autoInjects)) {
+    if (!inputTransforms[key]) {
+      inputTransforms[key] = { type: "javascript", expr };
+    }
   }
   const mod: FlowModule = {
     id: moduleId,
@@ -417,18 +422,20 @@ function buildFailureModule(node: DAGNode): FlowModule | null {
 
   const inputTransforms = buildInputTransforms(node.config, node.inputMapping);
 
-  // Auto-inject orgId, userId, runId, and serviceEnvs from flow_input unless explicitly mapped
-  if (!inputTransforms.orgId) {
-    inputTransforms.orgId = { type: "javascript", expr: "flow_input.orgId" };
-  }
-  if (!inputTransforms.userId) {
-    inputTransforms.userId = { type: "javascript", expr: "flow_input.userId" };
-  }
-  if (!inputTransforms.runId) {
-    inputTransforms.runId = { type: "javascript", expr: "flow_input.runId" };
-  }
-  if (!inputTransforms.serviceEnvs) {
-    inputTransforms.serviceEnvs = { type: "javascript", expr: "flow_input.serviceEnvs" };
+  // Auto-inject identity + tracking context from flow_input unless explicitly mapped
+  const failureAutoInjects: Record<string, string> = {
+    orgId: "flow_input.orgId",
+    userId: "flow_input.userId",
+    runId: "flow_input.runId",
+    serviceEnvs: "flow_input.serviceEnvs",
+    campaignId: "flow_input.campaignId",
+    brandId: "flow_input.brandId",
+    workflowName: "flow_input.workflowName",
+  };
+  for (const [key, expr] of Object.entries(failureAutoInjects)) {
+    if (!inputTransforms[key]) {
+      inputTransforms[key] = { type: "javascript", expr };
+    }
   }
 
   // Inject error context — available to the onError node

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -32,6 +32,8 @@ export async function createRun(opts: {
   userId: string;
   taskName: string;
   workflowName?: string;
+  campaignId?: string;
+  brandId?: string;
 }): Promise<CreateRunResult> {
   const { baseUrl, apiKey } = getRunsServiceConfig();
 
@@ -39,9 +41,9 @@ export async function createRun(opts: {
     serviceName: "workflow",
     taskName: opts.taskName,
   };
-  if (opts.workflowName) {
-    body.workflowName = opts.workflowName;
-  }
+  if (opts.workflowName) body.workflowName = opts.workflowName;
+  if (opts.campaignId) body.campaignId = opts.campaignId;
+  if (opts.brandId) body.brandId = opts.brandId;
 
   const res = await fetch(`${baseUrl}/v1/runs`, {
     method: "POST",

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -106,6 +106,10 @@ router.post(
       const userId = res.locals.userId as string;
       const callerRunId = res.locals.runId as string;
 
+      // Extract tracking context from inputs (campaign workflows always pass these)
+      const campaignId = body.inputs?.campaignId as string | undefined;
+      const brandId = body.inputs?.brandId as string | undefined;
+
       // Create a child run in runs-service (links to caller's run via parentRunId)
       let ownRunId: string | null = null;
       try {
@@ -115,6 +119,8 @@ router.post(
           userId,
           taskName: "execute-workflow",
           workflowName: workflow.name,
+          campaignId,
+          brandId,
         });
         ownRunId = newRunId;
       } catch (err) {
@@ -123,12 +129,12 @@ router.post(
         return;
       }
 
-      // Run in Windmill — inject orgId, userId, and our own runId so nodes can access them
+      // Run in Windmill — inject orgId, userId, runId, and tracking context so nodes can access them
       let windmillJobId: string | null = null;
       const client = getWindmillClient();
       if (client) {
         try {
-          const flowInputs = { ...body.inputs, orgId, userId, runId: ownRunId, serviceEnvs: collectServiceEnvs() };
+          const flowInputs = { ...body.inputs, orgId, userId, runId: ownRunId, workflowName: workflow.name, serviceEnvs: collectServiceEnvs() };
           windmillJobId = await client.runFlow(
             workflow.windmillFlowPath,
             flowInputs
@@ -225,6 +231,10 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
     const executeUserId = res.locals.userId as string;
     const callerRunId = res.locals.runId as string;
 
+    // Extract tracking context from inputs
+    const execCampaignId = body.inputs?.campaignId as string | undefined;
+    const execBrandId = body.inputs?.brandId as string | undefined;
+
     // Create a child run in runs-service (links to caller's run via parentRunId)
     let ownRunId: string | null = null;
     try {
@@ -234,6 +244,8 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
         userId: executeUserId,
         taskName: "execute-workflow",
         workflowName: workflow.name,
+        campaignId: execCampaignId,
+        brandId: execBrandId,
       });
       ownRunId = newRunId;
     } catch (err) {
@@ -242,12 +254,12 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
       return;
     }
 
-    // Run in Windmill — inject orgId, userId, and our own runId so nodes can access them
+    // Run in Windmill — inject orgId, userId, runId, and tracking context so nodes can access them
     let windmillJobId: string | null = null;
     const client = getWindmillClient();
     if (client) {
       try {
-        const flowInputs = { ...body.inputs, orgId, userId: executeUserId, runId: ownRunId, serviceEnvs: collectServiceEnvs() };
+        const flowInputs = { ...body.inputs, orgId, userId: executeUserId, runId: ownRunId, workflowName: workflow.name, serviceEnvs: collectServiceEnvs() };
         windmillJobId = await client.runFlow(
           workflow.windmillFlowPath,
           flowInputs

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -183,8 +183,8 @@ describe("dagToOpenFlow", () => {
     }
   });
 
-  it("auto-injects orgId, userId, runId, and serviceEnvs input_transforms into script modules", () => {
-    const result = dagToOpenFlow(VALID_LINEAR_DAG, "OrgId UserId Inject");
+  it("auto-injects orgId, userId, runId, serviceEnvs, and tracking context into script modules", () => {
+    const result = dagToOpenFlow(VALID_LINEAR_DAG, "Auto Inject");
 
     for (const mod of result.value.modules) {
       if (mod.value.type === "script") {
@@ -207,6 +207,18 @@ describe("dagToOpenFlow", () => {
         expect(transforms.serviceEnvs).toEqual({
           type: "javascript",
           expr: "flow_input.serviceEnvs",
+        });
+        expect(transforms.campaignId).toEqual({
+          type: "javascript",
+          expr: "flow_input.campaignId",
+        });
+        expect(transforms.brandId).toEqual({
+          type: "javascript",
+          expr: "flow_input.brandId",
+        });
+        expect(transforms.workflowName).toEqual({
+          type: "javascript",
+          expr: "flow_input.workflowName",
         });
       }
     }
@@ -339,7 +351,7 @@ describe("dagToOpenFlow", () => {
     const props = (result.schema as Record<string, unknown>).properties as Record<string, unknown>;
     expect(props.orgId).toEqual({ type: "string", description: "Organization identifier" });
     expect(props.userId).toEqual({ type: "string", description: "User identifier" });
-    expect(props.campaignId).toEqual({ type: "string" });
+    expect(props.campaignId).toEqual({ type: "string", description: "Campaign identifier (auto-injected)" });
   });
 
   it("declares flow_input fields from all nodes including onError handler", () => {

--- a/tests/unit/http-call.test.ts
+++ b/tests/unit/http-call.test.ts
@@ -60,6 +60,31 @@ describe("http-call script", () => {
     expect(options.headers["x-run-id"]).toBe("run-uuid-3");
   });
 
+  it("auto-injects tracking headers (x-campaign-id, x-brand-id, x-workflow-name) when provided", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    await main(
+      "lead", "POST", "/buffer/next",
+      { foo: "bar" },
+      undefined,
+      serviceEnvs,
+      undefined,
+      undefined,
+      "org-1",
+      "user-1",
+      "run-1",
+      undefined, // params
+      "camp-123",
+      "brand-456",
+      "sales-email-cold-outreach",
+    );
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers["x-campaign-id"]).toBe("camp-123");
+    expect(options.headers["x-brand-id"]).toBe("brand-456");
+    expect(options.headers["x-workflow-name"]).toBe("sales-email-cold-outreach");
+  });
+
   it("merges custom headers with defaults", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ found: true }));
 

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -81,6 +81,39 @@ describe("createRun", () => {
     );
   });
 
+  it("includes campaignId and brandId in body when provided", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: "new-run-tracking" }),
+      })
+    );
+
+    await createRun({
+      parentRunId: "caller-run-1",
+      orgId: "org-1",
+      userId: "user-1",
+      taskName: "execute-workflow",
+      workflowName: "sales-email-cold-outreach",
+      campaignId: "camp-123",
+      brandId: "brand-456",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:5000/v1/runs",
+      expect.objectContaining({
+        body: JSON.stringify({
+          serviceName: "workflow",
+          taskName: "execute-workflow",
+          workflowName: "sales-email-cold-outreach",
+          campaignId: "camp-123",
+          brandId: "brand-456",
+        }),
+      })
+    );
+  });
+
   it("does not send orgId, userId, or parentRunId in request body", async () => {
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
## Summary
- `dagToOpenFlow()` now auto-injects `campaignId`, `brandId`, `workflowName` from `flow_input` into every node's input_transforms — same pattern as the existing `orgId`/`userId`/`runId` injection
- `http-call.ts` forwards these as `x-campaign-id`, `x-brand-id`, `x-workflow-name` HTTP headers to every downstream service
- `runs-client.ts` now accepts and passes `campaignId`/`brandId` to runs-service, so the workflow run and all child runs inherit tracking context
- `workflow-runs.ts` extracts `campaignId`/`brandId` from inputs and passes them to createRun, and injects `workflowName` into Windmill flow inputs

## Why
LLM-generated DAGs sometimes omit `campaignId` from nodes like `email-generate`, causing downstream services to store `campaign_id = null`. By auto-injecting at the OpenFlow translation level, every node gets these values regardless of what the LLM included. Each downstream service is responsible for reading the headers and storing them.

## Test plan
- [x] dagToOpenFlow injects campaignId/brandId/workflowName into all script modules
- [x] http-call forwards x-campaign-id, x-brand-id, x-workflow-name headers
- [x] runs-client passes campaignId/brandId in request body
- [x] All 367 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)