### PR TITLE
fix: validate flat variables in additionalProperties at deploy

### DIFF
--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -206,7 +206,16 @@ Prefer "http.call" over legacy named types for new workflows.
 
 When using content-generation service (\`POST /generate\`):
 - \`body.type\` MUST be "cold-email" (matches the registered prompt type) — do NOT use "email", "cold_outreach", or other variants
-- Pass lead/brand data as \`body.variables.*\` (variable substitution into the prompt template)
+- **CRITICAL: \`body.variables\` MUST contain FLAT keys only.** Each variable must be a separate scalar mapping. NEVER pass an entire object like \`"body.variables.lead": "$ref:fetch-lead.output.lead"\`. Instead, map each field individually:
+  - \`"body.variables.leadFirstName": "$ref:fetch-lead.output.lead.data.firstName"\`
+  - \`"body.variables.leadLastName": "$ref:fetch-lead.output.lead.data.lastName"\`
+  - \`"body.variables.leadTitle": "$ref:fetch-lead.output.lead.data.title"\`
+  - \`"body.variables.leadEmail": "$ref:fetch-lead.output.lead.data.email"\`
+  - \`"body.variables.leadCompanyName": "$ref:fetch-lead.output.lead.data.organizationName"\`
+  - \`"body.variables.leadCompanyDomain": "$ref:fetch-lead.output.lead.data.organizationDomain"\`
+  - \`"body.variables.clientCompanyOverview": "$ref:brand-profile.output.profile.companyOverview"\`
+  - \`"body.variables.clientValueProposition": "$ref:brand-profile.output.profile.valueProposition"\`
+  - \`"body.variables.clientTargetAudience": "$ref:brand-profile.output.profile.targetAudience"\`
 - Include tracking fields: \`body.brandId\`, \`body.campaignId\`, \`body.leadId\`, \`body.workflowName\`, \`body.apolloEnrichmentId\`
 - Response contains \`subject\` (string) and \`sequence\` (array of { step, bodyHtml, bodyText, daysSinceLastStep })
 

--- a/src/lib/validate-workflow-endpoints.ts
+++ b/src/lib/validate-workflow-endpoints.ts
@@ -1,6 +1,6 @@
 import type { DAG, DAGNode } from "./dag-validator.js";
 import { extractHttpEndpoints } from "./extract-http-endpoints.js";
-import { getRequestBodySchema, getResponseSchema } from "./openapi-schema-resolver.js";
+import { getRequestBodySchema, getResponseSchema, resolveSchema } from "./openapi-schema-resolver.js";
 
 export interface InvalidEndpoint {
   service: string;
@@ -174,8 +174,9 @@ function validateFields(
     const hasWholeBodyMapping = node.inputMapping?.body !== undefined &&
       typeof node.inputMapping.body === "string";
 
+    const requestSchema = getRequestBodySchema(spec, path, method);
+
     if (!hasWholeBodyMapping) {
-      const requestSchema = getRequestBodySchema(spec, path, method);
       if (requestSchema) {
         const bodyFields = extractBodyFields(node);
 
@@ -205,6 +206,14 @@ function validateFields(
       }
     }
 
+    // --- Nested object detection in additionalProperties fields ---
+    if (requestSchema && node.inputMapping) {
+      const nestedObjectIssues = validateNoNestedObjects(
+        node, dag, specs, requestSchema, spec, service, method, path,
+      );
+      issues.push(...nestedObjectIssues);
+    }
+
     // --- Output field validation ---
     const responseSchema = getResponseSchema(spec, path, method);
     if (responseSchema) {
@@ -219,6 +228,98 @@ function validateFields(
           });
         }
       }
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * Detects when a body field with additionalProperties (e.g. `variables`)
+ * has a sub-key mapped to a $ref that resolves to an object type in the
+ * upstream node's response schema. This catches the bug where workflows
+ * pass `body.variables.lead = $ref:fetch-lead.output.lead` (entire object)
+ * instead of flat scalar keys like `body.variables.leadFirstName`.
+ */
+function validateNoNestedObjects(
+  node: DAGNode,
+  dag: DAG,
+  specs: Map<string, Record<string, unknown>>,
+  requestSchema: { properties: Record<string, unknown>; required: string[] },
+  _spec: Record<string, unknown>,
+  service: string,
+  method: string,
+  path: string,
+): FieldValidationIssue[] {
+  const issues: FieldValidationIssue[] = [];
+  if (!node.inputMapping) return issues;
+
+  for (const [mappingKey, refValue] of Object.entries(node.inputMapping)) {
+    if (typeof refValue !== "string" || !refValue.startsWith("$ref:")) continue;
+
+    // Match body.X.Y (exactly two levels below body)
+    const bodyMatch = mappingKey.match(/^body\.([^.]+)\.([^.]+)$/);
+    if (!bodyMatch) continue;
+
+    const [, parentField, nestedKey] = bodyMatch;
+
+    // Check if parentField exists and has additionalProperties
+    const fieldSchema = requestSchema.properties[parentField] as Record<string, unknown> | undefined;
+    if (!fieldSchema) continue;
+
+    // Resolve $ref in the field schema itself
+    const resolvedFieldSchema = fieldSchema.$ref
+      ? resolveSchema(fieldSchema as Record<string, unknown>, _spec)
+      : fieldSchema;
+
+    const schemaToCheck = resolvedFieldSchema && "type" in resolvedFieldSchema
+      ? resolvedFieldSchema as Record<string, unknown>
+      : fieldSchema;
+
+    if (schemaToCheck.type !== "object" || !schemaToCheck.additionalProperties) continue;
+
+    // Now check if the $ref target resolves to an object in the upstream response schema
+    const refPath = refValue.replace("$ref:", "");
+    const refParts = refPath.split(".");
+    if (refParts[0] === "flow_input") continue; // flow_input refs are opaque
+
+    const refNodeId = refParts[0];
+    const upstreamNode = dag.nodes.find((n) => n.id === refNodeId);
+    if (!upstreamNode || upstreamNode.type !== "http.call" || !upstreamNode.config) continue;
+
+    const upService = upstreamNode.config.service as string;
+    const upMethod = upstreamNode.config.method as string;
+    const upPath = upstreamNode.config.path as string;
+    if (!upService || !upMethod || !upPath) continue;
+
+    const upSpec = specs.get(upService);
+    if (!upSpec) continue;
+
+    const upResponseSchema = getResponseSchema(upSpec, upPath, upMethod);
+    if (!upResponseSchema) continue;
+
+    // Get the referenced field path, skipping "output" keyword
+    const fieldParts = refParts.slice(1).filter((p) => p !== "output");
+    if (fieldParts.length === 0) continue;
+
+    // If the ref goes deeper than the top-level field (e.g. lead.data.firstName),
+    // it's accessing a nested scalar — that's fine. Only flag when it stops at the
+    // object level (e.g. just "lead" with no further path).
+    if (fieldParts.length > 1) continue;
+
+    const refFieldName = fieldParts[0];
+    const refFieldSchema = upResponseSchema.properties[refFieldName] as Record<string, unknown> | undefined;
+
+    if (refFieldSchema && (refFieldSchema.type === "object" || refFieldSchema.properties)) {
+      issues.push({
+        nodeId: node.id,
+        service,
+        method,
+        path,
+        field: `${parentField}.${nestedKey}`,
+        severity: "error",
+        reason: `"body.${parentField}.${nestedKey}" maps to "${refValue}" which resolves to an object — ${parentField} values must be flat scalars, not nested objects. Map individual fields instead (e.g. body.${parentField}.${nestedKey}FirstName)`,
+      });
     }
   }
 

--- a/tests/unit/prompt-templates.test.ts
+++ b/tests/unit/prompt-templates.test.ts
@@ -35,7 +35,7 @@ describe("buildSystemPrompt", () => {
   it("documents the content-generation + email send pattern", () => {
     expect(prompt).toContain("Content Generation + Email Send Pattern");
     expect(prompt).toContain('body.type` MUST be "cold-email"');
-    expect(prompt).toContain("body.variables.*");
+    expect(prompt).toContain("body.variables` MUST contain FLAT keys only");
     expect(prompt).toContain("variable-length");
   });
 

