### PR TITLE
fix: upgraded workflows inherit stale displayName from ancestor

### DIFF
--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -310,7 +310,7 @@ async function attemptUpgrade(
         subrequestId: wf.subrequestId,
         styleName: wf.styleName,
         name: stableName,
-        displayName: wf.displayName ?? stableName,
+        displayName: stableName,
         description: result.description,
         category: result.category,
         channel: result.channel,

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -351,6 +351,8 @@ describe("validateAndUpgradeWorkflows", () => {
     expect(dbInserts.length).toBe(1);
     expect(dbInserts[0].status).toBe("active");
     expect(dbInserts[0].name).toBe(BROKEN_WORKFLOW.name);
+    // displayName must use the stable name, not inherit stale parent displayName
+    expect(dbInserts[0].displayName).toBe(BROKEN_WORKFLOW.name);
     expect(dbInserts[0].createdByUserId).toBe("workflow-service");
     expect(dbInserts[0].createdByRunId).toBe("platform-run-123");
 


### PR DESCRIPTION
## Summary
- During startup upgrade in `startup-validator.ts`, new workflows were created with `displayName: wf.displayName ?? stableName`, which copied the parent's displayName
- Through upgrade chains (jasmine → guardian → headwater → mintaka), the `displayName` stayed frozen on the original ancestor ("jasmine") even though `name` correctly changed at each step
- This is why clicking "Headwater" on the dashboard showed "sales-email-cold-outreach-jasmine" — the detail page reads `displayName`
- Fix: always set `displayName: stableName` during upgrade, same as what deploy does for new workflows
- 13 active workflows in prod currently have stale `display_name` and need a one-time data fix

## Test plan
- [x] Added `displayName` assertion to existing upgrade test
- [x] All 403 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)