### PR TITLE
fix: drop legacy CONTENT_GENERATION_URL env vars

### DIFF
--- a/src/lib/content-generation-client.ts
+++ b/src/lib/content-generation-client.ts
@@ -8,16 +8,12 @@ export interface PromptTemplate {
 }
 
 function getConfig(): { baseUrl: string; apiKey: string } {
-  const baseUrl =
-    process.env.CONTENT_GENERATION_SERVICE_URL ??
-    process.env.CONTENT_GENERATION_URL;
-  const apiKey =
-    process.env.CONTENT_GENERATION_SERVICE_API_KEY ??
-    process.env.CONTENT_GENERATION_API_KEY;
+  const baseUrl = process.env.CONTENT_GENERATION_SERVICE_URL;
+  const apiKey = process.env.CONTENT_GENERATION_SERVICE_API_KEY;
 
   if (!baseUrl || !apiKey) {
     throw new Error(
-      "CONTENT_GENERATION_SERVICE_URL / CONTENT_GENERATION_SERVICE_API_KEY (or legacy CONTENT_GENERATION_URL / CONTENT_GENERATION_API_KEY) must be set",
+      "CONTENT_GENERATION_SERVICE_URL and CONTENT_GENERATION_SERVICE_API_KEY must be set",
     );
   }
 

--- a/tests/unit/content-generation-client.test.ts
+++ b/tests/unit/content-generation-client.test.ts
@@ -1,14 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
-// We test getConfig indirectly through fetchPromptTemplate
-// since getConfig is not exported. We mock fetch to avoid real HTTP calls.
-
 describe("content-generation-client", () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
-    delete process.env.CONTENT_GENERATION_URL;
-    delete process.env.CONTENT_GENERATION_API_KEY;
     delete process.env.CONTENT_GENERATION_SERVICE_URL;
     delete process.env.CONTENT_GENERATION_SERVICE_API_KEY;
     vi.resetModules();
@@ -22,9 +17,9 @@ describe("content-generation-client", () => {
     vi.restoreAllMocks();
   });
 
-  it("uses CONTENT_GENERATION_SERVICE_URL/API_KEY (standard pattern)", async () => {
+  it("uses CONTENT_GENERATION_SERVICE_URL/API_KEY", async () => {
     process.env.CONTENT_GENERATION_SERVICE_URL = "https://cg.example.com";
-    process.env.CONTENT_GENERATION_SERVICE_API_KEY = "key-standard";
+    process.env.CONTENT_GENERATION_SERVICE_API_KEY = "key-123";
 
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -50,73 +45,11 @@ describe("content-generation-client", () => {
     expect(result!.type).toBe("cold-email");
     expect(mockFetch).toHaveBeenCalledWith(
       "https://cg.example.com/platform-prompts?type=cold-email",
-      { method: "GET", headers: { "x-api-key": "key-standard" } },
+      { method: "GET", headers: { "x-api-key": "key-123" } },
     );
   });
 
-  it("falls back to legacy CONTENT_GENERATION_URL/API_KEY", async () => {
-    process.env.CONTENT_GENERATION_URL = "https://cg-legacy.example.com";
-    process.env.CONTENT_GENERATION_API_KEY = "key-legacy";
-
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () =>
-        Promise.resolve({
-          id: "1",
-          type: "cold-email",
-          prompt: "test",
-          variables: [],
-          createdAt: "2026-01-01",
-          updatedAt: "2026-01-01",
-        }),
-    });
-    vi.stubGlobal("fetch", mockFetch);
-
-    const { fetchPromptTemplate } = await import(
-      "../../src/lib/content-generation-client.js"
-    );
-    await fetchPromptTemplate("cold-email");
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      "https://cg-legacy.example.com/platform-prompts?type=cold-email",
-      { method: "GET", headers: { "x-api-key": "key-legacy" } },
-    );
-  });
-
-  it("prefers CONTENT_GENERATION_SERVICE_URL over legacy when both are set", async () => {
-    process.env.CONTENT_GENERATION_SERVICE_URL = "https://cg-standard.example.com";
-    process.env.CONTENT_GENERATION_SERVICE_API_KEY = "key-standard";
-    process.env.CONTENT_GENERATION_URL = "https://cg-legacy.example.com";
-    process.env.CONTENT_GENERATION_API_KEY = "key-legacy";
-
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () =>
-        Promise.resolve({
-          id: "1",
-          type: "test",
-          prompt: "test",
-          variables: [],
-          createdAt: "2026-01-01",
-          updatedAt: "2026-01-01",
-        }),
-    });
-    vi.stubGlobal("fetch", mockFetch);
-
-    const { fetchPromptTemplate } = await import(
-      "../../src/lib/content-generation-client.js"
-    );
-    await fetchPromptTemplate("test");
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      "https://cg-standard.example.com/platform-prompts?type=test",
-      { method: "GET", headers: { "x-api-key": "key-standard" } },
-    );
-  });
-
-  it("throws when no env vars are set", async () => {
+  it("throws when env vars are not set", async () => {
     const mockFetch = vi.fn();
     vi.stubGlobal("fetch", mockFetch);
 


### PR DESCRIPTION
## Summary
- Removes the fallback to legacy `CONTENT_GENERATION_URL` / `CONTENT_GENERATION_API_KEY` added in #116 — those names no longer exist
- Client now only reads `CONTENT_GENERATION_SERVICE_URL` / `CONTENT_GENERATION_SERVICE_API_KEY` (standard pattern)
- Cleans up test cases that covered the legacy fallback

## Test plan
- [x] 305 unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)