### PR TITLE
feat: template contract validation in POST /workflows/:id/validate

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -452,6 +452,67 @@
           }
         }
       },
+      "TemplateRef": {
+        "type": "object",
+        "properties": {
+          "nodeId": {
+            "type": "string",
+            "description": "DAG node ID."
+          },
+          "templateType": {
+            "type": "string",
+            "description": "Prompt template type used by this node."
+          },
+          "variablesProvided": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Variable names the workflow provides to this node."
+          }
+        },
+        "required": [
+          "nodeId",
+          "templateType",
+          "variablesProvided"
+        ]
+      },
+      "TemplateContractIssue": {
+        "type": "object",
+        "properties": {
+          "nodeId": {
+            "type": "string",
+            "description": "DAG node ID that calls content-generation."
+          },
+          "templateType": {
+            "type": "string",
+            "description": "Prompt template type (e.g. 'cold-email')."
+          },
+          "field": {
+            "type": "string",
+            "description": "Variable name or template type."
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "error",
+              "warning"
+            ],
+            "description": "'error' = missing required variable, 'warning' = extra/unknown variable."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Human-readable explanation of the issue."
+          }
+        },
+        "required": [
+          "nodeId",
+          "templateType",
+          "field",
+          "severity",
+          "reason"
+        ]
+      },
       "ValidationResult": {
         "type": "object",
         "properties": {
@@ -475,6 +536,34 @@
                 "message"
               ]
             }
+          },
+          "templateContract": {
+            "type": "object",
+            "properties": {
+              "valid": {
+                "type": "boolean"
+              },
+              "templateRefs": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/TemplateRef"
+                },
+                "description": "Content-generation template references found in the DAG."
+              },
+              "issues": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/TemplateContractIssue"
+                },
+                "description": "Variable mismatches between workflow and prompt templates."
+              }
+            },
+            "required": [
+              "valid",
+              "templateRefs",
+              "issues"
+            ],
+            "description": "Template contract validation result. Present when content-generation service is reachable."
           }
         },
         "required": [

--- a/src/lib/content-generation-client.ts
+++ b/src/lib/content-generation-client.ts
@@ -1,0 +1,79 @@
+export interface PromptTemplate {
+  id: string;
+  type: string;
+  prompt: string;
+  variables: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+function getConfig(): { baseUrl: string; apiKey: string } {
+  const baseUrl = process.env.CONTENT_GENERATION_URL;
+  const apiKey = process.env.CONTENT_GENERATION_API_KEY;
+
+  if (!baseUrl || !apiKey) {
+    throw new Error(
+      "CONTENT_GENERATION_URL and CONTENT_GENERATION_API_KEY must be set",
+    );
+  }
+
+  return { baseUrl: baseUrl.replace(/\/$/, ""), apiKey };
+}
+
+/**
+ * Fetches a platform prompt template by type from content-generation service.
+ * Returns null if the template is not found (404).
+ */
+export async function fetchPromptTemplate(
+  type: string,
+): Promise<PromptTemplate | null> {
+  const { baseUrl, apiKey } = getConfig();
+
+  const res = await fetch(
+    `${baseUrl}/platform-prompts?type=${encodeURIComponent(type)}`,
+    {
+      method: "GET",
+      headers: { "x-api-key": apiKey },
+    },
+  );
+
+  if (res.status === 404) return null;
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `content-generation error: GET /platform-prompts?type=${type} -> ${res.status}: ${text}`,
+    );
+  }
+
+  return res.json() as Promise<PromptTemplate>;
+}
+
+/**
+ * Fetches multiple prompt templates by type (deduplicated, resilient).
+ */
+export async function fetchPromptTemplates(
+  types: string[],
+): Promise<Map<string, PromptTemplate>> {
+  const unique = [...new Set(types)];
+  const templates = new Map<string, PromptTemplate>();
+
+  const results = await Promise.allSettled(
+    unique.map(async (type) => {
+      const template = await fetchPromptTemplate(type);
+      return { type, template };
+    }),
+  );
+
+  for (const result of results) {
+    if (result.status === "fulfilled" && result.value.template) {
+      templates.set(result.value.type, result.value.template);
+    } else if (result.status === "rejected") {
+      console.warn(
+        `[content-generation] Failed to fetch prompt: ${result.reason}`,
+      );
+    }
+  }
+
+  return templates;
+}