--- a/tests/unit/validate-workflow-endpoints.test.ts
+++ b/tests/unit/validate-workflow-endpoints.test.ts
@@ -547,3 +547,290 @@ describe("field validation — output fields", () => {
     expect(refs.map((r) => r.field)).toContain("brandId");
   });
 });
+
+describe("field validation — nested object detection in additionalProperties", () => {
+  const CONTENT_GEN_SPEC: Record<string, unknown> = {
+    paths: {
+      "/generate": {
+        post: {
+          summary: "Generate content",
+          requestBody: {
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    type: { type: "string" },
+                    variables: {
+                      type: "object",
+                      additionalProperties: { nullable: true },
+                      description: "Flat variable keys only",
+                    },
+                    brandId: { type: "string" },
+                    campaignId: { type: "string" },
+                    leadId: { type: "string" },
+                    workflowName: { type: "string" },
+                  },
+                  required: ["type", "variables"],
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      subject: { type: "string" },
+                      sequence: { type: "array" },
+                    },
+                    required: ["subject", "sequence"],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const LEAD_SPEC_WITH_SCHEMAS: Record<string, unknown> = {
+    paths: {
+      "/buffer/next": {
+        post: {
+          summary: "Get next lead from buffer",
+          requestBody: {
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    brandId: { type: "string" },
+                    campaignId: { type: "string" },
+                  },
+                  required: ["campaignId"],
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      found: { type: "boolean" },
+                      lead: {
+                        type: "object",
+                        properties: {
+                          leadId: { type: "string" },
+                          email: { type: "string" },
+                          data: {
+                            type: "object",
+                            properties: {
+                              firstName: { type: "string" },
+                              lastName: { type: "string" },
+                              title: { type: "string" },
+                              organizationName: { type: "string" },
+                            },
+                          },
+                        },
+                      },
+                    },
+                    required: ["found"],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const BRAND_SPEC: Record<string, unknown> = {
+    paths: {
+      "/brands/{brandId}/sales-profile": {
+        get: {
+          summary: "Get brand sales profile",
+          responses: {
+            "200": {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      profile: {
+                        type: "object",
+                        properties: {
+                          companyOverview: { type: "string" },
+                          valueProposition: { type: "string" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  it("detects nested object in body.variables.lead (regression: 'To: Unknown recipient' bug)", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "fetch-lead",
+          type: "http.call",
+          config: { service: "lead", method: "POST", path: "/buffer/next" },
+          inputMapping: {
+            "body.campaignId": "$ref:flow_input.campaignId",
+          },
+        },
+        {
+          id: "brand-profile",
+          type: "http.call",
+          config: { service: "brand", method: "GET", path: "/brands/{brandId}/sales-profile" },
+          inputMapping: {
+            "params.brandId": "$ref:flow_input.brandId",
+          },
+        },
+        {
+          id: "email-generate",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "cold-email",
+            "body.variables.lead": "$ref:fetch-lead.output.lead",
+            "body.variables.brandProfile": "$ref:brand-profile.output",
+            "body.variables.targetUrl": "https://example.com",
+          },
+        },
+      ],
+      edges: [
+        { from: "fetch-lead", to: "email-generate" },
+        { from: "brand-profile", to: "email-generate" },
+      ],
+    };
+
+    const specs = new Map([
+      ["content-generation", CONTENT_GEN_SPEC],
+      ["lead", LEAD_SPEC_WITH_SCHEMAS],
+      ["brand", BRAND_SPEC],
+    ]);
+
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    // Should detect that body.variables.lead maps to an object
+    const nestedErrors = result.fieldIssues.filter(
+      (i) => i.severity === "error" && i.field === "variables.lead",
+    );
+    expect(nestedErrors).toHaveLength(1);
+    expect(nestedErrors[0].reason).toContain("object");
+    expect(nestedErrors[0].reason).toContain("flat scalars");
+    expect(result.valid).toBe(false);
+  });
+
+  it("allows flat scalar variables (leadFirstName, leadLastName, etc.)", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "fetch-lead",
+          type: "http.call",
+          config: { service: "lead", method: "POST", path: "/buffer/next" },
+          inputMapping: {
+            "body.campaignId": "$ref:flow_input.campaignId",
+          },
+        },
+        {
+          id: "email-generate",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "cold-email",
+            "body.variables.leadFirstName": "$ref:fetch-lead.output.lead.data.firstName",
+            "body.variables.leadLastName": "$ref:fetch-lead.output.lead.data.lastName",
+            "body.variables.leadTitle": "$ref:fetch-lead.output.lead.data.title",
+            "body.variables.targetUrl": "https://example.com",
+          },
+        },
+      ],
+      edges: [{ from: "fetch-lead", to: "email-generate" }],
+    };
+
+    const specs = new Map([
+      ["content-generation", CONTENT_GEN_SPEC],
+      ["lead", LEAD_SPEC_WITH_SCHEMAS],
+    ]);
+
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    // No nested object errors
+    const nestedErrors = result.fieldIssues.filter(
+      (i) => i.reason.includes("flat scalars"),
+    );
+    expect(nestedErrors).toHaveLength(0);
+  });
+
+  it("skips nested object check for flow_input refs", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "email-generate",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "cold-email",
+            "body.variables.targetUrl": "$ref:flow_input.targetUrl",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const specs = new Map([["content-generation", CONTENT_GEN_SPEC]]);
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    const nestedErrors = result.fieldIssues.filter(
+      (i) => i.reason.includes("flat scalars"),
+    );
+    expect(nestedErrors).toHaveLength(0);
+  });
+
+  it("skips nested object check when upstream spec is unavailable", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "fetch-lead",
+          type: "http.call",
+          config: { service: "unknown-service", method: "POST", path: "/buffer/next" },
+        },
+        {
+          id: "email-generate",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "cold-email",
+            "body.variables.lead": "$ref:fetch-lead.output.lead",
+          },
+        },
+      ],
+      edges: [{ from: "fetch-lead", to: "email-generate" }],
+    };
+
+    const specs = new Map([["content-generation", CONTENT_GEN_SPEC]]);
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    // Can't validate without upstream spec — no error for this specific check
+    const nestedErrors = result.fieldIssues.filter(
+      (i) => i.reason.includes("flat scalars"),
+    );
+    expect(nestedErrors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- The endpoint validator only checked **top-level** body fields (`variables` exists ✅) but never validated the **contents** of `additionalProperties` fields — so `body.variables.lead` (entire lead object) passed validation silently
- Adds `validateNoNestedObjects`: for body fields with `additionalProperties`, traces each `$ref` to the upstream node's response schema and flags when the target resolves to an object type
- Strengthens the LLM prompt template to explicitly list required flat variable keys and forbid passing entire objects

## Root cause
`GenerateRequest.variables` has `additionalProperties: { nullable: true }` which accepts any value type. The validator saw `variables` as a valid top-level field and stopped there. The description says "keys must be flat" but descriptions aren't structurally validated.

## Test plan
- [x] Regression test: detects `body.variables.lead` → `$ref:fetch-lead.output.lead` as error (exact bug scenario)
- [x] Passes flat scalar refs like `body.variables.leadFirstName` → `$ref:fetch-lead.output.lead.data.firstName`
- [x] Skips check for `flow_input` refs (opaque)
- [x] Skips check when upstream spec unavailable (graceful degradation)
- [x] All 377 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)