### PR TITLE
feat: split into GET /workflows/ranked and GET /workflows/best

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1004,6 +1004,53 @@
           "description"
         ]
       },
+      "WorkflowMetadata": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "brandId": {
+            "type": "string",
+            "nullable": true
+          },
+          "category": {
+            "$ref": "#/components/schemas/WorkflowCategory"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/WorkflowChannel"
+          },
+          "audienceType": {
+            "$ref": "#/components/schemas/WorkflowAudienceType"
+          },
+          "signature": {
+            "type": "string"
+          },
+          "signatureName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "displayName",
+          "brandId",
+          "category",
+          "channel",
+          "audienceType",
+          "signature",
+          "signatureName"
+        ],
+        "description": "Workflow metadata."
+      },
       "EmailStats": {
         "type": "object",
         "properties": {
@@ -1052,7 +1099,7 @@
         ],
         "description": "Aggregated transactional email stats across all runs."
       },
-      "BestWorkflowStats": {
+      "WorkflowStats": {
         "type": "object",
         "properties": {
           "totalCostInUsdCents": {
@@ -1105,50 +1152,11 @@
         ],
         "description": "Aggregated performance stats for this workflow."
       },
-      "BestWorkflowResultItem": {
+      "RankedWorkflowItem": {
         "type": "object",
         "properties": {
           "workflow": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "name": {
-                "type": "string"
-              },
-              "displayName": {
-                "type": "string",
-                "nullable": true
-              },
-              "category": {
-                "$ref": "#/components/schemas/WorkflowCategory"
-              },
-              "channel": {
-                "$ref": "#/components/schemas/WorkflowChannel"
-              },
-              "audienceType": {
-                "$ref": "#/components/schemas/WorkflowAudienceType"
-              },
-              "signature": {
-                "type": "string"
-              },
-              "signatureName": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "name",
-              "displayName",
-              "category",
-              "channel",
-              "audienceType",
-              "signature",
-              "signatureName"
-            ],
-            "description": "Workflow metadata."
+            "$ref": "#/components/schemas/WorkflowMetadata"
           },
           "dag": {
             "allOf": [
@@ -1161,7 +1169,7 @@
             ]
           },
           "stats": {
-            "$ref": "#/components/schemas/BestWorkflowStats"
+            "$ref": "#/components/schemas/WorkflowStats"
           }
         },
         "required": [
@@ -1170,13 +1178,13 @@
           "stats"
         ]
       },
-      "BestWorkflowResponse": {
+      "RankedWorkflowResponse": {
         "type": "object",
         "properties": {
           "results": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/BestWorkflowResultItem"
+              "$ref": "#/components/schemas/RankedWorkflowItem"
             },
             "description": "Workflows ranked by performance, best first."
           }
@@ -1185,7 +1193,7 @@
           "results"
         ]
       },
-      "BestWorkflowObjective": {
+      "RankedWorkflowObjective": {
         "type": "string",
         "enum": [
           "replies",
@@ -1193,6 +1201,72 @@
         ],
         "default": "replies",
         "description": "Which metric to optimize for. Defaults to 'replies'."
+      },
+      "RankedWorkflowGroupBy": {
+        "type": "string",
+        "enum": [
+          "section"
+        ],
+        "description": "Group results by section. When omitted, returns a flat ranked list."
+      },
+      "BestWorkflowRecord": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "workflowId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the workflow holding the record."
+          },
+          "workflowName": {
+            "type": "string",
+            "description": "Name of the workflow."
+          },
+          "displayName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Stable display name of the workflow family."
+          },
+          "brandId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Brand ID associated with the workflow."
+          },
+          "value": {
+            "type": "number",
+            "description": "The record value in USD cents."
+          }
+        },
+        "required": [
+          "workflowId",
+          "workflowName",
+          "displayName",
+          "brandId",
+          "value"
+        ],
+        "description": "Workflow with the lowest cost per email open. Null if no data."
+      },
+      "BestWorkflowResponse": {
+        "type": "object",
+        "properties": {
+          "bestCostPerOpen": {
+            "$ref": "#/components/schemas/BestWorkflowRecord"
+          },
+          "bestCostPerReply": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BestWorkflowRecord"
+              },
+              {
+                "description": "Workflow with the lowest cost per reply. Null if no data."
+              }
+            ]
+          }
+        },
+        "required": [
+          "bestCostPerOpen",
+          "bestCostPerReply"
+        ]
       },
       "ExecuteByNameRequest": {
         "type": "object",
@@ -2831,10 +2905,10 @@
         }
       }
     },
-    "/workflows/best": {
+    "/workflows/ranked": {
       "get": {
-        "summary": "Get the best-performing workflows by cost-per-outcome",
-        "description": "Returns workflows ranked by lowest cost-per-reply or cost-per-click for the given dimensions. Stats are aggregated across the full upgrade chain (deprecated predecessors included). Use `limit` to control how many results are returned (default 1). Workflows with no completed runs are included with zeroed stats.",
+        "summary": "Get workflows ranked by cost-per-outcome",
+        "description": "Returns workflows ranked by lowest cost-per-reply or cost-per-click for the given dimensions. Stats are aggregated across the full upgrade chain (deprecated predecessors included). Use `groupBy=section` to group results by category-channel-audienceType with aggregated section stats. Workflows with no completed runs are included with zeroed stats.",
         "tags": [
           "Workflows"
         ],
@@ -2904,7 +2978,7 @@
           },
           {
             "schema": {
-              "$ref": "#/components/schemas/BestWorkflowObjective"
+              "$ref": "#/components/schemas/RankedWorkflowObjective"
             },
             "required": false,
             "description": "Which metric to optimize for. Defaults to 'replies'.",
@@ -2916,12 +2990,21 @@
               "type": "integer",
               "minimum": 1,
               "maximum": 100,
-              "default": 1,
-              "description": "Number of workflows to return, ranked by performance. Defaults to 1."
+              "default": 10,
+              "description": "Max workflows per section (when groupBy=section) or total (when flat). Defaults to 10."
             },
             "required": false,
-            "description": "Number of workflows to return, ranked by performance. Defaults to 1.",
+            "description": "Max workflows per section (when groupBy=section) or total (when flat). Defaults to 10.",
             "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/RankedWorkflowGroupBy"
+            },
+            "required": false,
+            "description": "Group results by section. When omitted, returns a flat ranked list.",
+            "name": "groupBy",
             "in": "query"
           },
           {
@@ -2987,11 +3070,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Best workflow found",
+            "description": "Ranked workflows (flat list or grouped by section)",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BestWorkflowResponse"
+                  "$ref": "#/components/schemas/RankedWorkflowResponse"
                 }
               }
             }
