### PR TITLE
fix: validate template variables at deploy time

### DIFF
--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -454,6 +454,42 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
       }
     }
 
+    // Validate template contracts (variables provided vs declared in prompt templates)
+    try {
+      const allTemplateRefs: TemplateRef[] = [];
+      for (const wf of body.workflows) {
+        allTemplateRefs.push(...extractTemplateRefs(wf.dag as DAG));
+      }
+
+      if (allTemplateRefs.length > 0) {
+        const types = [...new Set(allTemplateRefs.map((r) => r.templateType))];
+        const templates = await fetchPromptTemplates(types);
+
+        const templateErrors: Array<{ index: number; issues: TemplateContractIssue[] }> = [];
+        for (let i = 0; i < body.workflows.length; i++) {
+          const result = validateTemplateContracts(body.workflows[i].dag as DAG, templates);
+          const errors = result.issues.filter((issue) => issue.severity === "error");
+          if (errors.length > 0) {
+            templateErrors.push({ index: i, issues: errors });
+          }
+        }
+
+        if (templateErrors.length > 0) {
+          console.error(
+            `[workflow-service] deploy: rejected — ${templateErrors.length} workflow(s) with missing template variables`,
+          );
+          res.status(400).json({
+            error: "Template contract validation failed",
+            details: templateErrors,
+          });
+          return;
+        }
+      }
+    } catch (err) {
+      console.warn("[workflow-service] deploy: template contract validation skipped:", err instanceof Error ? err.message : err);
+      // Don't block deploy if content-generation is unreachable
+    }
+
     // Fetch all existing signatureNames for this orgId to avoid collisions
     const existingWorkflows = await db
       .select({ signatureName: workflows.signatureName })

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -511,6 +511,48 @@ export const DAG_WITH_PATH_PARAMS: DAG = {
   edges: [],
 };
 