--- a/src/lib/validate-template-contracts.ts
+++ b/src/lib/validate-template-contracts.ts
@@ -1,0 +1,138 @@
+import type { DAG } from "./dag-validator.js";
+import type { PromptTemplate } from "./content-generation-client.js";
+
+export interface TemplateRef {
+  nodeId: string;
+  templateType: string;
+  variablesProvided: string[];
+}
+
+export interface TemplateContractIssue {
+  nodeId: string;
+  templateType: string;
+  field: string;
+  severity: "error" | "warning";
+  reason: string;
+}
+
+export interface TemplateContractResult {
+  valid: boolean;
+  templateRefs: TemplateRef[];
+  issues: TemplateContractIssue[];
+}
+
+/**
+ * Extracts content-generation template references from a DAG.
+ *
+ * Detects two patterns:
+ * 1. http.call nodes with config.service = "content-generation" and config.path = "/generate"
+ * 2. Legacy "content-generation" node type (uses body.type from inputMapping or config)
+ */
+export function extractTemplateRefs(dag: DAG): TemplateRef[] {
+  const refs: TemplateRef[] = [];
+
+  for (const node of dag.nodes) {
+    const isHttpCallToContentGen =
+      node.type === "http.call" &&
+      node.config?.service === "content-generation" &&
+      node.config?.path === "/generate";
+
+    const isLegacyContentGen = node.type === "content-generation";
+
+    if (!isHttpCallToContentGen && !isLegacyContentGen) continue;
+
+    // Extract template type from inputMapping["body.type"] or config.contentType
+    let templateType: string | undefined;
+
+    if (node.inputMapping?.["body.type"]) {
+      const val = node.inputMapping["body.type"];
+      // Only use literal values, not $ref
+      if (!val.startsWith("$ref:")) {
+        templateType = val;
+      }
+    }
+
+    if (!templateType && typeof node.config?.contentType === "string") {
+      templateType = node.config.contentType;
+    }
+
+    if (!templateType) continue;
+
+    // Extract variables provided via body.variables.* keys
+    const variablesProvided: string[] = [];
+    if (node.inputMapping) {
+      for (const key of Object.keys(node.inputMapping)) {
+        const match = key.match(/^body\.variables\.(.+)$/);
+        if (match) {
+          variablesProvided.push(match[1]);
+        }
+      }
+    }
+
+    refs.push({ nodeId: node.id, templateType, variablesProvided });
+  }
+
+  return refs;
+}
+
+/**
+ * Validates that the variables a workflow provides to content-generation nodes
+ * match the variables declared in the corresponding prompt templates.
+ *
+ * Pure function — no I/O. Call fetchPromptTemplates() separately.
+ */
+export function validateTemplateContracts(
+  dag: DAG,
+  templates: Map<string, PromptTemplate>,
+): TemplateContractResult {
+  const templateRefs = extractTemplateRefs(dag);
+  const issues: TemplateContractIssue[] = [];
+
+  for (const ref of templateRefs) {
+    const template = templates.get(ref.templateType);
+
+    if (!template) {
+      issues.push({
+        nodeId: ref.nodeId,
+        templateType: ref.templateType,
+        field: ref.templateType,
+        severity: "warning",
+        reason: `Template "${ref.templateType}" not found in content-generation service — cannot validate variable contract`,
+      });
+      continue;
+    }
+
+    const declaredVars = new Set(template.variables);
+    const providedVars = new Set(ref.variablesProvided);
+
+    // Missing variables (declared in template but not provided by workflow) → error
+    for (const declared of declaredVars) {
+      if (!providedVars.has(declared)) {
+        issues.push({
+          nodeId: ref.nodeId,
+          templateType: ref.templateType,
+          field: declared,
+          severity: "error",
+          reason: `Template "${ref.templateType}" expects variable "${declared}" but node "${ref.nodeId}" does not provide it. Available variables from this node: ${ref.variablesProvided.join(", ") || "(none)"}`,
+        });
+      }
+    }
+
+    // Extra variables (provided by workflow but not declared in template) → warning
+    for (const provided of providedVars) {
+      if (!declaredVars.has(provided)) {
+        issues.push({
+          nodeId: ref.nodeId,
+          templateType: ref.templateType,
+          field: provided,
+          severity: "warning",
+          reason: `Node "${ref.nodeId}" provides variable "${provided}" but template "${ref.templateType}" does not declare it — this variable will be ignored. Declared variables: ${template.variables.join(", ")}`,
+        });
+      }
+    }
+  }
+
+  const hasErrors = issues.some((i) => i.severity === "error");
+
+  return { valid: !hasErrors, templateRefs, issues };
+}

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -25,6 +25,8 @@ import { fetchSpecsForServices } from "../lib/api-registry-client.js";
 import { fetchProviderRequirements, fetchAnthropicKey } from "../lib/key-service-client.js";
 import { enrichProvidersWithDomains } from "../lib/provider-domains.js";
 import { fetchRunCosts, fetchEmailStats } from "../lib/stats-client.js";
