### PR TITLE
feat: fork workflow on DAG edit instead of in-place update

### DIFF
--- a/drizzle/0016_add_forked_from.sql
+++ b/drizzle/0016_add_forked_from.sql
@@ -1,0 +1,2 @@
+-- Track fork lineage: forked workflow points back to the original it was forked from
+ALTER TABLE "workflows" ADD COLUMN IF NOT EXISTS "forked_from" uuid;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1772361906410,
       "tag": "0015_add_run_tracking_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1772448306410,
+      "tag": "0016_add_forked_from",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -151,6 +151,12 @@
             "format": "uuid",
             "description": "If deprecated, the ID of the replacement workflow."
           },
+          "forkedFrom": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid",
+            "description": "If this workflow was forked from another, the ID of the original workflow."
+          },
           "createdByUserId": {
             "type": "string",
             "nullable": true,
@@ -196,6 +202,7 @@
           "signatureName",
           "status",
           "upgradedTo",
+          "forkedFrom",
           "createdByUserId",
           "createdByRunId",
           "windmillFlowPath",
@@ -1497,7 +1504,8 @@
         }
       },
       "put": {
-        "summary": "Update a workflow",
+        "summary": "Fork a workflow with modifications",
+        "description": "Creates a new workflow based on an existing one with a modified DAG. The original workflow remains active and unchanged. If only metadata (name, description, tags) is changed without a new DAG, the update is applied in-place. Returns the new forked workflow with a new name and signature.",
         "tags": [
           "Workflows"
         ],
@@ -1589,7 +1597,17 @@
         },
         "responses": {
           "200": {
-            "description": "Workflow updated",
+            "description": "Workflow updated in-place (metadata only, no DAG change)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Workflow forked (new workflow created with modified DAG)",
             "content": {
               "application/json": {
                 "schema": {
@@ -1600,6 +1618,16 @@
           },
           "404": {
             "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A workflow with this DAG signature already exists",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -30,6 +30,7 @@ export const workflows = pgTable(
     tags: jsonb("tags").default([]),
     status: text("status").notNull().default("active"),
     upgradedTo: uuid("upgraded_to"),
+    forkedFrom: uuid("forked_from"),
     createdByUserId: text("created_by_user_id"),
     createdByRunId: text("created_by_run_id"),
     windmillFlowPath: text("windmill_flow_path"),

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -931,10 +931,11 @@ router.get("/workflows/:id/required-providers", requireApiKey, async (req, res) 
   }
 });
 
-// PUT /workflows/:id — Update a workflow
+// PUT /workflows/:id — Fork a workflow (DAG change creates a new workflow; metadata-only updates in-place)
 router.put("/workflows/:id", requireApiKey, async (req, res) => {
   try {
     const body = UpdateWorkflowSchema.parse(req.body);
+    const orgId = res.locals.orgId as string;
 
     const [existing] = await db
       .select()
@@ -946,28 +947,42 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
       return;
     }
 
-    const updates: Record<string, unknown> = { updatedAt: new Date() };
-    if (body.name) updates.name = body.name;
-    if (body.description !== undefined) updates.description = body.description;
-    if (body.tags !== undefined) updates.tags = body.tags;
+    // No DAG provided — metadata-only in-place update
+    if (!body.dag) {
+      const updates: Record<string, unknown> = { updatedAt: new Date() };
+      if (body.name) updates.name = body.name;
+      if (body.description !== undefined) updates.description = body.description;
+      if (body.tags !== undefined) updates.tags = body.tags;
 
-    if (body.dag) {
-      const dag = body.dag as DAG;
-      const validation = validateDAG(dag);
-      if (!validation.valid) {
-        res
-          .status(400)
-          .json({ error: "Invalid DAG", details: validation.errors });
-        return;
-      }
+      const [updated] = await db
+        .update(workflows)
+        .set(updates)
+        .where(eq(workflows.id, req.params.id))
+        .returning();
 
-      updates.dag = body.dag;
-      updates.signature = computeDAGSignature(body.dag);
+      res.json(formatWorkflow(updated));
+      return;
+    }
 
-      // Re-translate and update in Windmill
+    // DAG provided — validate it
+    const dag = body.dag as DAG;
+    const validation = validateDAG(dag);
+    if (!validation.valid) {
+      res.status(400).json({ error: "Invalid DAG", details: validation.errors });
+      return;
+    }
+
+    const newSignature = computeDAGSignature(body.dag);
+
+    // Same signature — no structural change, update in-place
+    if (newSignature === existing.signature) {
+      const updates: Record<string, unknown> = { updatedAt: new Date(), dag: body.dag };
+      if (body.name) updates.name = body.name;
+      if (body.description !== undefined) updates.description = body.description;
+      if (body.tags !== undefined) updates.tags = body.tags;
+
       const flowName = body.name ?? existing.name;
       const openFlow = dagToOpenFlow(dag, flowName);
-
       if (existing.windmillFlowPath) {
         const client = getWindmillClient();
         if (client) {
@@ -978,28 +993,109 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
               schema: openFlow.schema,
             });
           } catch (err) {
-            console.error(
-              "[workflow-service] Failed to update flow in Windmill:",
-              err
-            );
+            console.error("[workflow-service] Failed to update flow in Windmill:", err);
           }
         }
       }
+
+      const [updated] = await db
+        .update(workflows)
+        .set(updates)
+        .where(eq(workflows.id, req.params.id))
+        .returning();
+
+      res.json(formatWorkflow(updated));
+      return;
     }
 
-    const [updated] = await db
-      .update(workflows)
-      .set(updates)
-      .where(eq(workflows.id, req.params.id))
+    // Different signature — FORK: create a new workflow, keep original untouched
+    // Check for existing active workflow with same signature (would violate unique index)
+    const [conflicting] = await db
+      .select()
+      .from(workflows)
+      .where(
+        and(
+          eq(workflows.signature, newSignature),
+          eq(workflows.status, "active"),
+        )
+      );
+
+    if (conflicting) {
+      res.status(409).json({
+        error: "A workflow with this DAG signature already exists",
+        existingWorkflowId: conflicting.id,
+        existingWorkflowName: conflicting.name,
+      });
+      return;
+    }
+
+    // Generate new signatureName
+    const existingWorkflows = await db
+      .select({ signatureName: workflows.signatureName })
+      .from(workflows)
+      .where(eq(workflows.orgId, orgId));
+    const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
+    const signatureName = pickSignatureName(newSignature, usedNames);
+
+    // Build new name from original's dimensions + new signatureName
+    const newName = `${existing.category}-${existing.channel}-${existing.audienceType}-${signatureName}`;
+
+    const openFlow = dagToOpenFlow(dag, newName);
+    const flowPath = generateFlowPath(orgId, newName);
+    const client = getWindmillClient();
+
+    if (client) {
+      try {
+        await client.createFlow({
+          path: flowPath,
+          summary: newName,
+          description: body.description ?? existing.description,
+          value: openFlow.value,
+          schema: openFlow.schema,
+        });
+      } catch (err) {
+        console.error("[workflow-service] Failed to create forked flow in Windmill:", err);
+      }
+    }
+
+    const [forked] = await db
+      .insert(workflows)
+      .values({
+        orgId: existing.orgId,
+        brandId: existing.brandId,
+        humanId: existing.humanId,
+        campaignId: existing.campaignId,
+        subrequestId: existing.subrequestId,
+        styleName: existing.styleName,
+        name: newName,
+        displayName: body.name ?? existing.displayName,
+        description: body.description ?? existing.description,
+        category: existing.category,
+        channel: existing.channel,
+        audienceType: existing.audienceType,
+        tags: body.tags ?? (existing.tags as string[]) ?? [],
+        signature: newSignature,
+        signatureName,
+        dag: body.dag,
+        status: "active",
+        forkedFrom: existing.id,
+        windmillFlowPath: flowPath,
+        createdByUserId: res.locals.userId as string,
+        createdByRunId: res.locals.runId as string,
+      })
       .returning();
 
-    res.json(formatWorkflow(updated));
+    console.log(
+      `[workflow-service] fork: "${existing.name}" (${existing.id}) -> "${newName}" (${forked.id})`,
+    );
+
+    res.status(201).json(formatWorkflow(forked));
   } catch (err: unknown) {
     if (err instanceof Error && err.name === "ZodError") {
       res.status(400).json({ error: "Validation error", details: err });
       return;
     }
-    console.error("[workflow-service] PUT error:", err);
+    console.error("[workflow-service] PUT fork error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -153,6 +153,7 @@ export const WorkflowResponseSchema = z
     dag: z.unknown().describe("The DAG definition as submitted."),
     status: z.enum(["active", "deprecated"]).describe("Workflow lifecycle status. Only active workflows can be executed."),
     upgradedTo: z.string().uuid().nullable().describe("If deprecated, the ID of the replacement workflow."),
+    forkedFrom: z.string().uuid().nullable().describe("If this workflow was forked from another, the ID of the original workflow."),
     createdByUserId: z.string().nullable().describe("User ID that created this workflow."),
     createdByRunId: z.string().nullable().describe("Run ID that created this workflow."),
     windmillFlowPath: z.string().nullable().describe("Internal Windmill flow path (managed automatically)."),
@@ -607,7 +608,12 @@ registry.registerPath({
 registry.registerPath({
   method: "put",
   path: "/workflows/{id}",
-  summary: "Update a workflow",
+  summary: "Fork a workflow with modifications",
+  description:
+    "Creates a new workflow based on an existing one with a modified DAG. " +
+    "The original workflow remains active and unchanged. " +
+    "If only metadata (name, description, tags) is changed without a new DAG, the update is applied in-place. " +
+    "Returns the new forked workflow with a new name and signature.",
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
   request: {
@@ -619,12 +625,20 @@ registry.registerPath({
     },
   },
   responses: {
+    201: {
+      description: "Workflow forked (new workflow created with modified DAG)",
+      content: { "application/json": { schema: WorkflowResponseSchema } },
+    },
     200: {
-      description: "Workflow updated",
+      description: "Workflow updated in-place (metadata only, no DAG change)",
       content: { "application/json": { schema: WorkflowResponseSchema } },
     },
     404: {
       description: "Not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    409: {
+      description: "A workflow with this DAG signature already exists",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -807,6 +807,276 @@ describe("GET /workflows/:id/required-providers", () => {
   });
 });
 
+describe("PUT /workflows/:id — fork", () => {
+  beforeEach(() => {
+    mockDbRows.length = 0;
+    mockSelectResponses.length = 0;
+  });
+
+  it("forks a workflow when DAG changes (returns 201 with new ID)", async () => {
+    const originalWorkflow = {
+      id: "wf-original",
+      orgId: "org-1",
+      brandId: "brand-1",
+      humanId: null,
+      campaignId: "camp-1",
+      subrequestId: null,
+      styleName: null,
+      name: "sales-email-cold-outreach-jasmine",
+      displayName: "Jasmine Flow",
+      description: "Original description",
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      tags: ["email"],
+      signature: "aaa111",
+      signatureName: "jasmine",
+      dag: VALID_LINEAR_DAG,
+      status: "active",
+      upgradedTo: null,
+      forkedFrom: null,
+      windmillFlowPath: "f/workflows/org-1/sales_email_cold_outreach_jasmine",
+      windmillWorkspace: "prod",
+      createdByUserId: "user-1",
+      createdByRunId: "run-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    // Queue: 1st select = find existing workflow, 2nd = check conflicting signature, 3rd = get used signatureNames
+    mockSelectResponses.push(
+      [originalWorkflow],  // existing workflow lookup
+      [],                  // no conflicting signature
+      [{ signatureName: "jasmine" }],  // existing signatureNames in org
+    );
+
+    const res = await request
+      .put("/workflows/wf-original")
+      .set(AUTH)
+      .send({
+        dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
+        description: "Forked with new DAG",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).not.toBe("wf-original");
+    expect(res.body.forkedFrom).toBe("wf-original");
+    expect(res.body.category).toBe("sales");
+    expect(res.body.channel).toBe("email");
+    expect(res.body.audienceType).toBe("cold-outreach");
+    expect(res.body.description).toBe("Forked with new DAG");
+    expect(res.body.status).toBe("active");
+    // Original should still be in mockDbRows unchanged
+    expect(originalWorkflow.status).toBe("active");
+  });
+
+  it("updates in-place when only metadata changes (no DAG)", async () => {
+    mockDbRows.push({
+      id: "wf-meta",
+      orgId: "org-1",
+      name: "sales-email-cold-outreach-maple",
+      description: "Old desc",
+      dag: VALID_LINEAR_DAG,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const res = await request
+      .put("/workflows/wf-meta")
+      .set(AUTH)
+      .send({
+        description: "Updated description",
+        tags: ["updated"],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.description).toBe("Updated description");
+    expect(res.body.tags).toEqual(["updated"]);
+    // No forkedFrom — it's the same workflow
+    expect(res.body.forkedFrom).toBeUndefined();
+  });
+
+  it("updates in-place when DAG is provided but signature is unchanged", async () => {
+    const { computeDAGSignature } = await import("../../src/lib/dag-signature.js");
+    const sig = computeDAGSignature(VALID_LINEAR_DAG);
+
+    mockDbRows.push({
+      id: "wf-same-sig",
+      orgId: "org-1",
+      name: "sales-email-cold-outreach-cedar",
+      signature: sig,
+      dag: VALID_LINEAR_DAG,
+      windmillFlowPath: "f/workflows/org-1/flow",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const res = await request
+      .put("/workflows/wf-same-sig")
+      .set(AUTH)
+      .send({
+        dag: VALID_LINEAR_DAG,
+        description: "Same DAG, new desc",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.description).toBe("Same DAG, new desc");
+  });
+
+  it("returns 404 for non-existent workflow", async () => {
+    const res = await request
+      .put("/workflows/nonexistent-id")
+      .set(AUTH)
+      .send({ description: "test" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("Workflow not found");
+  });
+
+  it("returns 409 when forked DAG conflicts with existing active workflow", async () => {
+    const { computeDAGSignature } = await import("../../src/lib/dag-signature.js");
+    const conflictingSig = computeDAGSignature(DAG_WITH_TRANSACTIONAL_EMAIL_SEND);
+
+    const originalWorkflow = {
+      id: "wf-src",
+      orgId: "org-1",
+      name: "sales-email-cold-outreach-oak",
+      signature: "different-sig",
+      dag: VALID_LINEAR_DAG,
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    mockSelectResponses.push(
+      [originalWorkflow],  // existing workflow lookup
+      [{ id: "wf-conflict", name: "sales-email-cold-outreach-birch", signature: conflictingSig, status: "active" }],  // conflicting workflow
+    );
+
+    const res = await request
+      .put("/workflows/wf-src")
+      .set(AUTH)
+      .send({ dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain("already exists");
+    expect(res.body.existingWorkflowId).toBe("wf-conflict");
+  });
+
+  it("forking a fork sets forkedFrom to immediate parent", async () => {
+    const fork1 = {
+      id: "wf-fork1",
+      orgId: "org-1",
+      brandId: null,
+      humanId: null,
+      campaignId: null,
+      subrequestId: null,
+      styleName: null,
+      name: "sales-email-cold-outreach-birch",
+      displayName: "Birch Flow",
+      description: "First fork",
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      tags: [],
+      signature: "bbb222",
+      signatureName: "birch",
+      dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
+      status: "active",
+      upgradedTo: null,
+      forkedFrom: "wf-original",
+      windmillFlowPath: "f/workflows/org-1/flow",
+      windmillWorkspace: "prod",
+      createdByUserId: "user-1",
+      createdByRunId: "run-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    mockSelectResponses.push(
+      [fork1],             // existing workflow lookup
+      [],                  // no conflicting signature
+      [{ signatureName: "birch" }, { signatureName: "jasmine" }],  // existing signatureNames
+    );
+
+    const res = await request
+      .put("/workflows/wf-fork1")
+      .set(AUTH)
+      .send({ dag: VALID_LINEAR_DAG });
+
+    expect(res.status).toBe(201);
+    expect(res.body.forkedFrom).toBe("wf-fork1"); // immediate parent, not wf-original
+  });
+
+  it("inherits metadata from parent workflow", async () => {
+    const parent = {
+      id: "wf-parent",
+      orgId: "org-1",
+      brandId: "brand-xyz",
+      humanId: "human-abc",
+      campaignId: "camp-123",
+      subrequestId: "sub-456",
+      styleName: "hormozi",
+      name: "sales-email-cold-outreach-sequoia",
+      displayName: "Sequoia Flow",
+      description: "Parent description",
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      tags: ["inherited"],
+      signature: "ccc333",
+      signatureName: "sequoia",
+      dag: VALID_LINEAR_DAG,
+      status: "active",
+      upgradedTo: null,
+      forkedFrom: null,
+      windmillFlowPath: "f/workflows/org-1/flow",
+      windmillWorkspace: "prod",
+      createdByUserId: "user-1",
+      createdByRunId: "run-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    mockSelectResponses.push(
+      [parent],
+      [],
+      [{ signatureName: "sequoia" }],
+    );
+
+    const res = await request
+      .put("/workflows/wf-parent")
+      .set(AUTH)
+      .send({ dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND });
+
+    expect(res.status).toBe(201);
+    expect(res.body.brandId).toBe("brand-xyz");
+    expect(res.body.category).toBe("sales");
+    expect(res.body.channel).toBe("email");
+    expect(res.body.audienceType).toBe("cold-outreach");
+    expect(res.body.tags).toEqual(["inherited"]);
+  });
+
+  it("rejects invalid DAG on fork", async () => {
+    mockDbRows.push({
+      id: "wf-bad",
+      orgId: "org-1",
+      name: "sales-email-cold-outreach-pine",
+      dag: VALID_LINEAR_DAG,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const res = await request
+      .put("/workflows/wf-bad")
+      .set(AUTH)
+      .send({ dag: DAG_WITH_UNKNOWN_TYPE });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Invalid DAG");
+  });
+});
+
 describe("POST /workflows/:id/validate", () => {
   beforeEach(() => {
     mockDbRows.length = 0;


### PR DESCRIPTION
## Summary
- **PUT /workflows/:id** now creates a **fork** when the DAG changes: original stays active, new workflow gets `forkedFrom` link
- Metadata-only edits (no DAG) still update in-place (200)
- Returns 409 if forked DAG's signature matches an existing active workflow
- New `forkedFrom` column (migration 0016) tracks fork lineage

## Why
When the dashboard LLM modifies a workflow (e.g. `sales-email-cold-outreach-jasmine`), it was overwriting the shared workflow in-place. Other clients using the same workflow would get the modified version without knowing. Now modifications always create a new workflow, keeping the original safe.

## Test plan
- [x] Fork creates new workflow with 201, `forkedFrom` set to parent ID
- [x] Metadata-only update returns 200, same workflow ID
- [x] Same-signature DAG returns 200, no fork
- [x] 409 on signature conflict with existing active workflow
- [x] Fork of a fork chains correctly (forkedFrom = immediate parent)
- [x] Inherits brandId, category, channel, audienceType from parent
- [x] Invalid DAG rejected with 400
- [x] All 402 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)