### PR TITLE
fix: add WorkflowConflictResponse schema for 409 on PUT /workflows/:id

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -437,6 +437,28 @@
           "providers"
         ]
       },
+      "WorkflowConflictResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "existingWorkflowId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the existing workflow that already has this DAG signature."
+          },
+          "existingWorkflowName": {
+            "type": "string",
+            "description": "Name of the existing workflow that already has this DAG signature."
+          }
+        },
+        "required": [
+          "error",
+          "existingWorkflowId",
+          "existingWorkflowName"
+        ]
+      },
       "UpdateWorkflowRequest": {
         "type": "object",
         "properties": {
@@ -1631,7 +1653,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/WorkflowConflictResponse"
                 }
               }
             }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -450,6 +450,16 @@ export const ProviderRequirementsResponseSchema = z
   })
   .openapi("ProviderRequirementsResponse");
 
+// --- Workflow conflict response (409 on PUT /workflows/:id) ---
+
+export const WorkflowConflictResponseSchema = z
+  .object({
+    error: z.string(),
+    existingWorkflowId: z.string().uuid().describe("ID of the existing workflow that already has this DAG signature."),
+    existingWorkflowName: z.string().describe("Name of the existing workflow that already has this DAG signature."),
+  })
+  .openapi("WorkflowConflictResponse");
+
 // --- Common ---
 
 export const ErrorResponseSchema = z
@@ -639,7 +649,7 @@ registry.registerPath({
     },
     409: {
       description: "A workflow with this DAG signature already exists",
-      content: { "application/json": { schema: ErrorResponseSchema } },
+      content: { "application/json": { schema: WorkflowConflictResponseSchema } },
     },
   },
 });

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -961,6 +961,7 @@ describe("PUT /workflows/:id — fork", () => {
     expect(res.status).toBe(409);
     expect(res.body.error).toContain("already exists");
     expect(res.body.existingWorkflowId).toBe("wf-conflict");
+    expect(res.body.existingWorkflowName).toBe("sales-email-cold-outreach-birch");
   });
 
   it("forking a fork sets forkedFrom to immediate parent", async () => {


### PR DESCRIPTION
## Summary
- Added `WorkflowConflictResponse` schema with `existingWorkflowId` and `existingWorkflowName` fields for the 409 response on PUT /workflows/{id}
- Updated the path registration to use the new schema instead of the generic `ErrorResponse`
- Regenerated `openapi.json`
- Added test assertion for `existingWorkflowName` in the 409 conflict test

## Test plan
- [x] All 403 existing tests pass
- [x] 409 conflict test now verifies both `existingWorkflowId` and `existingWorkflowName`

🤖 Generated with [Claude Code](https://claude.com/claude-code)