### PR TITLE
fix: accept standard env var names for template validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ RUNS_SERVICE_API_KEY=xxx
 # Email gateway service (for email engagement stats in GET /workflows/best)
 EMAIL_GATEWAY_SERVICE_URL=https://email-gateway.distribute.org
 EMAIL_GATEWAY_SERVICE_API_KEY=xxx
+
+# Content generation service (for template contract validation at deploy/validate time)
+CONTENT_GENERATION_SERVICE_URL=https://content-generation.mcpfactory.org
+CONTENT_GENERATION_SERVICE_API_KEY=xxx

--- a/src/lib/content-generation-client.ts
+++ b/src/lib/content-generation-client.ts
@@ -8,12 +8,16 @@ export interface PromptTemplate {
 }
 
 function getConfig(): { baseUrl: string; apiKey: string } {
-  const baseUrl = process.env.CONTENT_GENERATION_URL;
-  const apiKey = process.env.CONTENT_GENERATION_API_KEY;
+  const baseUrl =
+    process.env.CONTENT_GENERATION_SERVICE_URL ??
+    process.env.CONTENT_GENERATION_URL;
+  const apiKey =
+    process.env.CONTENT_GENERATION_SERVICE_API_KEY ??
+    process.env.CONTENT_GENERATION_API_KEY;
 
   if (!baseUrl || !apiKey) {
     throw new Error(
-      "CONTENT_GENERATION_URL and CONTENT_GENERATION_API_KEY must be set",
+      "CONTENT_GENERATION_SERVICE_URL / CONTENT_GENERATION_SERVICE_API_KEY (or legacy CONTENT_GENERATION_URL / CONTENT_GENERATION_API_KEY) must be set",
     );
   }
 
@@ -68,6 +72,10 @@ export async function fetchPromptTemplates(
   for (const result of results) {
     if (result.status === "fulfilled" && result.value.template) {
       templates.set(result.value.type, result.value.template);
+    } else if (result.status === "fulfilled" && !result.value.template) {
+      console.warn(
+        `[content-generation] Prompt "${result.value.type}" returned 404 from content-generation service`,
+      );
     } else if (result.status === "rejected") {
       console.warn(
         `[content-generation] Failed to fetch prompt: ${result.reason}`,

--- a/tests/unit/content-generation-client.test.ts
+++ b/tests/unit/content-generation-client.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// We test getConfig indirectly through fetchPromptTemplate
+// since getConfig is not exported. We mock fetch to avoid real HTTP calls.
+
+describe("content-generation-client", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.CONTENT_GENERATION_URL;
+    delete process.env.CONTENT_GENERATION_API_KEY;
+    delete process.env.CONTENT_GENERATION_SERVICE_URL;
+    delete process.env.CONTENT_GENERATION_SERVICE_API_KEY;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, originalEnv);
+    vi.restoreAllMocks();
+  });
+
+  it("uses CONTENT_GENERATION_SERVICE_URL/API_KEY (standard pattern)", async () => {
+    process.env.CONTENT_GENERATION_SERVICE_URL = "https://cg.example.com";
+    process.env.CONTENT_GENERATION_SERVICE_API_KEY = "key-standard";
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          id: "1",
+          type: "cold-email",
+          prompt: "test",
+          variables: ["leadFirstName"],
+          createdAt: "2026-01-01",
+          updatedAt: "2026-01-01",
+        }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { fetchPromptTemplate } = await import(
+      "../../src/lib/content-generation-client.js"
+    );
+    const result = await fetchPromptTemplate("cold-email");
+
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("cold-email");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://cg.example.com/platform-prompts?type=cold-email",
+      { method: "GET", headers: { "x-api-key": "key-standard" } },
+    );
+  });
+
+  it("falls back to legacy CONTENT_GENERATION_URL/API_KEY", async () => {
+    process.env.CONTENT_GENERATION_URL = "https://cg-legacy.example.com";
+    process.env.CONTENT_GENERATION_API_KEY = "key-legacy";
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          id: "1",
+          type: "cold-email",
+          prompt: "test",
+          variables: [],
+          createdAt: "2026-01-01",
+          updatedAt: "2026-01-01",
+        }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { fetchPromptTemplate } = await import(
+      "../../src/lib/content-generation-client.js"
+    );
+    await fetchPromptTemplate("cold-email");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://cg-legacy.example.com/platform-prompts?type=cold-email",
+      { method: "GET", headers: { "x-api-key": "key-legacy" } },
+    );
+  });
+
+  it("prefers CONTENT_GENERATION_SERVICE_URL over legacy when both are set", async () => {
+    process.env.CONTENT_GENERATION_SERVICE_URL = "https://cg-standard.example.com";
+    process.env.CONTENT_GENERATION_SERVICE_API_KEY = "key-standard";
+    process.env.CONTENT_GENERATION_URL = "https://cg-legacy.example.com";
+    process.env.CONTENT_GENERATION_API_KEY = "key-legacy";
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          id: "1",
+          type: "test",
+          prompt: "test",
+          variables: [],
+          createdAt: "2026-01-01",
+          updatedAt: "2026-01-01",
+        }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { fetchPromptTemplate } = await import(
+      "../../src/lib/content-generation-client.js"
+    );
+    await fetchPromptTemplate("test");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://cg-standard.example.com/platform-prompts?type=test",
+      { method: "GET", headers: { "x-api-key": "key-standard" } },
+    );
+  });
+
+  it("throws when no env vars are set", async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { fetchPromptTemplate } = await import(
+      "../../src/lib/content-generation-client.js"
+    );
+
+    await expect(fetchPromptTemplate("cold-email")).rejects.toThrow(
+      /CONTENT_GENERATION_SERVICE_URL/,
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null on 404", async () => {
+    process.env.CONTENT_GENERATION_SERVICE_URL = "https://cg.example.com";
+    process.env.CONTENT_GENERATION_SERVICE_API_KEY = "key";
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { fetchPromptTemplate } = await import(
+      "../../src/lib/content-generation-client.js"
+    );
+    const result = await fetchPromptTemplate("nonexistent");
+
+    expect(result).toBeNull();
+  });
+
+  it("fetchPromptTemplates logs warning for 404 templates", async () => {
+    process.env.CONTENT_GENERATION_SERVICE_URL = "https://cg.example.com";
+    process.env.CONTENT_GENERATION_SERVICE_API_KEY = "key";
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { fetchPromptTemplates } = await import(
+      "../../src/lib/content-generation-client.js"
+    );
+    const result = await fetchPromptTemplates(["cold-email"]);
+
+    expect(result.size).toBe(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Prompt "cold-email" returned 404'),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- The content-generation client only accepted `CONTENT_GENERATION_URL` / `CONTENT_GENERATION_API_KEY` (legacy pattern), but Railway likely has `CONTENT_GENERATION_SERVICE_URL` / `CONTENT_GENERATION_SERVICE_API_KEY` (standard pattern matching all other services). This caused `getConfig()` to throw inside `Promise.allSettled`, silently producing the misleading "Template 'cold-email' not found" warning during DAG validation.
- Now checks for the standard `*_SERVICE_URL` name first, falls back to legacy.
- Added logging when a template returns 404 (was previously completely silent — no way to distinguish 404 from fetch error).

## Test plan
- [x] New unit tests for both env var patterns, priority order, missing vars, 404 logging (6 tests)
- [x] All 310 existing unit tests pass
- [ ] After merge: verify in Railway that the warning disappears on `POST /workflows/:id/validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)