### PR TITLE
fix: handle null description in workflow fork

### DIFF
--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -1049,7 +1049,7 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
         await client.createFlow({
           path: flowPath,
           summary: newName,
-          description: body.description ?? existing.description,
+          description: body.description ?? existing.description ?? undefined,
           value: openFlow.value,
           schema: openFlow.schema,
         });

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -1057,6 +1057,51 @@ describe("PUT /workflows/:id — fork", () => {
     expect(res.body.tags).toEqual(["inherited"]);
   });
 
+  it("forks successfully when existing workflow has null description", async () => {
+    const originalWorkflow = {
+      id: "wf-null-desc",
+      orgId: "org-1",
+      brandId: null,
+      humanId: null,
+      campaignId: null,
+      subrequestId: null,
+      styleName: null,
+      name: "sales-email-cold-outreach-cedar",
+      displayName: "Cedar Flow",
+      description: null,
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      tags: [],
+      signature: "ccc333",
+      signatureName: "cedar",
+      dag: VALID_LINEAR_DAG,
+      status: "active",
+      upgradedTo: null,
+      forkedFrom: null,
+      windmillFlowPath: "f/workflows/org-1/sales_email_cold_outreach_cedar",
+      windmillWorkspace: "prod",
+      createdByUserId: "user-1",
+      createdByRunId: "run-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    mockSelectResponses.push(
+      [originalWorkflow],
+      [],
+      [{ signatureName: "cedar" }],
+    );
+
+    const res = await request
+      .put("/workflows/wf-null-desc")
+      .set(AUTH)
+      .send({ dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND });
+
+    expect(res.status).toBe(201);
+    expect(res.body.forkedFrom).toBe("wf-null-desc");
+  });
+
   it("rejects invalid DAG on fork", async () => {
     mockDbRows.push({
       id: "wf-bad",


### PR DESCRIPTION
## Summary
- Fixed TS2322 build error where `description: string | null` from the database was passed to Windmill's `createFlow` which expects `string | undefined`
- Added `?? undefined` to coerce null to undefined
- Added regression test for forking a workflow with null description

## Test plan
- [x] `npx tsc --noEmit` passes (no type errors)
- [x] All 402 existing tests pass
- [x] New regression test covers the null description fork case

🤖 Generated with [Claude Code](https://claude.com/claude-code)