### PR TITLE
fix: flatten lead.data into flat variables for POST /generate

### DIFF
--- a/scripts/nodes/content-generation.ts
+++ b/scripts/nodes/content-generation.ts
@@ -1,4 +1,4 @@
-// Windmill node script — calls email-generation POST /generate
+// Windmill node script — calls content-generation POST /generate
 export async function main(
   contentType: string,
   leadData: Record<string, unknown>,
@@ -29,15 +29,29 @@ export async function main(
   if (userId) reqHeaders["x-user-id"] = userId;
   if (resolvedRunId) reqHeaders["x-run-id"] = resolvedRunId;
 
+  // Flatten lead.data.* and clientData into the flat variables format
+  // expected by POST /generate (leadFirstName, leadLastName, etc.)
+  const nested = (leadData?.data ?? leadData) as Record<string, unknown>;
+  const variables: Record<string, unknown> = {
+    leadFirstName: nested.firstName,
+    leadLastName: nested.lastName,
+    leadTitle: nested.title,
+    leadCompanyName: nested.organizationName,
+    leadCompanyIndustry: nested.industry,
+    leadEmail: nested.email,
+    leadCompanyDomain: nested.organizationDomain,
+    clientCompanyName: (clientData as Record<string, unknown>)?.companyName
+      ?? (clientData as Record<string, unknown>)?.name,
+  };
+
   const response = await fetch(
     `${baseUrl}/generate`,
     {
       method: "POST",
       headers: reqHeaders,
       body: JSON.stringify({
-        contentType,
-        leadData,
-        clientData,
+        type: contentType,
+        variables,
         runId: resolvedRunId,
         campaignId: context.campaignId,
         brandId: context.brandId,
@@ -50,6 +64,7 @@ export async function main(
     id: data.id,
     subject: data.subject,
     bodyHtml: data.bodyHtml,
-    email: (leadData as { email?: string }).email,
+    sequence: data.sequence,
+    email: nested.email as string | undefined,
   };
 }

--- a/tests/unit/node-identity-headers.test.ts
+++ b/tests/unit/node-identity-headers.test.ts
@@ -231,12 +231,12 @@ describe("node scripts inject identity headers", () => {
   describe("content-generation", () => {
     it("sends identity headers via top-level params", async () => {
       const { main } = await import("../../scripts/nodes/content-generation.js");
-      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "c1", subject: "Hi", bodyHtml: "<p>hi</p>" }));
+      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "c1", subject: "Hi", bodyHtml: "<p>hi</p>", sequence: [] }));
 
       await main(
-        "email",                                                       // contentType
-        { email: "lead@test.com" },                                    // leadData
-        {},                                                            // clientData
+        "cold-email",                                                  // contentType
+        { data: { email: "lead@test.com", firstName: "Alice" } },      // leadData (nested)
+        { companyName: "Acme" },                                       // clientData
         { orgId: "ctx-org", brandId: "b1", campaignId: "c1", runId: "ctx-run" }, // context
         contentGenEnvs,                                                // serviceEnvs
         "org-uuid-1",                                                  // orgId
@@ -252,11 +252,11 @@ describe("node scripts inject identity headers", () => {
 
     it("falls back to context.orgId and context.runId", async () => {
       const { main } = await import("../../scripts/nodes/content-generation.js");
-      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "c1", subject: "Hi", bodyHtml: "<p>hi</p>" }));
+      mockFetch.mockResolvedValueOnce(jsonResponse({ id: "c1", subject: "Hi", bodyHtml: "<p>hi</p>", sequence: [] }));
 
       await main(
-        "email",
-        { email: "lead@test.com" },
+        "cold-email",
+        { data: { email: "lead@test.com" } },
         {},
         { orgId: "ctx-org", brandId: "b1", campaignId: "c1", runId: "ctx-run" },
         contentGenEnvs,
@@ -266,6 +266,100 @@ describe("node scripts inject identity headers", () => {
       expect(options.headers["x-org-id"]).toBe("ctx-org");
       expect(options.headers["x-run-id"]).toBe("ctx-run");
       expect(options.headers["x-user-id"]).toBeUndefined();
+    });
+
+    it("flattens nested lead.data into flat variables for POST /generate", async () => {
+      const { main } = await import("../../scripts/nodes/content-generation.js");
+      mockFetch.mockResolvedValueOnce(jsonResponse({
+        id: "gen-1",
+        subject: "Hi Alice",
+        bodyHtml: "<p>Hello</p>",
+        sequence: [{ step: 1, bodyHtml: "<p>Hello</p>", bodyText: "Hello", daysSinceLastStep: 0 }],
+      }));
+
+      const leadData = {
+        data: {
+          email: "alice@acme.com",
+          firstName: "Alice",
+          lastName: "Smith",
+          title: "VP Sales",
+          organizationName: "Acme Corp",
+          organizationDomain: "acme.com",
+          industry: "SaaS",
+        },
+      };
+      const clientData = { companyName: "Our Corp" };
+
+      const result = await main(
+        "cold-email",
+        leadData,
+        clientData,
+        { orgId: "org-1", brandId: "b-1", campaignId: "c-1", runId: "r-1" },
+        contentGenEnvs,
+        "org-1",
+        "user-1",
+        "r-1",
+      );
+
+      const [, options] = mockFetch.mock.calls[0];
+      const body = JSON.parse(options.body);
+
+      // Must send "type" not "contentType"
+      expect(body.type).toBe("cold-email");
+      expect(body.contentType).toBeUndefined();
+
+      // Must send flat "variables" not nested "leadData"/"clientData"
+      expect(body.leadData).toBeUndefined();
+      expect(body.clientData).toBeUndefined();
+      expect(body.variables).toEqual({
+        leadEmail: "alice@acme.com",
+        leadFirstName: "Alice",
+        leadLastName: "Smith",
+        leadTitle: "VP Sales",
+        leadCompanyName: "Acme Corp",
+        leadCompanyDomain: "acme.com",
+        leadCompanyIndustry: "SaaS",
+        clientCompanyName: "Our Corp",
+      });
+
+      // Tracking fields
+      expect(body.brandId).toBe("b-1");
+      expect(body.campaignId).toBe("c-1");
+
+      // Return value includes email + sequence
+      expect(result.email).toBe("alice@acme.com");
+      expect(result.sequence).toHaveLength(1);
+    });
+
+    it("handles flat leadData (no nested .data) gracefully", async () => {
+      const { main } = await import("../../scripts/nodes/content-generation.js");
+      mockFetch.mockResolvedValueOnce(jsonResponse({
+        id: "gen-2", subject: "Hi", bodyHtml: "<p>Hi</p>", sequence: [],
+      }));
+
+      // Some callers pass leadData without the .data wrapper
+      const leadData = {
+        email: "bob@co.com",
+        firstName: "Bob",
+        lastName: "Jones",
+        title: "CTO",
+        organizationName: "BigCo",
+      };
+
+      await main(
+        "cold-email",
+        leadData,
+        { name: "Client Inc" },
+        { orgId: "org-1", brandId: "b-1", campaignId: "c-1", runId: "r-1" },
+        contentGenEnvs,
+        "org-1", "user-1", "r-1",
+      );
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.variables.leadFirstName).toBe("Bob");
+      expect(body.variables.leadLastName).toBe("Jones");
+      expect(body.variables.leadEmail).toBe("bob@co.com");
+      expect(body.variables.clientCompanyName).toBe("Client Inc");
     });
   });
 


### PR DESCRIPTION
## Summary
- The legacy `content-generation` node script was sending `leadData` and `clientData` as raw nested objects to `POST /generate`
- content-generation-service expects flat `variables` keys: `leadFirstName`, `leadLastName`, `leadTitle`, `leadCompanyName`, `leadCompanyIndustry`, `clientCompanyName`
- This caused the dedicated DB columns to stay `null`, making the dashboard display "To: —" instead of the recipient name
- Fixed by flattening `lead.data.*` into the expected flat format before the API call
- Handles both nested (`leadData.data.firstName`) and flat (`leadData.firstName`) input gracefully

## Test plan
- [x] Regression test: verifies body sent to `/generate` uses `type` (not `contentType`) and flat `variables` (not nested `leadData`/`clientData`)
- [x] Edge case test: flat leadData without `.data` wrapper
- [x] Existing identity-header tests updated and passing
- [x] All 373 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)