### PR TITLE
feat: accept and forward tracking headers (x-campaign-id, x-brand-id, x-workflow-name)

### DIFF
--- a/drizzle/0015_add_run_tracking_columns.sql
+++ b/drizzle/0015_add_run_tracking_columns.sql
@@ -1,0 +1,4 @@
+-- Add brand_id and workflow_name to workflow_runs for tracking
+ALTER TABLE "workflow_runs" ADD COLUMN IF NOT EXISTS "brand_id" text;
+--> statement-breakpoint
+ALTER TABLE "workflow_runs" ADD COLUMN IF NOT EXISTS "workflow_name" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1772275506410,
       "tag": "0014_add_workflow_status",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1772361906410,
+      "tag": "0015_add_run_tracking_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -501,6 +501,15 @@
             "type": "string",
             "nullable": true
           },
+          "brandId": {
+            "type": "string",
+            "nullable": true
+          },
+          "workflowName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Name of the workflow that was executed."
+          },
           "subrequestId": {
             "type": "string",
             "nullable": true
@@ -557,6 +566,8 @@
           "workflowId",
           "orgId",
           "campaignId",
+          "brandId",
+          "workflowName",
           "subrequestId",
           "userId",
           "runId",
@@ -1050,6 +1061,36 @@
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -1204,6 +1245,36 @@
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1281,6 +1352,36 @@
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1354,6 +1455,36 @@
             "required": true,
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
             "in": "header"
           }
         ],
@@ -1439,6 +1570,36 @@
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1513,6 +1674,36 @@
             "required": true,
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
             "in": "header"
           }
         ],
@@ -1600,6 +1791,36 @@
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1665,6 +1886,36 @@
             "required": true,
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
             "in": "header"
           }
         ],
@@ -1743,6 +1994,36 @@
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1809,6 +2090,36 @@
             "required": true,
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
             "in": "header"
           }
         ],
@@ -1910,6 +2221,36 @@
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1987,6 +2328,36 @@
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
+            "in": "header"
           }
         ],
         "responses": {
@@ -2044,6 +2415,36 @@
             "required": true,
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
             "in": "header"
           }
         ],
@@ -2122,6 +2523,36 @@
             "required": true,
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
             "in": "header"
           }
         ],