+import { extractTemplateRefs, validateTemplateContracts, type TemplateContractIssue, type TemplateRef } from "../lib/validate-template-contracts.js";
+import { fetchPromptTemplates } from "../lib/content-generation-client.js";
 
 const router = Router();
 
@@ -1005,7 +1007,7 @@ router.delete("/workflows/:id", requireApiKey, async (req, res) => {
   }
 });
 
-// POST /workflows/:id/validate — Validate DAG only
+// POST /workflows/:id/validate — Validate DAG structure + template contracts
 router.post("/workflows/:id/validate", requireApiKey, async (req, res) => {
   try {
     const [workflow] = await db
@@ -1018,8 +1020,29 @@ router.post("/workflows/:id/validate", requireApiKey, async (req, res) => {
       return;
     }
 
-    const validation = validateDAG(workflow.dag as DAG);
-    res.json(validation);
+    const dag = workflow.dag as DAG;
+    const validation = validateDAG(dag);
+
+    // Template contract validation (best-effort — doesn't block if content-gen is unreachable)
+    let templateContract: { valid: boolean; templateRefs: TemplateRef[]; issues: TemplateContractIssue[] } | undefined;
+    try {
+      const templateRefs = extractTemplateRefs(dag);
+      if (templateRefs.length > 0) {
+        const types = templateRefs.map((r) => r.templateType);
+        const templates = await fetchPromptTemplates(types);
+        templateContract = validateTemplateContracts(dag, templates);
+      }
+    } catch (err) {
+      console.warn("[workflow-service] Template contract check skipped:", err instanceof Error ? err.message : err);
+    }
+
+    const result: Record<string, unknown> = { ...validation };
+    if (templateContract) {
+      result.valid = validation.valid && templateContract.valid;
+      result.templateContract = templateContract;
+    }
+
+    res.json(result);
   } catch (err) {
     console.error("[workflow-service] VALIDATE error:", err);
     res.status(500).json({ error: "Internal server error" });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -162,12 +162,38 @@ export const WorkflowResponseSchema = z
   })
   .openapi("WorkflowResponse");
 
+export const TemplateContractIssueSchema = z
+  .object({
+    nodeId: z.string().describe("DAG node ID that calls content-generation."),
+    templateType: z.string().describe("Prompt template type (e.g. 'cold-email')."),
+    field: z.string().describe("Variable name or template type."),
+    severity: z.enum(["error", "warning"]).describe("'error' = missing required variable, 'warning' = extra/unknown variable."),
+    reason: z.string().describe("Human-readable explanation of the issue."),
+  })
+  .openapi("TemplateContractIssue");
+
+export const TemplateRefSchema = z
+  .object({
+    nodeId: z.string().describe("DAG node ID."),
+    templateType: z.string().describe("Prompt template type used by this node."),
+    variablesProvided: z.array(z.string()).describe("Variable names the workflow provides to this node."),
+  })
+  .openapi("TemplateRef");
+
 export const ValidationResultSchema = z
   .object({
     valid: z.boolean(),
     errors: z
       .array(z.object({ field: z.string(), message: z.string() }))
       .optional(),
+    templateContract: z
+      .object({
+        valid: z.boolean(),
+        templateRefs: z.array(TemplateRefSchema).describe("Content-generation template references found in the DAG."),
+        issues: z.array(TemplateContractIssueSchema).describe("Variable mismatches between workflow and prompt templates."),
+      })
+      .optional()
+      .describe("Template contract validation result. Present when content-generation service is reachable."),
   })
   .openapi("ValidationResult");
 

--- a/tests/unit/validate-template-contracts.test.ts
+++ b/tests/unit/validate-template-contracts.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractTemplateRefs,
+  validateTemplateContracts,
+} from "../../src/lib/validate-template-contracts.js";
+import type { DAG } from "../../src/lib/dag-validator.js";
+import type { PromptTemplate } from "../../src/lib/content-generation-client.js";
+
+const COLD_EMAIL_TEMPLATE: PromptTemplate = {
+  id: "e371bd39-b974-43ab-a761-b9717f3e3c42",
+  type: "cold-email",
+  prompt: "Write a cold email for {{leadFirstName}} at {{leadCompanyName}}...",
+  variables: [
+    "leadFirstName",
+    "leadLastName",
+    "leadTitle",
+    "leadCompanyName",
+    "leadCompanyIndustry",
+    "clientCompanyName",
+    "brandProfile",
+  ],
+  createdAt: "2026-03-12T15:06:04.002Z",
+  updatedAt: "2026-03-17T08:02:50.277Z",
+};
+
+describe("extractTemplateRefs", () => {
+  it("extracts template type and variables from http.call content-generation node", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "email-generate",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "cold-email",
+            "body.variables.leadFirstName": "$ref:fetch-lead.output.lead.data.firstName",
+            "body.variables.leadLastName": "$ref:fetch-lead.output.lead.data.lastName",
+            "body.variables.brandProfile": "$ref:brand-profile.output.profile",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const refs = extractTemplateRefs(dag);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].nodeId).toBe("email-generate");
+    expect(refs[0].templateType).toBe("cold-email");
+    expect(refs[0].variablesProvided).toEqual(
+      expect.arrayContaining(["leadFirstName", "leadLastName", "brandProfile"]),
+    );
+  });
+
+  it("ignores non-content-generation http.call nodes", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/gate-check" },
+          inputMapping: { "body.type": "cold-email" },
+        },
+      ],
+      edges: [],
+    };
+
+    const refs = extractTemplateRefs(dag);
+    expect(refs).toHaveLength(0);
+  });
+
+  it("ignores http.call to content-generation with non-/generate path", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "stats",
+          type: "http.call",
+          config: { service: "content-generation", method: "GET", path: "/stats" },
+        },
+      ],
+      edges: [],
+    };
+
+    const refs = extractTemplateRefs(dag);
+    expect(refs).toHaveLength(0);
+  });
+
+  it("skips nodes where body.type is a $ref (dynamic template type)", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "email-generate",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "$ref:flow_input.templateType",
+            "body.variables.leadFirstName": "$ref:fetch-lead.output.lead.data.firstName",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const refs = extractTemplateRefs(dag);
+    expect(refs).toHaveLength(0);
+  });
+
+  it("handles legacy content-generation node type", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "gen",
+          type: "content-generation",
+          config: { contentType: "cold-email" },
+          inputMapping: {
+            "body.variables.leadFirstName": "$ref:fetch-lead.output.lead.data.firstName",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const refs = extractTemplateRefs(dag);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].templateType).toBe("cold-email");
+  });
+
+  it("handles multiple content-generation nodes in one DAG", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "email-gen",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "cold-email",
+            "body.variables.leadFirstName": "$ref:lead.output.firstName",
+          },
+        },
+        {
+          id: "linkedin-gen",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "linkedin-dm",
+            "body.variables.leadFirstName": "$ref:lead.output.firstName",
+            "body.variables.leadTitle": "$ref:lead.output.title",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const refs = extractTemplateRefs(dag);
+    expect(refs).toHaveLength(2);
+    expect(refs.map((r) => r.templateType)).toEqual(["cold-email", "linkedin-dm"]);
+  });
+});
+
+describe("validateTemplateContracts", () => {
+  it("returns valid when all variables match", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "email-generate",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "cold-email",
+            "body.variables.leadFirstName": "$ref:lead.output.firstName",
+            "body.variables.leadLastName": "$ref:lead.output.lastName",
+            "body.variables.leadTitle": "$ref:lead.output.title",
+            "body.variables.leadCompanyName": "$ref:lead.output.orgName",
+            "body.variables.leadCompanyIndustry": "$ref:lead.output.industry",
+            "body.variables.clientCompanyName": "$ref:brand.output.name",
+            "body.variables.brandProfile": "$ref:brand.output.profile",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const templates = new Map([["cold-email", COLD_EMAIL_TEMPLATE]]);
+    const result = validateTemplateContracts(dag, templates);
+
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(result.templateRefs).toHaveLength(1);
+  });
+
+  it("detects missing required variable (error)", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "email-generate",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "cold-email",
+            "body.variables.leadFirstName": "$ref:lead.output.firstName",
+            // Missing: leadLastName, leadTitle, leadCompanyName, leadCompanyIndustry, clientCompanyName, brandProfile
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const templates = new Map([["cold-email", COLD_EMAIL_TEMPLATE]]);
+    const result = validateTemplateContracts(dag, templates);
+
+    expect(result.valid).toBe(false);
+    const errors = result.issues.filter((i) => i.severity === "error");
+    expect(errors.length).toBe(6); // 7 declared - 1 provided = 6 missing
+    expect(errors.map((e) => e.field)).toContain("clientCompanyName");
+    expect(errors.map((e) => e.field)).toContain("brandProfile");
+  });
+
+  it("detects extra variable not in template (warning)", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "email-generate",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "cold-email",
+            "body.variables.leadFirstName": "$ref:lead.output.firstName",
+            "body.variables.leadLastName": "$ref:lead.output.lastName",
+            "body.variables.leadTitle": "$ref:lead.output.title",
+            "body.variables.leadCompanyName": "$ref:lead.output.orgName",
+            "body.variables.leadCompanyIndustry": "$ref:lead.output.industry",
+            "body.variables.clientCompanyName": "$ref:brand.output.name",
+            "body.variables.brandProfile": "$ref:brand.output.profile",
+            "body.variables.targetUrl": "https://example.com",
+            "body.variables.callToAction": "click here",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const templates = new Map([["cold-email", COLD_EMAIL_TEMPLATE]]);
+    const result = validateTemplateContracts(dag, templates);
+
+    // Extra vars are warnings, not errors → still valid
+    expect(result.valid).toBe(true);
+    const warnings = result.issues.filter((i) => i.severity === "warning");
+    expect(warnings.length).toBe(2);
+    expect(warnings.map((w) => w.field)).toContain("targetUrl");
+    expect(warnings.map((w) => w.field)).toContain("callToAction");
+  });
+
+  it("warns when template is not found in content-generation", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "email-generate",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "unknown-template",
+            "body.variables.foo": "bar",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const templates = new Map<string, PromptTemplate>();
+    const result = validateTemplateContracts(dag, templates);
+
+    // Template not found → warning, not error (could be org-specific prompt)
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].severity).toBe("warning");
+    expect(result.issues[0].reason).toContain("not found");
+  });
+
+  it("reproduces the Headwaters bug: brandProfile provided but clientCompanyName missing", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "email-generate",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "cold-email",
+            "body.variables.leadTitle": "$ref:fetch-lead.output.lead.data.title",
+            "body.variables.targetUrl": "https://pressbeat.io",
+            "body.variables.brandProfile": "$ref:brand-profile.output",
+            "body.variables.callToAction": "click to visit PressBean.io",
+            "body.variables.leadLastName": "$ref:fetch-lead.output.lead.data.lastName",
+            "body.variables.leadFirstName": "$ref:fetch-lead.output.lead.data.firstName",
+            "body.variables.leadCompanyName": "$ref:fetch-lead.output.lead.data.organizationName",
+            "body.variables.leadCompanyIndustry": "$ref:fetch-lead.output.lead.data.organizationIndustry",
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const templates = new Map([["cold-email", COLD_EMAIL_TEMPLATE]]);
+    const result = validateTemplateContracts(dag, templates);
+
+    // clientCompanyName is missing → error
+    expect(result.valid).toBe(false);
+    const errors = result.issues.filter((i) => i.severity === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe("clientCompanyName");
+
+    // targetUrl and callToAction are extra → warnings
+    const warnings = result.issues.filter((i) => i.severity === "warning");
+    expect(warnings).toHaveLength(2);
+    expect(warnings.map((w) => w.field)).toContain("targetUrl");
+    expect(warnings.map((w) => w.field)).toContain("callToAction");
+  });
+
+  it("returns empty result for DAG with no content-generation nodes", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "gate-check",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/gate-check" },
+        },
+      ],
+      edges: [],
+    };
+
+    const templates = new Map<string, PromptTemplate>();
+    const result = validateTemplateContracts(dag, templates);
+
+    expect(result.valid).toBe(true);
+    expect(result.templateRefs).toHaveLength(0);
+    expect(result.issues).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds cross-service template contract validation to `POST /workflows/:id/validate`
- New `content-generation-client.ts` fetches prompt templates via `GET /platform-prompts?type=` (content-gen PR #52)
- New `validate-template-contracts.ts` extracts content-generation nodes from DAG, compares provided variables against declared template variables
- Returns **errors** for missing variables, **warnings** for extra/unused variables
- Best-effort: if content-generation is unreachable, validation still returns DAG-level results

## Context
Discovered that the Headwaters workflow was sending `brandProfile` to content-generation but the prompt template expected `clientCompanyName` (never provided). This validator would have caught that mismatch at deploy time.

## Test plan
- [x] 12 new unit tests covering extraction, validation, edge cases, and Headwaters regression
- [x] All 304 existing unit tests pass
- [x] TypeScript compiles clean
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)