+export const DAG_WITH_CONTENT_GEN_MISSING_VAR: DAG = {
+  nodes: [
+    {
+      id: "email-generate",
+      type: "http.call",
+      config: { service: "content-generation", method: "POST", path: "/generate" },
+      inputMapping: {
+        "body.type": "cold-email",
+        "body.variables.leadFirstName": "$ref:flow_input.leadFirstName",
+        "body.variables.leadLastName": "$ref:flow_input.leadLastName",
+        "body.variables.leadTitle": "$ref:flow_input.leadTitle",
+        "body.variables.leadCompanyName": "$ref:flow_input.leadCompanyName",
+        "body.variables.leadCompanyIndustry": "$ref:flow_input.leadCompanyIndustry",
+        "body.variables.brandProfile": "$ref:flow_input.brandProfile",
+        // Missing: clientCompanyName
+      },
+    },
+  ],
+  edges: [],
+};
+
+export const DAG_WITH_CONTENT_GEN_ALL_VARS: DAG = {
+  nodes: [
+    {
+      id: "email-generate",
+      type: "http.call",
+      config: { service: "content-generation", method: "POST", path: "/generate" },
+      inputMapping: {
+        "body.type": "cold-email",
+        "body.variables.leadFirstName": "$ref:flow_input.leadFirstName",
+        "body.variables.leadLastName": "$ref:flow_input.leadLastName",
+        "body.variables.leadTitle": "$ref:flow_input.leadTitle",
+        "body.variables.leadCompanyName": "$ref:flow_input.leadCompanyName",
+        "body.variables.leadCompanyIndustry": "$ref:flow_input.leadCompanyIndustry",
+        "body.variables.clientCompanyName": "$ref:flow_input.clientCompanyName",
+        "body.variables.brandProfile": "$ref:flow_input.brandProfile",
+      },
+    },
+  ],
+  edges: [],
+};
+
 export const POLARITY_WELCOME_DAG: DAG = {
   nodes: [
     {

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -5,6 +5,8 @@ import {
   DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
   DAG_WITH_HTTP_CALL,
   DAG_WITH_HTTP_CALL_CHAIN,
+  DAG_WITH_CONTENT_GEN_MISSING_VAR,
+  DAG_WITH_CONTENT_GEN_ALL_VARS,
 } from "../helpers/fixtures.js";
 
 // Mock DB
@@ -61,6 +63,14 @@ const mockFetchProviderRequirements = vi.fn();
 vi.mock("../../src/lib/key-service-client.js", () => ({
   fetchProviderRequirements: (...args: unknown[]) =>
     mockFetchProviderRequirements(...args),
+}));
+
+// Mock content-generation client (for template contract validation)
+const mockFetchPromptTemplates = vi.fn().mockResolvedValue(new Map());
+vi.mock("../../src/lib/content-generation-client.js", () => ({
+  fetchPromptTemplate: vi.fn().mockResolvedValue(null),
+  fetchPromptTemplates: (...args: unknown[]) =>
+    mockFetchPromptTemplates(...args),
 }));
 
 // Mock Windmill client
@@ -246,6 +256,8 @@ describe("PUT /workflows/deploy", () => {
   beforeEach(() => {
     mockDbRows.length = 0;
     mockSelectResponses.length = 0;
+    mockFetchPromptTemplates.mockReset();
+    mockFetchPromptTemplates.mockResolvedValue(new Map());
   });
 
   it("deploys a workflow with tags", async () => {
@@ -529,6 +541,111 @@ describe("PUT /workflows/deploy", () => {
       .send({}); // missing workflows
 
     expect(res.status).toBe(400);
+  });
+
+  it("rejects deploy when workflow is missing template variables", async () => {
+    const COLD_EMAIL_TEMPLATE = {
+      id: "tmpl-1",
+      type: "cold-email",
+      prompt: "Write for {{leadFirstName}} at {{clientCompanyName}}...",
+      variables: [
+        "leadFirstName",
+        "leadLastName",
+        "leadTitle",
+        "leadCompanyName",
+        "leadCompanyIndustry",
+        "clientCompanyName",
+        "brandProfile",
+      ],
+      createdAt: "2026-03-12T00:00:00Z",
+      updatedAt: "2026-03-17T00:00:00Z",
+    };
+
+    mockFetchPromptTemplates.mockResolvedValueOnce(
+      new Map([["cold-email", COLD_EMAIL_TEMPLATE]]),
+    );
+
+    const res = await request
+      .put("/workflows/deploy")
+      .set(AUTH)
+      .send({
+        workflows: [
+          {
+            ...DEPLOY_ITEM,
+            dag: DAG_WITH_CONTENT_GEN_MISSING_VAR,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Template contract validation failed");
+    expect(res.body.details).toHaveLength(1);
+    expect(res.body.details[0].issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: "clientCompanyName",
+          severity: "error",
+        }),
+      ]),
+    );
+  });
+
+  it("allows deploy when all template variables are provided", async () => {
+    const COLD_EMAIL_TEMPLATE = {
+      id: "tmpl-1",
+      type: "cold-email",
+      prompt: "Write for {{leadFirstName}} at {{clientCompanyName}}...",
+      variables: [
+        "leadFirstName",
+        "leadLastName",
+        "leadTitle",
+        "leadCompanyName",
+        "leadCompanyIndustry",
+        "clientCompanyName",
+        "brandProfile",
+      ],
+      createdAt: "2026-03-12T00:00:00Z",
+      updatedAt: "2026-03-17T00:00:00Z",
+    };
+
+    mockFetchPromptTemplates.mockResolvedValueOnce(
+      new Map([["cold-email", COLD_EMAIL_TEMPLATE]]),
+    );
+
+    const res = await request
+      .put("/workflows/deploy")
+      .set(AUTH)
+      .send({
+        workflows: [
+          {
+            ...DEPLOY_ITEM,
+            dag: DAG_WITH_CONTENT_GEN_ALL_VARS,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("does not block deploy when content-generation service is unreachable", async () => {
+    mockFetchPromptTemplates.mockRejectedValueOnce(
+      new Error("ECONNREFUSED"),
+    );
+
+    const res = await request
+      .put("/workflows/deploy")
+      .set(AUTH)
+      .send({
+        workflows: [
+          {
+            ...DEPLOY_ITEM,
+            dag: DAG_WITH_CONTENT_GEN_MISSING_VAR,
+          },
+        ],
+      });
+
+    // Should still succeed — template validation is best-effort
+    expect(res.status).toBe(200);
   });
 
 });


### PR DESCRIPTION
## Summary
- Adds template contract validation to `PUT /workflows/deploy` — previously this check only ran on `POST /workflows/:id/validate`
- Workflows that omit required prompt template variables (e.g. `{{clientCompanyName}}` declared in the cold-email template but not provided in the DAG's `body.variables.*`) are now **rejected at deploy time** with a 400 error
- Validation remains best-effort: if the content-generation service is unreachable, deploy proceeds with a warning

## Test plan
- [x] New test: rejects deploy when workflow is missing template variables
- [x] New test: allows deploy when all template variables are provided
- [x] New test: does not block deploy when content-generation service is unreachable
- [x] All 393 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)