### PR TITLE
fix: forked workflows inherit stale displayName

### DIFF
--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -1068,7 +1068,7 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
         subrequestId: existing.subrequestId,
         styleName: existing.styleName,
         name: newName,
-        displayName: body.name ?? existing.displayName,
+        displayName: body.name ?? newName,
         description: body.description ?? existing.description,
         category: existing.category,
         channel: existing.channel,

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -866,6 +866,9 @@ describe("PUT /workflows/:id — fork", () => {
     expect(res.body.audienceType).toBe("cold-outreach");
     expect(res.body.description).toBe("Forked with new DAG");
     expect(res.body.status).toBe("active");
+    // displayName must use the new generated name, not inherit the parent's stale displayName
+    expect(res.body.displayName).not.toBe("Jasmine Flow");
+    expect(res.body.displayName).toMatch(/^sales-email-cold-outreach-/);
     // Original should still be in mockDbRows unchanged
     expect(originalWorkflow.status).toBe("active");
   });


### PR DESCRIPTION
## Summary
- When forking a workflow via `PUT /workflows/:id`, the `displayName` was set to `body.name ?? existing.displayName`, inheriting the parent's stale displayName
- Changed to `body.name ?? newName` so the forked workflow gets the correct generated name (e.g. "sales-email-cold-outreach-headwater" instead of the parent's "sales-email-cold-outreach-jasmine")
- Added regression test asserting `displayName` matches the new name pattern after fork

## Root cause
Line 1071 in `src/routes/workflows.ts` fell back to `existing.displayName` when no explicit `body.name` was provided, copying the original workflow's displayName through every fork in the chain.

## Impact
13 active workflows currently have stale `display_name` values in prod. A one-time data fix (`UPDATE workflows SET display_name = name WHERE display_name != name AND status = 'active'`) is needed after merge.

## Test plan
- [x] Existing fork test updated with `displayName` assertions
- [x] All 403 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)