### PR TITLE
fix: upgrade uses new signatureName in name, keeps displayName stable

### DIFF
--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -255,12 +255,12 @@ async function attemptUpgrade(
 
     const newSignatureName = pickSignatureName(newSignature, usedNames);
 
-    // Reuse the old workflow's name so clients calling by-name are not disrupted
-    const stableName = wf.name;
+    // Build the new name with the new signatureName; displayName stays as the ancestor's name
+    const newName = `${result.category}-${result.channel}-${result.audienceType}-${newSignatureName}`;
 
     // Deploy to Windmill
-    const openFlow = dagToOpenFlow(result.dag, stableName);
-    const flowPath = `f/workflows/${wf.orgId}/${stableName.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
+    const openFlow = dagToOpenFlow(result.dag, newName);
+    const flowPath = `f/workflows/${wf.orgId}/${newName.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
     let windmillFlowPath: string | null = null;
 
     if (windmillClient) {
@@ -269,7 +269,7 @@ async function attemptUpgrade(
       // This avoids Windmill logging noisy 400 "already exists" errors.
       try {
         await windmillClient.updateFlow(flowPath, {
-          summary: stableName,
+          summary: newName,
           description: result.description,
           value: openFlow.value,
           schema: openFlow.schema,
@@ -281,7 +281,7 @@ async function attemptUpgrade(
           try {
             await windmillClient.createFlow({
               path: flowPath,
-              summary: stableName,
+              summary: newName,
               description: result.description,
               value: openFlow.value,
               schema: openFlow.schema,
@@ -309,8 +309,8 @@ async function attemptUpgrade(
         campaignId: wf.campaignId,
         subrequestId: wf.subrequestId,
         styleName: wf.styleName,
-        name: stableName,
-        displayName: stableName,
+        name: newName,
+        displayName: wf.displayName ?? wf.name,
         description: result.description,
         category: result.category,
         channel: result.channel,

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -1068,7 +1068,7 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
         subrequestId: existing.subrequestId,
         styleName: existing.styleName,
         name: newName,
-        displayName: body.name ?? newName,
+        displayName: body.name ?? existing.displayName,
         description: body.description ?? existing.description,
         category: existing.category,
         channel: existing.channel,

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -866,9 +866,8 @@ describe("PUT /workflows/:id — fork", () => {
     expect(res.body.audienceType).toBe("cold-outreach");
     expect(res.body.description).toBe("Forked with new DAG");
     expect(res.body.status).toBe("active");
-    // displayName must use the new generated name, not inherit the parent's stale displayName
-    expect(res.body.displayName).not.toBe("Jasmine Flow");
-    expect(res.body.displayName).toMatch(/^sales-email-cold-outreach-/);
+    // displayName stays as the parent's displayName (stable ancestor name)
+    expect(res.body.displayName).toBe("Jasmine Flow");
     // Original should still be in mockDbRows unchanged
     expect(originalWorkflow.status).toBe("active");
   });

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -347,12 +347,13 @@ describe("validateAndUpgradeWorkflows", () => {
       expect.objectContaining({ category: "sales" }),
     );
 
-    // Should have inserted a new workflow with the SAME name as the old one
+    // Should have inserted a new workflow with a NEW name (using new signatureName)
     expect(dbInserts.length).toBe(1);
     expect(dbInserts[0].status).toBe("active");
-    expect(dbInserts[0].name).toBe(BROKEN_WORKFLOW.name);
-    // displayName must use the stable name, not inherit stale parent displayName
-    expect(dbInserts[0].displayName).toBe(BROKEN_WORKFLOW.name);
+    expect(dbInserts[0].name).toMatch(/^sales-email-cold-outreach-/);
+    expect(dbInserts[0].name).not.toBe(BROKEN_WORKFLOW.name); // name must change with new signature
+    // displayName stays as the ancestor's name (stable display identity)
+    expect(dbInserts[0].displayName).toBe(BROKEN_WORKFLOW.displayName ?? BROKEN_WORKFLOW.name);
     expect(dbInserts[0].createdByUserId).toBe("workflow-service");
     expect(dbInserts[0].createdByRunId).toBe("platform-run-123");
 


### PR DESCRIPTION
## Summary
- During startup upgrade in `startup-validator.ts`, `name` was set to `wf.name` (the old workflow's name), keeping it frozen (e.g. always "headwater") across many upgrades
- The `name` field should use the new `signatureName` since it encodes the current DAG signature: `{category}-{channel}-{audienceType}-{newSignatureName}`
- The `displayName` correctly stays as the ancestor's stable name (e.g. "jasmine") — this is intentional so users see a consistent identity across upgrade chains
- Also reverts the incorrect `displayName` changes from PRs #121 and #122 (both fork path and upgrade path)

## Root cause
Line 259: `const stableName = wf.name` was reused for both `name` and Windmill flow path, freezing the name through all upgrades. The `name` should be regenerated with the new `signatureName` at each upgrade.

## Impact
- 13 active workflows in prod have stale `name` values (e.g. name ends with "headwater" but signatureName is "mintaka")
- After deploy, future upgrades will generate correct names
- A one-time data fix is still needed for existing workflows:
  ```sql
  UPDATE workflows SET name = category || '-' || channel || '-' || audience_type || '-' || signature_name
  WHERE status = 'active' AND name != category || '-' || channel || '-' || audience_type || '-' || signature_name;
  ```

## Test plan
- [x] Updated startup-validator test to assert `name` changes with new signatureName
- [x] Updated startup-validator test to assert `displayName` stays as ancestor's name
- [x] Reverted incorrect fork test assertion (displayName should stay as parent's)
- [x] All 403 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)