@@ -2278,6 +2709,36 @@
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
+            "in": "header"
           }
         ],
         "responses": {
@@ -2373,6 +2834,36 @@
             "required": true,
             "description": "Run ID for tracing across services. Required.",
             "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
             "in": "header"
           }
         ],

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -52,6 +52,8 @@ export const workflowRuns = pgTable(
     orgId: text("org_id").notNull(),
     userId: text("user_id"),
     campaignId: text("campaign_id"),
+    brandId: text("brand_id"),
+    workflowName: text("workflow_name"),
     subrequestId: text("subrequest_id"),
     runId: text("run_id"),
 

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -45,15 +45,20 @@ export async function createRun(opts: {
   if (opts.campaignId) body.campaignId = opts.campaignId;
   if (opts.brandId) body.brandId = opts.brandId;
 
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": apiKey,
+    "x-org-id": opts.orgId,
+    "x-user-id": opts.userId,
+    "x-run-id": opts.parentRunId,
+  };
+  if (opts.campaignId) headers["x-campaign-id"] = opts.campaignId;
+  if (opts.brandId) headers["x-brand-id"] = opts.brandId;
+  if (opts.workflowName) headers["x-workflow-name"] = opts.workflowName;
+
   const res = await fetch(`${baseUrl}/v1/runs`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": apiKey,
-      "x-org-id": opts.orgId,
-      "x-user-id": opts.userId,
-      "x-run-id": opts.parentRunId,
-    },
+    headers,
     body: JSON.stringify(body),
   });
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -32,5 +32,14 @@ export function requireIdentity(
   res.locals.orgId = orgId;
   res.locals.userId = userId;
   res.locals.runId = runId;
+
+  // Optional tracking headers — read if present, never required
+  const campaignId = req.headers["x-campaign-id"] as string | undefined;
+  const brandId = req.headers["x-brand-id"] as string | undefined;
+  const workflowName = req.headers["x-workflow-name"] as string | undefined;
+  if (campaignId) res.locals.campaignId = campaignId;
+  if (brandId) res.locals.brandId = brandId;
+  if (workflowName) res.locals.workflowName = workflowName;
+
   next();
 }

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -106,9 +106,10 @@ router.post(
       const userId = res.locals.userId as string;
       const callerRunId = res.locals.runId as string;
 
-      // Extract tracking context from inputs (campaign workflows always pass these)
-      const campaignId = body.inputs?.campaignId as string | undefined;
-      const brandId = body.inputs?.brandId as string | undefined;
+      // Extract tracking context: prefer request body inputs, fall back to headers
+      const campaignId = (body.inputs?.campaignId as string | undefined) ?? (res.locals.campaignId as string | undefined);
+      const brandId = (body.inputs?.brandId as string | undefined) ?? (res.locals.brandId as string | undefined);
+      const headerWorkflowName = res.locals.workflowName as string | undefined;
 
       // Create a child run in runs-service (links to caller's run via parentRunId)
       let ownRunId: string | null = null;
@@ -134,7 +135,7 @@ router.post(
       const client = getWindmillClient();
       if (client) {
         try {
-          const flowInputs = { ...body.inputs, orgId, userId, runId: ownRunId, workflowName: workflow.name, serviceEnvs: collectServiceEnvs() };
+          const flowInputs = { ...body.inputs, orgId, userId, runId: ownRunId, workflowName: workflow.name, campaignId, brandId, serviceEnvs: collectServiceEnvs() };
           windmillJobId = await client.runFlow(
             workflow.windmillFlowPath,
             flowInputs
@@ -152,15 +153,16 @@ router.post(
       }
 
       // Create workflow run in DB
-      // Prefer campaignId/subrequestId from caller inputs over workflow record
-      // (workflow record values are null for deployed workflows; callers pass them at runtime)
+      // Prefer resolved campaignId/brandId (from inputs or headers) over workflow record
       const [run] = await db
         .insert(workflowRuns)
         .values({
           workflowId: workflow.id,
           orgId,
           userId,
-          campaignId: (body.inputs?.campaignId as string | undefined) ?? workflow.campaignId,
+          campaignId: campaignId ?? workflow.campaignId,
+          brandId: brandId ?? workflow.brandId,
+          workflowName: workflow.name,
           subrequestId: (body.inputs?.subrequestId as string | undefined) ?? workflow.subrequestId,
           runId: ownRunId,
           windmillJobId,
@@ -231,9 +233,9 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
     const executeUserId = res.locals.userId as string;
     const callerRunId = res.locals.runId as string;
 
-    // Extract tracking context from inputs
-    const execCampaignId = body.inputs?.campaignId as string | undefined;
-    const execBrandId = body.inputs?.brandId as string | undefined;
+    // Extract tracking context: prefer request body inputs, fall back to headers
+    const execCampaignId = (body.inputs?.campaignId as string | undefined) ?? (res.locals.campaignId as string | undefined);
+    const execBrandId = (body.inputs?.brandId as string | undefined) ?? (res.locals.brandId as string | undefined);
 
     // Create a child run in runs-service (links to caller's run via parentRunId)
     let ownRunId: string | null = null;
@@ -259,7 +261,7 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
     const client = getWindmillClient();
     if (client) {
       try {
-        const flowInputs = { ...body.inputs, orgId, userId: executeUserId, runId: ownRunId, workflowName: workflow.name, serviceEnvs: collectServiceEnvs() };
+        const flowInputs = { ...body.inputs, orgId, userId: executeUserId, runId: ownRunId, workflowName: workflow.name, campaignId: execCampaignId, brandId: execBrandId, serviceEnvs: collectServiceEnvs() };
         windmillJobId = await client.runFlow(
           workflow.windmillFlowPath,
           flowInputs
@@ -274,14 +276,16 @@ router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
     }
 
     // Create workflow run in DB
-    // Prefer campaignId/subrequestId from caller inputs over workflow record
+    // Prefer resolved campaignId/brandId (from inputs or headers) over workflow record
     const [run] = await db
       .insert(workflowRuns)
       .values({
         workflowId: workflow.id,
         orgId,
         userId: executeUserId,
-        campaignId: (body.inputs?.campaignId as string | undefined) ?? workflow.campaignId,
+        campaignId: execCampaignId ?? workflow.campaignId,
+        brandId: execBrandId ?? workflow.brandId,
+        workflowName: workflow.name,
         subrequestId: (body.inputs?.subrequestId as string | undefined) ?? workflow.subrequestId,
         runId: ownRunId,
         windmillJobId,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -187,6 +187,8 @@ export const WorkflowRunResponseSchema = z
     workflowId: z.string().uuid().nullable(),
     orgId: z.string(),
     campaignId: z.string().nullable(),
+    brandId: z.string().nullable(),
+    workflowName: z.string().nullable().describe("Name of the workflow that was executed."),
     subrequestId: z.string().nullable(),
     userId: z.string().nullable().describe("User ID from the execution context."),
     runId: z.string().nullable().describe("Runs-service run ID for this execution (auto-created)."),
@@ -445,6 +447,9 @@ const IdentityHeaders = z.object({
   "x-org-id": z.string().describe("Internal org UUID (from client-service). Required."),
   "x-user-id": z.string().describe("Internal user UUID (from client-service). Required."),
   "x-run-id": z.string().describe("Run ID for tracing across services. Required."),
+  "x-campaign-id": z.string().optional().describe("Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."),
+  "x-brand-id": z.string().optional().describe("Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."),
+  "x-workflow-name": z.string().optional().describe("Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."),
 });
 
 // --- Register Paths ---

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -81,7 +81,7 @@ describe("createRun", () => {
     );
   });
 
-  it("includes campaignId and brandId in body when provided", async () => {
+  it("includes campaignId and brandId in body and forwards tracking headers when provided", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -103,6 +103,11 @@ describe("createRun", () => {
     expect(fetch).toHaveBeenCalledWith(
       "http://localhost:5000/v1/runs",
       expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-campaign-id": "camp-123",
+          "x-brand-id": "brand-456",
+          "x-workflow-name": "sales-email-cold-outreach",
+        }),
         body: JSON.stringify({
           serviceName: "workflow",
           taskName: "execute-workflow",
@@ -112,6 +117,28 @@ describe("createRun", () => {
         }),
       })
     );
+  });
+
+  it("does not send tracking headers when campaignId/brandId are not provided", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: "new-run-no-tracking" }),
+      })
+    );
+
+    await createRun({
+      parentRunId: "caller-run-1",
+      orgId: "org-1",
+      userId: "user-1",
+      taskName: "execute-workflow",
+    });
+
+    const calledHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+    expect(calledHeaders).not.toHaveProperty("x-campaign-id");
+    expect(calledHeaders).not.toHaveProperty("x-brand-id");
+    expect(calledHeaders).not.toHaveProperty("x-workflow-name");
   });
 
   it("does not send orgId, userId, or parentRunId in request body", async () => {

--- a/tests/unit/tracking-headers.test.ts
+++ b/tests/unit/tracking-headers.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+import { requireIdentity } from "../../src/middleware/auth.js";
+
+function mockReqRes(headers: Record<string, string>) {
+  const req = { headers } as unknown as Request;
+  const locals: Record<string, unknown> = {};
+  const res = { locals, status: () => ({ json: () => {} }) } as unknown as Response;
+  return { req, res, locals };
+}
+
+describe("requireIdentity – tracking headers", () => {
+  it("extracts optional x-campaign-id, x-brand-id, x-workflow-name into res.locals", () => {
+    const { req, res, locals } = mockReqRes({
+      "x-org-id": "org-1",
+      "x-user-id": "user-1",
+      "x-run-id": "run-1",
+      "x-campaign-id": "camp-abc",
+      "x-brand-id": "brand-xyz",
+      "x-workflow-name": "sales-email-cold-outreach",
+    });
+
+    let called = false;
+    const next: NextFunction = () => { called = true; };
+
+    requireIdentity(req, res, next);
+
+    expect(called).toBe(true);
+    expect(locals.campaignId).toBe("camp-abc");
+    expect(locals.brandId).toBe("brand-xyz");
+    expect(locals.workflowName).toBe("sales-email-cold-outreach");
+  });
+
+  it("does not set tracking locals when headers are absent", () => {
+    const { req, res, locals } = mockReqRes({
+      "x-org-id": "org-1",
+      "x-user-id": "user-1",
+      "x-run-id": "run-1",
+    });
+
+    let called = false;
+    const next: NextFunction = () => { called = true; };
+
+    requireIdentity(req, res, next);
+
+    expect(called).toBe(true);
+    expect(locals).not.toHaveProperty("campaignId");
+    expect(locals).not.toHaveProperty("brandId");
+    expect(locals).not.toHaveProperty("workflowName");
+  });
+
+  it("still rejects requests missing required identity headers", () => {
+    const req = { headers: { "x-campaign-id": "camp-1" } } as unknown as Request;
+    let statusCode = 0;
+    const res = {
+      locals: {},
+      status: (code: number) => {
+        statusCode = code;
+        return { json: () => {} };
+      },
+    } as unknown as Response;
+
+    let called = false;
+    const next: NextFunction = () => { called = true; };
+
+    requireIdentity(req, res, next);
+
+    expect(called).toBe(false);
+    expect(statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- Middleware now extracts optional `x-campaign-id`, `x-brand-id`, `x-workflow-name` headers and stores them in `res.locals`
- Route handlers use header values as fallback when tracking fields aren't in the request body
- `workflow_runs` table gains `brand_id` and `workflow_name` columns (nullable) via migration 0015
- `runs-client` forwards tracking headers to runs-service on HTTP calls
- OpenAPI spec updated: all endpoints now document the three optional tracking headers
- `WorkflowRunResponse` schema includes `brandId` and `workflowName` fields

## Test plan
- [x] New unit test `tracking-headers.test.ts` covers middleware extraction (present, absent, missing required)
- [x] Updated `runs-client.test.ts` verifies tracking headers are forwarded when provided, omitted when absent
- [x] All 371 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)