@@ -3007,7 +3090,7 @@
             }
           },
           "404": {
-            "description": "No workflows found matching the criteria or no completed runs",
+            "description": "No workflows found matching the criteria",
             "content": {
               "application/json": {
                 "schema": {
@@ -3018,6 +3101,124 @@
           },
           "502": {
             "description": "External service (runs-service or email-gateway-service) unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/best": {
+      "get": {
+        "summary": "Get hero records — best cost-per-open and best cost-per-reply",
+        "description": "Returns the single best workflow for cost-per-open and cost-per-reply across all active workflows. Stats are aggregated across the full upgrade chain. Use this for leaderboard hero/headline stats.",
+        "tags": [
+          "Workflows"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Organization ID. When omitted, searches across all orgs."
+            },
+            "required": false,
+            "description": "Organization ID. When omitted, searches across all orgs.",
+            "name": "orgId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Hero records found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BestWorkflowResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No active workflows found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "External service unavailable",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -11,6 +11,7 @@ import {
   UpdateWorkflowSchema,
   DeployWorkflowsSchema,
   GenerateWorkflowSchema,
+  RankedWorkflowQuerySchema,
   BestWorkflowQuerySchema,
 } from "../schemas.js";
 import {
@@ -642,22 +643,203 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
   }
 });
 
-// GET /workflows/best — Get the best-performing workflow by cost efficiency
-router.get("/workflows/best", requireApiKey, async (req, res) => {
+// --- Shared helpers for ranked/best endpoints ---
+
+const EMPTY_EMAIL_STATS = {
+  sent: 0, delivered: 0, opened: 0, clicked: 0,
+  replied: 0, bounced: 0, unsubscribed: 0, recipients: 0,
+};
+
+interface WorkflowScore {
+  workflow: typeof workflows.$inferSelect;
+  totalCost: number;
+  totalOutcomes: number;
+  costPerOutcome: number | null;
+  completedRuns: number;
+  emailStats: { transactional: typeof EMPTY_EMAIL_STATS; broadcast: typeof EMPTY_EMAIL_STATS };
+}
+
+async function computeWorkflowScores(
+  activeWorkflows: (typeof workflows.$inferSelect)[],
+  deprecatedWorkflows: { id: string; upgradedTo: string | null }[],
+  objective: "replies" | "clicks",
+  identity: { orgId: string; userId: string; runId: string },
+): Promise<WorkflowScore[]> {
+  // 1. For each active workflow, get completed runs across entire upgrade chain
+  const workflowRunsByWfId: Record<string, string[]> = {};
+  const allRunIds: string[] = [];
+
+  for (const wf of activeWorkflows) {
+    const chainIds = getUpgradeChainIds(wf.id, deprecatedWorkflows);
+
+    const runs = chainIds.length === 1
+      ? await db
+          .select()
+          .from(workflowRuns)
+          .where(
+            and(
+              eq(workflowRuns.workflowId, chainIds[0]),
+              eq(workflowRuns.status, "completed"),
+            )
+          )
+      : await db
+          .select()
+          .from(workflowRuns)
+          .where(
+            and(
+              inArray(workflowRuns.workflowId, chainIds),
+              eq(workflowRuns.status, "completed"),
+            )
+          );
+
+    const runIds = runs
+      .map((r) => r.runId)
+      .filter((id): id is string => id !== null);
+
+    workflowRunsByWfId[wf.id] = runIds;
+    allRunIds.push(...runIds);
+  }
+
+  // 2. Batch fetch costs from runs-service (only if there are runs)
+  const costByRunId = new Map<string, number>();
+  if (allRunIds.length > 0) {
+    const runCosts = await fetchRunCosts(allRunIds, identity);
+    for (const c of runCosts) {
+      costByRunId.set(c.runId, c.totalCostInUsdCents);
+    }
+  }
+
+  // 3. Per-workflow: compute cost + fetch email stats
+  const scores: WorkflowScore[] = [];
+
+  for (const wf of activeWorkflows) {
+    const runIds = workflowRunsByWfId[wf.id] ?? [];
+
+    if (runIds.length === 0) {
+      scores.push({
+        workflow: wf,
+        totalCost: 0,
+        totalOutcomes: 0,
+        costPerOutcome: null,
+        completedRuns: 0,
+        emailStats: { transactional: { ...EMPTY_EMAIL_STATS }, broadcast: { ...EMPTY_EMAIL_STATS } },
+      });
+      continue;
+    }
+
+    const totalCost = runIds.reduce(
+      (sum, id) => sum + (costByRunId.get(id) ?? 0),
+      0
+    );
+
+    const stats = await fetchEmailStats(runIds, identity);
+    const outcomes =
+      objective === "replies"
+        ? (stats.transactional?.replied ?? 0) + (stats.broadcast?.replied ?? 0)
+        : (stats.transactional?.clicked ?? 0) + (stats.broadcast?.clicked ?? 0);
+
+    const costPerOutcome = outcomes > 0 ? totalCost / outcomes : null;
+
+    scores.push({
+      workflow: wf,
+      totalCost,
+      totalOutcomes: outcomes,
+      costPerOutcome,
+      completedRuns: runIds.length,
+      emailStats: {
+        transactional: stats.transactional ?? { ...EMPTY_EMAIL_STATS },
+        broadcast: stats.broadcast ?? { ...EMPTY_EMAIL_STATS },
+      },
+    });
+  }
+
+  return scores;
+}
+
+function rankScores(scores: WorkflowScore[]): WorkflowScore[] {
+  return [...scores].sort((a, b) => {
+    if (a.costPerOutcome !== null && b.costPerOutcome !== null) {
+      return a.costPerOutcome - b.costPerOutcome;
+    }
+    if (a.costPerOutcome !== null) return -1;
+    if (b.costPerOutcome !== null) return 1;
+    return b.completedRuns - a.completedRuns;
+  });
+}
+
+function formatScoreItem(entry: WorkflowScore) {
+  return {
+    workflow: {
+      id: entry.workflow.id,
+      name: entry.workflow.name,
+      displayName: entry.workflow.displayName,
+      brandId: entry.workflow.brandId,
+      category: entry.workflow.category,
+      channel: entry.workflow.channel,
+      audienceType: entry.workflow.audienceType,
+      signature: entry.workflow.signature,
+      signatureName: entry.workflow.signatureName,
+    },
+    dag: entry.workflow.dag,
+    stats: {
+      totalCostInUsdCents: entry.totalCost,
+      totalOutcomes: entry.totalOutcomes,
+      costPerOutcome: entry.costPerOutcome,
+      completedRuns: entry.completedRuns,
+      email: entry.emailStats,
+    },
+  };
+}
+
+function aggregateSectionStats(scores: WorkflowScore[]) {
+  const totalCost = scores.reduce((s, e) => s + e.totalCost, 0);
+  const totalOutcomes = scores.reduce((s, e) => s + e.totalOutcomes, 0);
+  const completedRuns = scores.reduce((s, e) => s + e.completedRuns, 0);
+  const costPerOutcome = totalOutcomes > 0 ? totalCost / totalOutcomes : null;
+  const transactional = { ...EMPTY_EMAIL_STATS };
+  const broadcast = { ...EMPTY_EMAIL_STATS };
+  for (const e of scores) {
+    for (const key of Object.keys(EMPTY_EMAIL_STATS) as (keyof typeof EMPTY_EMAIL_STATS)[]) {
+      transactional[key] += e.emailStats.transactional[key];
+      broadcast[key] += e.emailStats.broadcast[key];
+    }
+  }
+  return { totalCostInUsdCents: totalCost, totalOutcomes, costPerOutcome, completedRuns, email: { transactional, broadcast } };
+}
+
+function handleExternalServiceError(err: unknown, res: import("express").Response, label: string) {
+  if (err instanceof Error && err.name === "ZodError") {
+    res.status(400).json({ error: "Validation error", details: err });
+    return true;
+  }
+  if (
+    err instanceof Error &&
+    (err.message.includes("RUNS_SERVICE_URL") ||
+      err.message.includes("EMAIL_GATEWAY_SERVICE_URL") ||
+      err.message.startsWith("email-gateway-service error:"))
+  ) {
+    console.error(`[workflow-service] ${label}: external service error:`, err.message);
+    res.status(502).json({ error: err.message });
+    return true;
+  }
+  return false;
+}
+
+// GET /workflows/ranked — Workflows ranked by cost-per-outcome, with optional groupBy=section
+router.get("/workflows/ranked", requireApiKey, async (req, res) => {
   try {
-    const query = BestWorkflowQuerySchema.safeParse(req.query);
+    const query = RankedWorkflowQuerySchema.safeParse(req.query);
     if (!query.success) {
       res.status(400).json({ error: "Validation error", details: query.error });
       return;
     }
-    const { orgId, category, channel, audienceType, objective, limit } = query.data;
+    const { orgId, category, channel, audienceType, objective, limit, groupBy } = query.data;
     const identity = {
       orgId: res.locals.orgId as string,
       userId: res.locals.userId as string,
       runId: res.locals.runId as string,
     };
 
-    // 1. Get all workflows matching the dimensions (active + deprecated for chain stats)
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (category) conditions.push(eq(workflows.category, category));
@@ -676,157 +858,120 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
       return;
     }
 
-    // 2. For each active workflow, get completed runs across entire upgrade chain
-    const workflowRunsByWfId: Record<string, string[]> = {};
-    const allRunIds: string[] = [];
+    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, objective, identity);
 
-    for (const wf of activeWorkflows) {
-      const chainIds = getUpgradeChainIds(wf.id, deprecatedWorkflows);
-
-      const runs = chainIds.length === 1
-        ? await db
-            .select()
-            .from(workflowRuns)
-            .where(
-              and(
-                eq(workflowRuns.workflowId, chainIds[0]),
-                eq(workflowRuns.status, "completed"),
-              )
-            )
-        : await db
-            .select()
-            .from(workflowRuns)
-            .where(
-              and(
-                inArray(workflowRuns.workflowId, chainIds),
-                eq(workflowRuns.status, "completed"),
-              )
-            );
-
-      const runIds = runs
-        .map((r) => r.runId)
-        .filter((id): id is string => id !== null);
-
-      workflowRunsByWfId[wf.id] = runIds;
-      allRunIds.push(...runIds);
-    }
-
-    // 3. Batch fetch costs from runs-service (only if there are runs)
-    const costByRunId = new Map<string, number>();
-    if (allRunIds.length > 0) {
-      const runCosts = await fetchRunCosts(allRunIds, identity);
-      for (const c of runCosts) {
-        costByRunId.set(c.runId, c.totalCostInUsdCents);
+    if (groupBy === "section") {
+      // Group by sectionKey = category-channel-audienceType
+      const sectionMap = new Map<string, WorkflowScore[]>();
+      for (const score of scores) {
+        const key = `${score.workflow.category}-${score.workflow.channel}-${score.workflow.audienceType}`;
+        const arr = sectionMap.get(key) ?? [];
+        arr.push(score);
+        sectionMap.set(key, arr);
       }
-    }
 
-    const EMPTY_EMAIL_STATS = {
-      sent: 0, delivered: 0, opened: 0, clicked: 0,
-      replied: 0, bounced: 0, unsubscribed: 0, recipients: 0,
+      const sections = [...sectionMap.entries()].map(([sectionKey, sectionScores]) => {
+        const ranked = rankScores(sectionScores).slice(0, limit);
+        const sample = sectionScores[0].workflow;
+        return {
+          sectionKey,
+          category: sample.category,
+          channel: sample.channel,
+          audienceType: sample.audienceType,
+          stats: aggregateSectionStats(sectionScores),
+          workflows: ranked.map(formatScoreItem),
+        };
+      });
+
+      res.json({ sections });
+    } else {
+      const ranked = rankScores(scores).slice(0, limit);
+      res.json({ results: ranked.map(formatScoreItem) });
+    }
+  } catch (err: unknown) {
+    if (!handleExternalServiceError(err, res, "ranked")) {
+      console.error("[workflow-service] GET ranked error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  }
+});
+
+// GET /workflows/best — Hero records: best cost-per-open and best cost-per-reply
+router.get("/workflows/best", requireApiKey, async (req, res) => {
+  try {
+    const query = BestWorkflowQuerySchema.safeParse(req.query);
+    if (!query.success) {
+      res.status(400).json({ error: "Validation error", details: query.error });
+      return;
+    }
+    const { orgId } = query.data;
+    const identity = {
+      orgId: res.locals.orgId as string,
+      userId: res.locals.userId as string,
+      runId: res.locals.runId as string,
     };
 
-    // 4. Per-workflow: compute cost + fetch email stats
-    const workflowScores: Array<{
-      workflow: (typeof activeWorkflows)[0];
-      totalCost: number;
-      totalOutcomes: number;
-      costPerOutcome: number | null;
-      completedRuns: number;
-      emailStats: { transactional: typeof EMPTY_EMAIL_STATS; broadcast: typeof EMPTY_EMAIL_STATS };
-    }> = [];
+    const conditions: ReturnType<typeof eq>[] = [];
+    if (orgId) conditions.push(eq(workflows.orgId, orgId));
 
-    for (const wf of activeWorkflows) {
-      const runIds = workflowRunsByWfId[wf.id] ?? [];
+    const allMatchingWorkflows = conditions.length > 0
+      ? await db.select().from(workflows).where(and(...conditions))
+      : await db.select().from(workflows);
 
-      if (runIds.length === 0) {
-        workflowScores.push({
-          workflow: wf,
-          totalCost: 0,
-          totalOutcomes: 0,
-          costPerOutcome: null,
-          completedRuns: 0,
-          emailStats: { transactional: { ...EMPTY_EMAIL_STATS }, broadcast: { ...EMPTY_EMAIL_STATS } },
-        });
-        continue;
-      }
+    const activeWorkflows = allMatchingWorkflows.filter((w) => w.status === "active");
+    const deprecatedWorkflows = allMatchingWorkflows.filter((w) => w.status === "deprecated");
 
-      const totalCost = runIds.reduce(
-        (sum, id) => sum + (costByRunId.get(id) ?? 0),
-        0
-      );
-
-      const stats = await fetchEmailStats(runIds, identity);
-      const outcomes =
-        objective === "replies"
-          ? (stats.transactional?.replied ?? 0) + (stats.broadcast?.replied ?? 0)
-          : (stats.transactional?.clicked ?? 0) + (stats.broadcast?.clicked ?? 0);
-
-      const costPerOutcome = outcomes > 0 ? totalCost / outcomes : null;
-
-      workflowScores.push({
-        workflow: wf,
-        totalCost,
-        totalOutcomes: outcomes,
-        costPerOutcome,
-        completedRuns: runIds.length,
-        emailStats: {
-          transactional: stats.transactional ?? { ...EMPTY_EMAIL_STATS },
-          broadcast: stats.broadcast ?? { ...EMPTY_EMAIL_STATS },
-        },
-      });
+    if (activeWorkflows.length === 0) {
+      res.status(404).json({ error: "No active workflows found" });
+      return;
     }
 
-    // 5. Sort: lowest costPerOutcome first; null last (fallback: most runs)
-    workflowScores.sort((a, b) => {
-      if (a.costPerOutcome !== null && b.costPerOutcome !== null) {
-        return a.costPerOutcome - b.costPerOutcome;
-      }
-      if (a.costPerOutcome !== null) return -1;
-      if (b.costPerOutcome !== null) return 1;
-      return b.completedRuns - a.completedRuns;
-    });
+    // Use "replies" as objective — we compute both cost-per-open and cost-per-reply from email stats
+    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, "replies", identity);
 
-    // 6. Return ranked results up to limit
-    const top = workflowScores.slice(0, limit);
+    let bestCostPerOpen: { score: WorkflowScore; value: number } | null = null;
+    let bestCostPerReply: { score: WorkflowScore; value: number } | null = null;
+
+    for (const s of scores) {
+      if (s.completedRuns === 0) continue;
+
+      const totalOpened = s.emailStats.transactional.opened + s.emailStats.broadcast.opened;
+      if (totalOpened > 0) {
+        const costPerOpen = s.totalCost / totalOpened;
+        if (!bestCostPerOpen || costPerOpen < bestCostPerOpen.value) {
+          bestCostPerOpen = { score: s, value: costPerOpen };
+        }
+      }
+
+      const totalReplied = s.emailStats.transactional.replied + s.emailStats.broadcast.replied;
+      if (totalReplied > 0) {
+        const costPerReply = s.totalCost / totalReplied;
+        if (!bestCostPerReply || costPerReply < bestCostPerReply.value) {
+          bestCostPerReply = { score: s, value: costPerReply };
+        }
+      }
+    }
+
+    function formatRecord(entry: { score: WorkflowScore; value: number } | null) {
+      if (!entry) return null;
+      return {
+        workflowId: entry.score.workflow.id,
+        workflowName: entry.score.workflow.name,
+        displayName: entry.score.workflow.displayName,
+        brandId: entry.score.workflow.brandId,
+        value: Math.round(entry.value * 100) / 100,
+      };
+    }
+
     res.json({
-      results: top.map((entry) => ({
-        workflow: {
-          id: entry.workflow.id,
-          name: entry.workflow.name,
-          displayName: entry.workflow.displayName,
-          category: entry.workflow.category,
-          channel: entry.workflow.channel,
-          audienceType: entry.workflow.audienceType,
-          signature: entry.workflow.signature,
-          signatureName: entry.workflow.signatureName,
-        },
-        dag: entry.workflow.dag,
-        stats: {
-          totalCostInUsdCents: entry.totalCost,
-          totalOutcomes: entry.totalOutcomes,
-          costPerOutcome: entry.costPerOutcome,
-          completedRuns: entry.completedRuns,
-          email: entry.emailStats,
-        },
-      })),
+      bestCostPerOpen: formatRecord(bestCostPerOpen),
+      bestCostPerReply: formatRecord(bestCostPerReply),
     });
   } catch (err: unknown) {
-    if (err instanceof Error && err.name === "ZodError") {
-      res.status(400).json({ error: "Validation error", details: err });
-      return;
+    if (!handleExternalServiceError(err, res, "best")) {
+      console.error("[workflow-service] GET best error:", err);
+      res.status(500).json({ error: "Internal server error" });
     }
-    if (
-      err instanceof Error &&
-      (err.message.includes("RUNS_SERVICE_URL") ||
-        err.message.includes("EMAIL_GATEWAY_SERVICE_URL") ||
-        err.message.startsWith("email-gateway-service error:"))
-    ) {
-      console.error("[workflow-service] best: external service error:", err.message);
-      res.status(502).json({ error: err.message });
-      return;
-    }
-    console.error("[workflow-service] GET best error:", err);
-    res.status(500).json({ error: "Internal server error" });
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -373,25 +373,7 @@ export const GenerateWorkflowResponseSchema = z
   })
   .openapi("GenerateWorkflowResponse");
 
-// --- Best Workflow schemas ---
-
-export const BestWorkflowObjectiveSchema = z
-  .enum(["replies", "clicks"])
-  .describe(
-    'Optimization objective. "replies" sorts by lowest cost per reply; "clicks" sorts by lowest cost per click.'
-  )
-  .openapi("BestWorkflowObjective");
-
-export const BestWorkflowQuerySchema = z
-  .object({
-    orgId: z.string().optional().describe("Organization ID. When omitted, searches across all orgs."),
-    category: WorkflowCategorySchema.optional().describe("Filter workflows by category."),
-    channel: WorkflowChannelSchema.optional().describe("Filter workflows by channel."),
-    audienceType: WorkflowAudienceTypeSchema.optional().describe("Filter workflows by audience type."),
-    objective: BestWorkflowObjectiveSchema.default("replies").describe("Which metric to optimize for. Defaults to 'replies'."),
-    limit: z.coerce.number().int().min(1).max(100).default(1).describe("Number of workflows to return, ranked by performance. Defaults to 1."),
-  })
-  .openapi("BestWorkflowQuery");
+// --- Shared stats schemas ---
 
 export const EmailStatsSchema = z
   .object({
@@ -406,7 +388,7 @@ export const EmailStatsSchema = z
   })
   .openapi("EmailStats");
 
-export const BestWorkflowStatsSchema = z
+export const WorkflowStatsSchema = z
   .object({
     totalCostInUsdCents: z.number().describe("Total cost across all completed runs of this workflow."),
     totalOutcomes: z.number().describe("Total replies or clicks (depending on objective) across all runs."),
@@ -417,28 +399,103 @@ export const BestWorkflowStatsSchema = z
       broadcast: EmailStatsSchema.describe("Aggregated broadcast email stats across all runs."),
     }).describe("Detailed email engagement stats aggregated across the upgrade chain."),
   })
-  .openapi("BestWorkflowStats");
+  .openapi("WorkflowStats");
 
-export const BestWorkflowResultItemSchema = z
+export const WorkflowMetadataSchema = z
   .object({
-    workflow: z.object({
-      id: z.string().uuid(),
-      name: z.string(),
-      displayName: z.string().nullable(),
-      category: WorkflowCategorySchema,
-      channel: WorkflowChannelSchema,
-      audienceType: WorkflowAudienceTypeSchema,
-      signature: z.string(),
-      signatureName: z.string(),
-    }).describe("Workflow metadata."),
-    dag: DAGSchema.describe("The DAG definition of the workflow."),
-    stats: BestWorkflowStatsSchema.describe("Aggregated performance stats for this workflow."),
+    id: z.string().uuid(),
+    name: z.string(),
+    displayName: z.string().nullable(),
+    brandId: z.string().nullable(),
+    category: WorkflowCategorySchema,
+    channel: WorkflowChannelSchema,
+    audienceType: WorkflowAudienceTypeSchema,
+    signature: z.string(),
+    signatureName: z.string(),
   })
-  .openapi("BestWorkflowResultItem");
+  .openapi("WorkflowMetadata");
+
+// --- Ranked Workflow schemas ---
+
+export const RankedWorkflowObjectiveSchema = z
+  .enum(["replies", "clicks"])
+  .describe(
+    'Optimization objective. "replies" sorts by lowest cost per reply; "clicks" sorts by lowest cost per click.'
+  )
+  .openapi("RankedWorkflowObjective");
+
+export const RankedWorkflowGroupBySchema = z
+  .enum(["section"])
+  .describe(
+    'Group results by section (category-channel-audienceType). Each section includes aggregated stats and its workflows ranked within.'
+  )
+  .openapi("RankedWorkflowGroupBy");
+
+export const RankedWorkflowQuerySchema = z
+  .object({
+    orgId: z.string().optional().describe("Organization ID. When omitted, searches across all orgs."),
+    category: WorkflowCategorySchema.optional().describe("Filter workflows by category."),
+    channel: WorkflowChannelSchema.optional().describe("Filter workflows by channel."),
+    audienceType: WorkflowAudienceTypeSchema.optional().describe("Filter workflows by audience type."),
+    objective: RankedWorkflowObjectiveSchema.default("replies").describe("Which metric to optimize for. Defaults to 'replies'."),
+    limit: z.coerce.number().int().min(1).max(100).default(10).describe("Max workflows per section (when groupBy=section) or total (when flat). Defaults to 10."),
+    groupBy: RankedWorkflowGroupBySchema.optional().describe("Group results by section. When omitted, returns a flat ranked list."),
+  })
+  .openapi("RankedWorkflowQuery");
+
+export const RankedWorkflowItemSchema = z
+  .object({
+    workflow: WorkflowMetadataSchema.describe("Workflow metadata."),
+    dag: DAGSchema.describe("The DAG definition of the workflow."),
+    stats: WorkflowStatsSchema.describe("Aggregated performance stats for this workflow."),
+  })
+  .openapi("RankedWorkflowItem");
+
+export const RankedSectionSchema = z
+  .object({
+    sectionKey: z.string().describe("Section key in the format category-channel-audienceType."),
+    category: WorkflowCategorySchema,
+    channel: WorkflowChannelSchema,
+    audienceType: WorkflowAudienceTypeSchema,
+    stats: WorkflowStatsSchema.describe("Aggregated stats across all workflows in this section."),
+    workflows: z.array(RankedWorkflowItemSchema).describe("Workflows in this section, ranked by performance."),
+  })
+  .openapi("RankedSection");
+
+export const RankedWorkflowResponseSchema = z
+  .object({
+    results: z.array(RankedWorkflowItemSchema).describe("Workflows ranked by performance, best first."),
+  })
+  .openapi("RankedWorkflowResponse");
+
+export const RankedWorkflowGroupedResponseSchema = z
+  .object({
+    sections: z.array(RankedSectionSchema).describe("Workflow sections grouped by category-channel-audienceType."),
+  })
+  .openapi("RankedWorkflowGroupedResponse");
+
+// --- Best Workflow schemas (hero records) ---
+
+export const BestWorkflowQuerySchema = z
+  .object({
+    orgId: z.string().optional().describe("Organization ID. When omitted, searches across all orgs."),
+  })
+  .openapi("BestWorkflowQuery");
+
+export const BestWorkflowRecordSchema = z
+  .object({
+    workflowId: z.string().uuid().describe("ID of the workflow holding the record."),
+    workflowName: z.string().describe("Name of the workflow."),
+    displayName: z.string().nullable().describe("Stable display name of the workflow family."),
+    brandId: z.string().nullable().describe("Brand ID associated with the workflow."),
+    value: z.number().describe("The record value in USD cents."),
+  })
+  .openapi("BestWorkflowRecord");
 
 export const BestWorkflowResponseSchema = z
   .object({
-    results: z.array(BestWorkflowResultItemSchema).describe("Workflows ranked by performance, best first."),
+    bestCostPerOpen: BestWorkflowRecordSchema.nullable().describe("Workflow with the lowest cost per email open. Null if no data."),
+    bestCostPerReply: BestWorkflowRecordSchema.nullable().describe("Workflow with the lowest cost per reply. Null if no data."),
   })
   .openapi("BestWorkflowResponse");
 
@@ -921,28 +978,28 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/workflows/best",
-  summary: "Get the best-performing workflows by cost-per-outcome",
+  path: "/workflows/ranked",
+  summary: "Get workflows ranked by cost-per-outcome",
   description:
     "Returns workflows ranked by lowest cost-per-reply or cost-per-click for the given dimensions. " +
     "Stats are aggregated across the full upgrade chain (deprecated predecessors included). " +
-    "Use `limit` to control how many results are returned (default 1). " +
+    "Use `groupBy=section` to group results by category-channel-audienceType with aggregated section stats. " +
     "Workflows with no completed runs are included with zeroed stats.",
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
   request: {
     headers: IdentityHeaders,
-    query: BestWorkflowQuerySchema,
+    query: RankedWorkflowQuerySchema,
   },
   responses: {
     200: {
-      description: "Best workflow found",
+      description: "Ranked workflows (flat list or grouped by section)",
       content: {
-        "application/json": { schema: BestWorkflowResponseSchema },
+        "application/json": { schema: RankedWorkflowResponseSchema },
       },
     },
     404: {
-      description: "No workflows found matching the criteria or no completed runs",
+      description: "No workflows found matching the criteria",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
     400: {
@@ -951,6 +1008,38 @@ registry.registerPath({
     },
     502: {
       description: "External service (runs-service or email-gateway-service) unavailable",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/workflows/best",
+  summary: "Get hero records — best cost-per-open and best cost-per-reply",
+  description:
+    "Returns the single best workflow for cost-per-open and cost-per-reply across all active workflows. " +
+    "Stats are aggregated across the full upgrade chain. " +
+    "Use this for leaderboard hero/headline stats.",
+  tags: ["Workflows"],
+  security: [{ apiKey: [] }],
+  request: {
+    headers: IdentityHeaders,
+    query: BestWorkflowQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "Hero records found",
+      content: {
+        "application/json": { schema: BestWorkflowResponseSchema },
+      },
+    },
+    404: {
+      description: "No active workflows found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "External service unavailable",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/integration/best-workflow.test.ts
+++ b/tests/integration/best-workflow.test.ts
@@ -5,10 +5,6 @@ import { VALID_LINEAR_DAG } from "../helpers/fixtures.js";
 const mockWorkflowRows: Record<string, unknown>[] = [];
 const mockWorkflowRunRows: Record<string, unknown>[] = [];
 
-// Track which table is being queried
-const workflowsTableMarker = Symbol("workflows");
-const workflowRunsTableMarker = Symbol("workflowRuns");
-
 vi.mock("../../src/db/index.js", () => ({
   db: {
     insert: () => ({
@@ -28,7 +24,6 @@ vi.mock("../../src/db/index.js", () => ({
     }),
     select: () => ({
       from: (table: unknown) => {
-        // Determine which table is being queried based on the table reference
         const isWorkflowRuns =
           table &&
           typeof table === "object" &&
@@ -109,6 +104,7 @@ function makeWorkflow(overrides: Record<string, unknown> = {}) {
     orgId: "org1",
     name: "sales-email-cold-outreach-alpha",
     displayName: null,
+    brandId: null,
     description: null,
     category: "sales",
     channel: "email",
@@ -157,7 +153,9 @@ const EMPTY_STATS = {
   recipients: 0,
 };
 
-describe("GET /workflows/best", () => {
+// ==================== GET /workflows/ranked ====================
+
+describe("GET /workflows/ranked", () => {
   beforeEach(() => {
     mockWorkflowRows.length = 0;
     mockWorkflowRunRows.length = 0;
@@ -165,7 +163,7 @@ describe("GET /workflows/best", () => {
     mockFetchEmailStats.mockReset();
   });
 
-  it("returns the best workflow by cost_per_reply", async () => {
+  it("returns ranked workflows with stats", async () => {
     const wf = makeWorkflow({ id: "wf-a" });
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(
@@ -183,7 +181,7 @@ describe("GET /workflows/best", () => {
     });
 
     const res = await request
-      .get("/workflows/best")
+      .get("/workflows/ranked")
       .query(BASE_QUERY)
       .set(AUTH);
 
@@ -214,7 +212,7 @@ describe("GET /workflows/best", () => {
     });
 
     const res = await request
-      .get("/workflows/best")
+      .get("/workflows/ranked")
       .query({ ...BASE_QUERY, objective: "clicks" })
       .set(AUTH);
 
@@ -224,41 +222,9 @@ describe("GET /workflows/best", () => {
     expect(best.stats.costPerOutcome).toBe(10);
   });
 
-  it("accepts partial filters (all optional)", async () => {
-    // With only category set and no matching workflows, should return 404 (not 400)
-    const res = await request
-      .get("/workflows/best")
-      .query({ category: "sales" })
-      .set(AUTH);
-
-    expect(res.status).toBe(404);
-  });
-
-  it("returns best workflow with no filters (defaults objective to replies)", async () => {
-    const wf = makeWorkflow({ id: "wf-nofilter" });
-    mockWorkflowRows.push(wf);
-    mockWorkflowRunRows.push(makeRun("wf-nofilter", "ext-run-nf"));
-
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-nf", totalCostInUsdCents: 100 },
-    ]);
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
-
-    const res = await request
-      .get("/workflows/best")
-      .set(AUTH);
-
-    expect(res.status).toBe(200);
-    expect(res.body.results[0].workflow.id).toBe("wf-nofilter");
-    expect(res.body.results[0].stats.totalOutcomes).toBe(5);
-  });
-
   it("returns 404 when no workflows match", async () => {
     const res = await request
-      .get("/workflows/best")
+      .get("/workflows/ranked")
       .query(BASE_QUERY)
       .set(AUTH);
 
@@ -280,7 +246,7 @@ describe("GET /workflows/best", () => {
     );
 
     const res = await request
-      .get("/workflows/best")
+      .get("/workflows/ranked")
       .query(BASE_QUERY)
       .set(AUTH);
 
@@ -290,20 +256,11 @@ describe("GET /workflows/best", () => {
 
   it("requires authentication", async () => {
     const res = await request
-      .get("/workflows/best")
+      .get("/workflows/ranked")
       .set(IDENTITY)
       .query(BASE_QUERY);
 
     expect(res.status).toBe(401);
-  });
-
-  it("rejects invalid objective value", async () => {
-    const res = await request
-      .get("/workflows/best")
-      .query({ ...BASE_QUERY, objective: "conversions" })
-      .set(AUTH);
-
-    expect(res.status).toBe(400);
   });
 
   it("handles workflow with zero outcomes (costPerOutcome is null)", async () => {
@@ -319,7 +276,7 @@ describe("GET /workflows/best", () => {
     });
 
     const res = await request
-      .get("/workflows/best")
+      .get("/workflows/ranked")
       .query(BASE_QUERY)
       .set(AUTH);
 
@@ -348,7 +305,7 @@ describe("GET /workflows/best", () => {
     });
 
     const res = await request
-      .get("/workflows/best")
+      .get("/workflows/ranked")
       .query(BASE_QUERY)
       .set(AUTH);
 
@@ -381,7 +338,7 @@ describe("GET /workflows/best", () => {
     });
 
     const res = await request
-      .get("/workflows/best")
+      .get("/workflows/ranked")
       .query(BASE_QUERY)
       .set(AUTH);
 
@@ -391,32 +348,7 @@ describe("GET /workflows/best", () => {
     expect(res.body.results[0].stats.completedRuns).toBe(3);
   });
 
-  it("returns only active workflow in response even when deprecated predecessors exist", async () => {
-    mockWorkflowRows.push(
-      makeWorkflow({ id: "wf-active" }),
-      makeWorkflow({ id: "wf-old", status: "deprecated", upgradedTo: "wf-active" }),
-    );
-    mockWorkflowRunRows.push(makeRun("wf-active", "ext-run-1"));
-
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 100 },
-    ]);
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
-
-    const res = await request
-      .get("/workflows/best")
-      .query(BASE_QUERY)
-      .set(AUTH);
-
-    expect(res.status).toBe(200);
-    // The returned workflow is the active one, not the deprecated predecessor
-    expect(res.body.results[0].workflow.id).toBe("wf-active");
-  });
-
-  it("returns multiple workflows when limit > 1", async () => {
+  it("returns multiple workflows ranked when limit > 1", async () => {
     const wfA = makeWorkflow({ id: "wf-a", signatureName: "alpha" });
     const wfB = makeWorkflow({ id: "wf-b", signatureName: "beta" });
     const wfC = makeWorkflow({ id: "wf-c", signatureName: "gamma" });
@@ -432,16 +364,13 @@ describe("GET /workflows/best", () => {
       { runId: "ext-run-b", totalCostInUsdCents: 200 },
       { runId: "ext-run-c", totalCostInUsdCents: 50 },
     ]);
-    // wf-a: cost=100, replies=10, cpo=10
-    // wf-b: cost=200, replies=5, cpo=40
-    // wf-c: cost=50, replies=25, cpo=2
     mockFetchEmailStats
       .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, replied: 10 }, broadcast: { ...EMPTY_STATS } })
       .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, replied: 5 }, broadcast: { ...EMPTY_STATS } })
       .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, replied: 25 }, broadcast: { ...EMPTY_STATS } });
 
     const res = await request
-      .get("/workflows/best")
+      .get("/workflows/ranked")
       .query({ ...BASE_QUERY, limit: "3" })
       .set(AUTH);
 
@@ -453,40 +382,8 @@ describe("GET /workflows/best", () => {
     expect(res.body.results[2].workflow.id).toBe("wf-b");
   });
 
-  it("includes all active workflows with their stats when limit > 1", async () => {
-    // The mock DB returns all rows regardless of where clause, so both workflows
-    // get the same runs. This test verifies that all active workflows appear in results.
-    const wfA = makeWorkflow({ id: "wf-a-stats" });
-    const wfB = makeWorkflow({ id: "wf-b-stats" });
-    mockWorkflowRows.push(wfA, wfB);
-    mockWorkflowRunRows.push(
-      makeRun("wf-a-stats", "ext-run-1"),
-      makeRun("wf-b-stats", "ext-run-2"),
-    );
-
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 100 },
-      { runId: "ext-run-2", totalCostInUsdCents: 200 },
-    ]);
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
-
-    const res = await request
-      .get("/workflows/best")
-      .query({ ...BASE_QUERY, limit: "10" })
-      .set(AUTH);
-
-    expect(res.status).toBe(200);
-    expect(res.body.results).toHaveLength(2);
-    // Both workflows should have email stats included
-    expect(res.body.results[0].stats.email.transactional.replied).toBe(5);
-    expect(res.body.results[1].stats.email.transactional.replied).toBe(5);
-  });
-
-  it("includes displayName in workflow response", async () => {
-    const wf = makeWorkflow({ id: "wf-dn", displayName: "sales-email-cold-outreach-jasmine" });
+  it("includes displayName and brandId in workflow response", async () => {
+    const wf = makeWorkflow({ id: "wf-dn", displayName: "sales-email-cold-outreach-jasmine", brandId: "brand-123" });
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-dn", "ext-run-dn"));
 
@@ -499,18 +396,18 @@ describe("GET /workflows/best", () => {
     });
 
     const res = await request
-      .get("/workflows/best")
+      .get("/workflows/ranked")
       .query(BASE_QUERY)
       .set(AUTH);
 
     expect(res.status).toBe(200);
     expect(res.body.results[0].workflow.displayName).toBe("sales-email-cold-outreach-jasmine");
+    expect(res.body.results[0].workflow.brandId).toBe("brand-123");
   });
 
   it("respects limit to cap results", async () => {
     for (let i = 0; i < 5; i++) {
-      const wf = makeWorkflow({ id: `wf-${i}` });
-      mockWorkflowRows.push(wf);
+      mockWorkflowRows.push(makeWorkflow({ id: `wf-${i}` }));
       mockWorkflowRunRows.push(makeRun(`wf-${i}`, `ext-run-${i}`));
     }
 
@@ -523,11 +420,177 @@ describe("GET /workflows/best", () => {
     });
 
     const res = await request
-      .get("/workflows/best")
+      .get("/workflows/ranked")
       .query({ ...BASE_QUERY, limit: "2" })
       .set(AUTH);
 
     expect(res.status).toBe(200);
     expect(res.body.results).toHaveLength(2);
+  });
+
+  it("returns grouped sections with groupBy=section", async () => {
+    const wfSales = makeWorkflow({ id: "wf-sales", category: "sales", channel: "email", audienceType: "cold-outreach" });
+    const wfSales2 = makeWorkflow({ id: "wf-sales2", category: "sales", channel: "email", audienceType: "cold-outreach" });
+    mockWorkflowRows.push(wfSales, wfSales2);
+    mockWorkflowRunRows.push(
+      makeRun("wf-sales", "ext-run-s1"),
+      makeRun("wf-sales2", "ext-run-s2"),
+    );
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-s1", totalCostInUsdCents: 100 },
+      { runId: "ext-run-s2", totalCostInUsdCents: 200 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS, replied: 5, sent: 50, opened: 20 },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    const res = await request
+      .get("/workflows/ranked")
+      .query({ ...BASE_QUERY, groupBy: "section" })
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.sections).toBeDefined();
+    expect(res.body.sections).toHaveLength(1);
+    const section = res.body.sections[0];
+    expect(section.sectionKey).toBe("sales-email-cold-outreach");
+    expect(section.category).toBe("sales");
+    expect(section.channel).toBe("email");
+    expect(section.audienceType).toBe("cold-outreach");
+    expect(section.stats).toBeDefined();
+    expect(section.stats.email).toBeDefined();
+    expect(section.workflows).toHaveLength(2);
+  });
+});
+
+// ==================== GET /workflows/best (hero records) ====================
+
+describe("GET /workflows/best (hero records)", () => {
+  beforeEach(() => {
+    mockWorkflowRows.length = 0;
+    mockWorkflowRunRows.length = 0;
+    mockFetchRunCosts.mockReset();
+    mockFetchEmailStats.mockReset();
+  });
+
+  it("returns bestCostPerOpen and bestCostPerReply", async () => {
+    const wf = makeWorkflow({ id: "wf-hero", brandId: "brand-abc" });
+    mockWorkflowRows.push(wf);
+    mockWorkflowRunRows.push(makeRun("wf-hero", "ext-run-hero"));
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-hero", totalCostInUsdCents: 100 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    const res = await request
+      .get("/workflows/best")
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.bestCostPerOpen).toBeDefined();
+    expect(res.body.bestCostPerOpen.workflowId).toBe("wf-hero");
+    expect(res.body.bestCostPerOpen.brandId).toBe("brand-abc");
+    expect(res.body.bestCostPerOpen.value).toBe(10); // 100 / 10 opens
+    expect(res.body.bestCostPerReply).toBeDefined();
+    expect(res.body.bestCostPerReply.workflowId).toBe("wf-hero");
+    expect(res.body.bestCostPerReply.value).toBe(20); // 100 / 5 replies
+  });
+
+  it("returns null when no opens or replies exist", async () => {
+    const wf = makeWorkflow({ id: "wf-no-outcomes" });
+    mockWorkflowRows.push(wf);
+    mockWorkflowRunRows.push(makeRun("wf-no-outcomes", "ext-run-no"));
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-no", totalCostInUsdCents: 100 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    const res = await request
+      .get("/workflows/best")
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.bestCostPerOpen).toBeNull();
+    expect(res.body.bestCostPerReply).toBeNull();
+  });
+
+  it("returns 404 when no active workflows exist", async () => {
+    const res = await request
+      .get("/workflows/best")
+      .set(AUTH);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("requires authentication", async () => {
+    const res = await request
+      .get("/workflows/best")
+      .set(IDENTITY);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("includes displayName in hero records", async () => {
+    const wf = makeWorkflow({ id: "wf-dn-hero", displayName: "sales-email-cold-outreach-jasmine" });
+    mockWorkflowRows.push(wf);
+    mockWorkflowRunRows.push(makeRun("wf-dn-hero", "ext-run-dn"));
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-dn", totalCostInUsdCents: 100 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    const res = await request
+      .get("/workflows/best")
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.bestCostPerOpen.displayName).toBe("sales-email-cold-outreach-jasmine");
+    expect(res.body.bestCostPerReply.displayName).toBe("sales-email-cold-outreach-jasmine");
+  });
+
+  it("picks the best from multiple workflows", async () => {
+    // Mock DB returns all runs for all workflows, so both workflows see the same runs.
+    // To test ranking, we use different mockFetchEmailStats responses per workflow call.
+    // wf-expensive gets called first (higher cost-per-outcome), wf-cheap second (lower).
+    const wfExpensive = makeWorkflow({ id: "wf-expensive" });
+    const wfCheap = makeWorkflow({ id: "wf-cheap" });
+    mockWorkflowRows.push(wfExpensive, wfCheap);
+    mockWorkflowRunRows.push(
+      makeRun("wf-expensive", "ext-run-1"),
+      makeRun("wf-cheap", "ext-run-2"),
+    );
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-1", totalCostInUsdCents: 500 },
+      { runId: "ext-run-2", totalCostInUsdCents: 500 },
+    ]);
+    // First call (wf-expensive): low opens/replies → high cost-per
+    mockFetchEmailStats
+      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 2, replied: 1 }, broadcast: { ...EMPTY_STATS } })
+      // Second call (wf-cheap): high opens/replies → low cost-per
+      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 100, replied: 50 }, broadcast: { ...EMPTY_STATS } });
+
+    const res = await request
+      .get("/workflows/best")
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    // wf-cheap has lower cost-per-open (1000/100=10 vs 1000/2=500) and cost-per-reply
+    expect(res.body.bestCostPerOpen.workflowId).toBe("wf-cheap");
+    expect(res.body.bestCostPerReply.workflowId).toBe("wf-cheap");
   });
 });


### PR DESCRIPTION
## Summary
- **`GET /workflows/ranked`**: replaces the old `GET /workflows/best` (ranked list). Supports filtering by category/channel/audienceType, `limit`, and `groupBy=section` for grouped results with aggregated section stats.
- **`GET /workflows/best`**: new hero records endpoint — returns `bestCostPerOpen` and `bestCostPerReply` across all active workflows.
- Both endpoints aggregate stats across upgrade chains and include `brandId`, `displayName`, and full email stats.
- **Breaking change**: old `GET /workflows/best` (ranked list) is now at `/workflows/ranked`. The new `/workflows/best` returns a different response shape.

## Test plan
- [x] 408 tests pass (29 test files)
- [x] 12 tests for `/workflows/ranked` (filtering, ranking, limit, groupBy=section, upgrade chain aggregation, 502 handling)
- [x] 6 tests for `/workflows/best` (hero records, null handling, multiple workflow selection, auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)