### PR TITLE
feat: public /public/workflows/ranked and /best endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1268,6 +1268,36 @@
           "bestCostPerReply"
         ]
       },
+      "PublicRankedWorkflowItem": {
+        "type": "object",
+        "properties": {
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowMetadata"
+          },
+          "stats": {
+            "$ref": "#/components/schemas/WorkflowStats"
+          }
+        },
+        "required": [
+          "workflow",
+          "stats"
+        ]
+      },
+      "PublicRankedWorkflowResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PublicRankedWorkflowItem"
+            },
+            "description": "Workflows ranked by performance, best first."
+          }
+        },
+        "required": [
+          "results"
+        ]
+      },
       "ExecuteByNameRequest": {
         "type": "object",
         "properties": {
@@ -3194,6 +3224,201 @@
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
             "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Hero records found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BestWorkflowResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No active workflows found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "External service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/workflows/ranked": {
+      "get": {
+        "summary": "Public: Get workflows ranked by cost-per-outcome",
+        "description": "Public version of GET /workflows/ranked. No authentication required. Returns workflows ranked by performance with stats, but without DAG details. Stats are aggregated across the full upgrade chain. Use `groupBy=section` to group results by category-channel-audienceType.",
+        "tags": [
+          "Public"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Organization ID. When omitted, searches across all orgs."
+            },
+            "required": false,
+            "description": "Organization ID. When omitted, searches across all orgs.",
+            "name": "orgId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/WorkflowCategory"
+                },
+                {
+                  "description": "Filter workflows by category."
+                }
+              ]
+            },
+            "required": false,
+            "description": "Filter workflows by category.",
+            "name": "category",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/WorkflowChannel"
+                },
+                {
+                  "description": "Filter workflows by channel."
+                }
+              ]
+            },
+            "required": false,
+            "description": "Filter workflows by channel.",
+            "name": "channel",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/WorkflowAudienceType"
+                },
+                {
+                  "description": "Filter workflows by audience type."
+                }
+              ]
+            },
+            "required": false,
+            "description": "Filter workflows by audience type.",
+            "name": "audienceType",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/RankedWorkflowObjective"
+            },
+            "required": false,
+            "description": "Which metric to optimize for. Defaults to 'replies'.",
+            "name": "objective",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10,
+              "description": "Max workflows per section (when groupBy=section) or total (when flat). Defaults to 10."
+            },
+            "required": false,
+            "description": "Max workflows per section (when groupBy=section) or total (when flat). Defaults to 10.",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/RankedWorkflowGroupBy"
+            },
+            "required": false,
+            "description": "Group results by section. When omitted, returns a flat ranked list.",
+            "name": "groupBy",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ranked workflows (flat list or grouped by section)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicRankedWorkflowResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid query parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No workflows found matching the criteria",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "External service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/workflows/best": {
+      "get": {
+        "summary": "Public: Get hero records — best cost-per-open and best cost-per-reply",
+        "description": "Public version of GET /workflows/best. No authentication required. Returns the single best workflow for cost-per-open and cost-per-reply across all active workflows. Stats are aggregated across the full upgrade chain.",
+        "tags": [
+          "Public"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Organization ID. When omitted, searches across all orgs."
+            },
+            "required": false,
+            "description": "Organization ID. When omitted, searches across all orgs.",
+            "name": "orgId",
+            "in": "query"
           }
         ],
         "responses": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import healthRoutes from "./routes/health.js";
 import workflowsRoutes from "./routes/workflows.js";
 import workflowRunsRoutes from "./routes/workflow-runs.js";
 import openapiRoutes from "./routes/openapi.js";
+import publicWorkflowsRoutes from "./routes/public-workflows.js";
 
 const app = express();
 const PORT = process.env.PORT ?? 3000;
@@ -22,6 +23,7 @@ app.use(express.json());
 // Public routes (no identity required)
 app.use(healthRoutes);
 app.use(openapiRoutes);
+app.use(publicWorkflowsRoutes);
 
 // Identity-gated routes
 app.use(requireIdentity);

--- a/src/lib/workflow-scoring.ts
+++ b/src/lib/workflow-scoring.ts
@@ -1,0 +1,244 @@
+import { eq, and, inArray } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { workflows, workflowRuns } from "../db/schema.js";
+import { fetchRunCosts, fetchEmailStats } from "./stats-client.js";
+import type { IdentityHeaders } from "./key-service-client.js";
+
+export const EMPTY_EMAIL_STATS = {
+  sent: 0, delivered: 0, opened: 0, clicked: 0,
+  replied: 0, bounced: 0, unsubscribed: 0, recipients: 0,
+};
+
+export interface WorkflowScore {
+  workflow: typeof workflows.$inferSelect;
+  totalCost: number;
+  totalOutcomes: number;
+  costPerOutcome: number | null;
+  completedRuns: number;
+  emailStats: { transactional: typeof EMPTY_EMAIL_STATS; broadcast: typeof EMPTY_EMAIL_STATS };
+}
+
+export function getUpgradeChainIds(
+  activeWorkflowId: string,
+  deprecatedWorkflows: { id: string; upgradedTo: string | null }[],
+): string[] {
+  const predecessorMap = new Map<string, string[]>();
+  for (const d of deprecatedWorkflows) {
+    if (!d.upgradedTo) continue;
+    const existing = predecessorMap.get(d.upgradedTo) ?? [];
+    existing.push(d.id);
+    predecessorMap.set(d.upgradedTo, existing);
+  }
+
+  const chainIds: string[] = [activeWorkflowId];
+  const queue = [activeWorkflowId];
+  const visited = new Set<string>([activeWorkflowId]);
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const preds = predecessorMap.get(current) ?? [];
+    for (const predId of preds) {
+      if (!visited.has(predId)) {
+        visited.add(predId);
+        chainIds.push(predId);
+        queue.push(predId);
+      }
+    }
+  }
+
+  return chainIds;
+}
+
+export async function computeWorkflowScores(
+  activeWorkflows: (typeof workflows.$inferSelect)[],
+  deprecatedWorkflows: { id: string; upgradedTo: string | null }[],
+  objective: "replies" | "clicks",
+  identity: IdentityHeaders,
+): Promise<WorkflowScore[]> {
+  // 1. For each active workflow, get completed runs across entire upgrade chain
+  const workflowRunsByWfId: Record<string, string[]> = {};
+  const allRunIds: string[] = [];
+
+  for (const wf of activeWorkflows) {
+    const chainIds = getUpgradeChainIds(wf.id, deprecatedWorkflows);
+
+    const runs = chainIds.length === 1
+      ? await db
+          .select()
+          .from(workflowRuns)
+          .where(
+            and(
+              eq(workflowRuns.workflowId, chainIds[0]),
+              eq(workflowRuns.status, "completed"),
+            )
+          )
+      : await db
+          .select()
+          .from(workflowRuns)
+          .where(
+            and(
+              inArray(workflowRuns.workflowId, chainIds),
+              eq(workflowRuns.status, "completed"),
+            )
+          );
+
+    const runIds = runs
+      .map((r) => r.runId)
+      .filter((id): id is string => id !== null);
+
+    workflowRunsByWfId[wf.id] = runIds;
+    allRunIds.push(...runIds);
+  }
+
+  // 2. Batch fetch costs from runs-service (only if there are runs)
+  const costByRunId = new Map<string, number>();
+  if (allRunIds.length > 0) {
+    const runCosts = await fetchRunCosts(allRunIds, identity);
+    for (const c of runCosts) {
+      costByRunId.set(c.runId, c.totalCostInUsdCents);
+    }
+  }
+
+  // 3. Per-workflow: compute cost + fetch email stats
+  const scores: WorkflowScore[] = [];
+
+  for (const wf of activeWorkflows) {
+    const runIds = workflowRunsByWfId[wf.id] ?? [];
+
+    if (runIds.length === 0) {
+      scores.push({
+        workflow: wf,
+        totalCost: 0,
+        totalOutcomes: 0,
+        costPerOutcome: null,
+        completedRuns: 0,
+        emailStats: { transactional: { ...EMPTY_EMAIL_STATS }, broadcast: { ...EMPTY_EMAIL_STATS } },
+      });
+      continue;
+    }
+
+    const totalCost = runIds.reduce(
+      (sum, id) => sum + (costByRunId.get(id) ?? 0),
+      0
+    );
+
+    const stats = await fetchEmailStats(runIds, identity);
+    const outcomes =
+      objective === "replies"
+        ? (stats.transactional?.replied ?? 0) + (stats.broadcast?.replied ?? 0)
+        : (stats.transactional?.clicked ?? 0) + (stats.broadcast?.clicked ?? 0);
+
+    const costPerOutcome = outcomes > 0 ? totalCost / outcomes : null;
+
+    scores.push({
+      workflow: wf,
+      totalCost,
+      totalOutcomes: outcomes,
+      costPerOutcome,
+      completedRuns: runIds.length,
+      emailStats: {
+        transactional: stats.transactional ?? { ...EMPTY_EMAIL_STATS },
+        broadcast: stats.broadcast ?? { ...EMPTY_EMAIL_STATS },
+      },
+    });
+  }
+
+  return scores;
+}
+
+export function rankScores(scores: WorkflowScore[]): WorkflowScore[] {
+  return [...scores].sort((a, b) => {
+    if (a.costPerOutcome !== null && b.costPerOutcome !== null) {
+      return a.costPerOutcome - b.costPerOutcome;
+    }
+    if (a.costPerOutcome !== null) return -1;
+    if (b.costPerOutcome !== null) return 1;
+    return b.completedRuns - a.completedRuns;
+  });
+}
+
+export function formatScoreItem(entry: WorkflowScore) {
+  return {
+    workflow: {
+      id: entry.workflow.id,
+      name: entry.workflow.name,
+      displayName: entry.workflow.displayName,
+      brandId: entry.workflow.brandId,
+      category: entry.workflow.category,
+      channel: entry.workflow.channel,
+      audienceType: entry.workflow.audienceType,
+      signature: entry.workflow.signature,
+      signatureName: entry.workflow.signatureName,
+    },
+    dag: entry.workflow.dag,
+    stats: formatStats(entry),
+  };
+}
+
+export function formatPublicScoreItem(entry: WorkflowScore) {
+  return {
+    workflow: {
+      id: entry.workflow.id,
+      name: entry.workflow.name,
+      displayName: entry.workflow.displayName,
+      brandId: entry.workflow.brandId,
+      category: entry.workflow.category,
+      channel: entry.workflow.channel,
+      audienceType: entry.workflow.audienceType,
+      signature: entry.workflow.signature,
+      signatureName: entry.workflow.signatureName,
+    },
+    stats: formatStats(entry),
+  };
+}
+
+function formatStats(entry: WorkflowScore) {
+  return {
+    totalCostInUsdCents: entry.totalCost,
+    totalOutcomes: entry.totalOutcomes,
+    costPerOutcome: entry.costPerOutcome,
+    completedRuns: entry.completedRuns,
+    email: entry.emailStats,
+  };
+}
+
+export function aggregateSectionStats(scores: WorkflowScore[]) {
+  const totalCost = scores.reduce((s, e) => s + e.totalCost, 0);
+  const totalOutcomes = scores.reduce((s, e) => s + e.totalOutcomes, 0);
+  const completedRuns = scores.reduce((s, e) => s + e.completedRuns, 0);
+  const costPerOutcome = totalOutcomes > 0 ? totalCost / totalOutcomes : null;
+  const transactional = { ...EMPTY_EMAIL_STATS };
+  const broadcast = { ...EMPTY_EMAIL_STATS };
+  for (const e of scores) {
+    for (const key of Object.keys(EMPTY_EMAIL_STATS) as (keyof typeof EMPTY_EMAIL_STATS)[]) {
+      transactional[key] += e.emailStats.transactional[key];
+      broadcast[key] += e.emailStats.broadcast[key];
+    }
+  }
+  return { totalCostInUsdCents: totalCost, totalOutcomes, costPerOutcome, completedRuns, email: { transactional, broadcast } };
+}
+
+export function handleExternalServiceError(err: unknown, res: import("express").Response, label: string) {
+  if (err instanceof Error && err.name === "ZodError") {
+    res.status(400).json({ error: "Validation error", details: err });
+    return true;
+  }
+  if (
+    err instanceof Error &&
+    (err.message.includes("RUNS_SERVICE_URL") ||
+      err.message.includes("EMAIL_GATEWAY_SERVICE_URL") ||
+      err.message.startsWith("email-gateway-service error:"))
+  ) {
+    console.error(`[workflow-service] ${label}: external service error:`, err.message);
+    res.status(502).json({ error: err.message });
+    return true;
+  }
+  return false;
+}
+
+/** System identity for public endpoints — used only for logging by downstream services */
+export const SYSTEM_IDENTITY = {
+  orgId: "system",
+  userId: "system",
+  runId: "system-public",
+};

--- a/src/routes/public-workflows.ts
+++ b/src/routes/public-workflows.ts
@@ -1,0 +1,159 @@
+import { Router } from "express";
+import { eq, and } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { workflows } from "../db/schema.js";
+import {
+  RankedWorkflowQuerySchema,
+  BestWorkflowQuerySchema,
+} from "../schemas.js";
+import {
+  computeWorkflowScores,
+  rankScores,
+  formatPublicScoreItem,
+  aggregateSectionStats,
+  handleExternalServiceError,
+  SYSTEM_IDENTITY,
+  type WorkflowScore,
+} from "../lib/workflow-scoring.js";
+
+const router = Router();
+
+// GET /public/workflows/ranked — Public ranked workflows (no auth, no DAG)
+router.get("/public/workflows/ranked", async (req, res) => {
+  try {
+    const query = RankedWorkflowQuerySchema.safeParse(req.query);
+    if (!query.success) {
+      res.status(400).json({ error: "Validation error", details: query.error });
+      return;
+    }
+    const { orgId, category, channel, audienceType, objective, limit, groupBy } = query.data;
+
+    const conditions: ReturnType<typeof eq>[] = [];
+    if (orgId) conditions.push(eq(workflows.orgId, orgId));
+    if (category) conditions.push(eq(workflows.category, category));
+    if (channel) conditions.push(eq(workflows.channel, channel));
+    if (audienceType) conditions.push(eq(workflows.audienceType, audienceType));
+
+    const allMatchingWorkflows = conditions.length > 0
+      ? await db.select().from(workflows).where(and(...conditions))
+      : await db.select().from(workflows);
+
+    const activeWorkflows = allMatchingWorkflows.filter((w) => w.status === "active");
+    const deprecatedWorkflows = allMatchingWorkflows.filter((w) => w.status === "deprecated");
+
+    if (activeWorkflows.length === 0) {
+      res.status(404).json({ error: "No workflows found matching the criteria" });
+      return;
+    }
+
+    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, objective, SYSTEM_IDENTITY);
+
+    if (groupBy === "section") {
+      const sectionMap = new Map<string, WorkflowScore[]>();
+      for (const score of scores) {
+        const key = `${score.workflow.category}-${score.workflow.channel}-${score.workflow.audienceType}`;
+        const arr = sectionMap.get(key) ?? [];
+        arr.push(score);
+        sectionMap.set(key, arr);
+      }
+
+      const sections = [...sectionMap.entries()].map(([sectionKey, sectionScores]) => {
+        const ranked = rankScores(sectionScores).slice(0, limit);
+        const sample = sectionScores[0].workflow;
+        return {
+          sectionKey,
+          category: sample.category,
+          channel: sample.channel,
+          audienceType: sample.audienceType,
+          stats: aggregateSectionStats(sectionScores),
+          workflows: ranked.map(formatPublicScoreItem),
+        };
+      });
+
+      res.json({ sections });
+    } else {
+      const ranked = rankScores(scores).slice(0, limit);
+      res.json({ results: ranked.map(formatPublicScoreItem) });
+    }
+  } catch (err: unknown) {
+    if (!handleExternalServiceError(err, res, "public/ranked")) {
+      console.error("[workflow-service] GET public/ranked error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  }
+});
+
+// GET /public/workflows/best — Public hero records (no auth, no DAG)
+router.get("/public/workflows/best", async (req, res) => {
+  try {
+    const query = BestWorkflowQuerySchema.safeParse(req.query);
+    if (!query.success) {
+      res.status(400).json({ error: "Validation error", details: query.error });
+      return;
+    }
+    const { orgId } = query.data;
+
+    const conditions: ReturnType<typeof eq>[] = [];
+    if (orgId) conditions.push(eq(workflows.orgId, orgId));
+
+    const allMatchingWorkflows = conditions.length > 0
+      ? await db.select().from(workflows).where(and(...conditions))
+      : await db.select().from(workflows);
+
+    const activeWorkflows = allMatchingWorkflows.filter((w) => w.status === "active");
+    const deprecatedWorkflows = allMatchingWorkflows.filter((w) => w.status === "deprecated");
+
+    if (activeWorkflows.length === 0) {
+      res.status(404).json({ error: "No active workflows found" });
+      return;
+    }
+
+    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, "replies", SYSTEM_IDENTITY);
+
+    let bestCostPerOpen: { score: WorkflowScore; value: number } | null = null;
+    let bestCostPerReply: { score: WorkflowScore; value: number } | null = null;
+
+    for (const s of scores) {
+      if (s.completedRuns === 0) continue;
+
+      const totalOpened = s.emailStats.transactional.opened + s.emailStats.broadcast.opened;
+      if (totalOpened > 0) {
+        const costPerOpen = s.totalCost / totalOpened;
+        if (!bestCostPerOpen || costPerOpen < bestCostPerOpen.value) {
+          bestCostPerOpen = { score: s, value: costPerOpen };
+        }
+      }
+
+      const totalReplied = s.emailStats.transactional.replied + s.emailStats.broadcast.replied;
+      if (totalReplied > 0) {
+        const costPerReply = s.totalCost / totalReplied;
+        if (!bestCostPerReply || costPerReply < bestCostPerReply.value) {
+          bestCostPerReply = { score: s, value: costPerReply };
+        }
+      }
+    }
+
+    function formatRecord(entry: { score: WorkflowScore; value: number } | null) {
+      if (!entry) return null;
+      return {
+        workflowId: entry.score.workflow.id,
+        workflowName: entry.score.workflow.name,
+        displayName: entry.score.workflow.displayName,
+        brandId: entry.score.workflow.brandId,
+        value: Math.round(entry.value * 100) / 100,
+      };
+    }
+
+    res.json({
+      bestCostPerOpen: formatRecord(bestCostPerOpen),
+      bestCostPerReply: formatRecord(bestCostPerReply),
+    });
+  } catch (err: unknown) {
+    if (!handleExternalServiceError(err, res, "public/best")) {
+      console.error("[workflow-service] GET public/best error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  }
+});
+
+export default router;

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { eq, and, sql, inArray } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { workflows, workflowRuns } from "../db/schema.js";
 import { requireApiKey } from "../middleware/auth.js";
@@ -25,9 +25,17 @@ import { validateWorkflowEndpoints } from "../lib/validate-workflow-endpoints.js
 import { fetchSpecsForServices } from "../lib/api-registry-client.js";
 import { fetchProviderRequirements, fetchAnthropicKey } from "../lib/key-service-client.js";
 import { enrichProvidersWithDomains } from "../lib/provider-domains.js";
-import { fetchRunCosts, fetchEmailStats } from "../lib/stats-client.js";
 import { extractTemplateRefs, validateTemplateContracts, type TemplateContractIssue, type TemplateRef } from "../lib/validate-template-contracts.js";
 import { fetchPromptTemplates } from "../lib/content-generation-client.js";
+import {
+  getUpgradeChainIds,
+  computeWorkflowScores,
+  rankScores,
+  formatScoreItem,
+  aggregateSectionStats,
+  handleExternalServiceError,
+  type WorkflowScore,
+} from "../lib/workflow-scoring.js";
 
 const router = Router();
 
@@ -45,42 +53,6 @@ function generateFlowPath(scope: string, name: string): string {
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_|_$/g, "");
   return `f/workflows/${scope}/${slug}`;
-}
-
-/**
- * Returns all workflow IDs in the upgrade chain for the given active workflow,
- * including the active workflow itself. Walks backwards through deprecated
- * predecessors via the `upgraded_to` column.
- */
-function getUpgradeChainIds(
-  activeWorkflowId: string,
-  deprecatedWorkflows: { id: string; upgradedTo: string | null }[],
-): string[] {
-  const predecessorMap = new Map<string, string[]>();
-  for (const d of deprecatedWorkflows) {
-    if (!d.upgradedTo) continue;
-    const existing = predecessorMap.get(d.upgradedTo) ?? [];
-    existing.push(d.id);
-    predecessorMap.set(d.upgradedTo, existing);
-  }
-
-  const chainIds: string[] = [activeWorkflowId];
-  const queue = [activeWorkflowId];
-  const visited = new Set<string>([activeWorkflowId]);
-
-  while (queue.length > 0) {
-    const current = queue.shift()!;
-    const preds = predecessorMap.get(current) ?? [];
-    for (const predId of preds) {
-      if (!visited.has(predId)) {
-        visited.add(predId);
-        chainIds.push(predId);
-        queue.push(predId);
-      }
-    }
-  }
-
-  return chainIds;
 }
 
 // POST /workflows/generate — Generate a workflow from natural language
@@ -642,188 +614,6 @@ router.put("/workflows/deploy", requireApiKey, async (req, res) => {
     res.status(500).json({ error: "Internal server error" });
   }
 });
-
-// --- Shared helpers for ranked/best endpoints ---
-
-const EMPTY_EMAIL_STATS = {
-  sent: 0, delivered: 0, opened: 0, clicked: 0,
-  replied: 0, bounced: 0, unsubscribed: 0, recipients: 0,
-};
-
-interface WorkflowScore {
-  workflow: typeof workflows.$inferSelect;
-  totalCost: number;
-  totalOutcomes: number;
-  costPerOutcome: number | null;
-  completedRuns: number;
-  emailStats: { transactional: typeof EMPTY_EMAIL_STATS; broadcast: typeof EMPTY_EMAIL_STATS };
-}
-
-async function computeWorkflowScores(
-  activeWorkflows: (typeof workflows.$inferSelect)[],
-  deprecatedWorkflows: { id: string; upgradedTo: string | null }[],
-  objective: "replies" | "clicks",
-  identity: { orgId: string; userId: string; runId: string },
-): Promise<WorkflowScore[]> {
-  // 1. For each active workflow, get completed runs across entire upgrade chain
-  const workflowRunsByWfId: Record<string, string[]> = {};
-  const allRunIds: string[] = [];
-
-  for (const wf of activeWorkflows) {
-    const chainIds = getUpgradeChainIds(wf.id, deprecatedWorkflows);
-
-    const runs = chainIds.length === 1
-      ? await db
-          .select()
-          .from(workflowRuns)
-          .where(
-            and(
-              eq(workflowRuns.workflowId, chainIds[0]),
-              eq(workflowRuns.status, "completed"),
-            )
-          )
-      : await db
-          .select()
-          .from(workflowRuns)
-          .where(
-            and(
-              inArray(workflowRuns.workflowId, chainIds),
-              eq(workflowRuns.status, "completed"),
-            )
-          );
-
-    const runIds = runs
-      .map((r) => r.runId)
-      .filter((id): id is string => id !== null);
-
-    workflowRunsByWfId[wf.id] = runIds;
-    allRunIds.push(...runIds);
-  }
-
-  // 2. Batch fetch costs from runs-service (only if there are runs)
-  const costByRunId = new Map<string, number>();
-  if (allRunIds.length > 0) {
-    const runCosts = await fetchRunCosts(allRunIds, identity);
-    for (const c of runCosts) {
-      costByRunId.set(c.runId, c.totalCostInUsdCents);
-    }
-  }
-
-  // 3. Per-workflow: compute cost + fetch email stats
-  const scores: WorkflowScore[] = [];
-
-  for (const wf of activeWorkflows) {
-    const runIds = workflowRunsByWfId[wf.id] ?? [];
-
-    if (runIds.length === 0) {
-      scores.push({
-        workflow: wf,
-        totalCost: 0,
-        totalOutcomes: 0,
-        costPerOutcome: null,
-        completedRuns: 0,
-        emailStats: { transactional: { ...EMPTY_EMAIL_STATS }, broadcast: { ...EMPTY_EMAIL_STATS } },
-      });
-      continue;
-    }
-
-    const totalCost = runIds.reduce(
-      (sum, id) => sum + (costByRunId.get(id) ?? 0),
-      0
-    );
-
-    const stats = await fetchEmailStats(runIds, identity);
-    const outcomes =
-      objective === "replies"
-        ? (stats.transactional?.replied ?? 0) + (stats.broadcast?.replied ?? 0)
-        : (stats.transactional?.clicked ?? 0) + (stats.broadcast?.clicked ?? 0);
-
-    const costPerOutcome = outcomes > 0 ? totalCost / outcomes : null;
-
-    scores.push({
-      workflow: wf,
-      totalCost,
-      totalOutcomes: outcomes,
-      costPerOutcome,
-      completedRuns: runIds.length,
-      emailStats: {
-        transactional: stats.transactional ?? { ...EMPTY_EMAIL_STATS },
-        broadcast: stats.broadcast ?? { ...EMPTY_EMAIL_STATS },
-      },
-    });
-  }
-
-  return scores;
-}
-
-function rankScores(scores: WorkflowScore[]): WorkflowScore[] {
-  return [...scores].sort((a, b) => {
-    if (a.costPerOutcome !== null && b.costPerOutcome !== null) {
-      return a.costPerOutcome - b.costPerOutcome;
-    }
-    if (a.costPerOutcome !== null) return -1;
-    if (b.costPerOutcome !== null) return 1;
-    return b.completedRuns - a.completedRuns;
-  });
-}
-
-function formatScoreItem(entry: WorkflowScore) {
-  return {
-    workflow: {
-      id: entry.workflow.id,
-      name: entry.workflow.name,
-      displayName: entry.workflow.displayName,
-      brandId: entry.workflow.brandId,
-      category: entry.workflow.category,
-      channel: entry.workflow.channel,
-      audienceType: entry.workflow.audienceType,
-      signature: entry.workflow.signature,
-      signatureName: entry.workflow.signatureName,
-    },
-    dag: entry.workflow.dag,
-    stats: {
-      totalCostInUsdCents: entry.totalCost,
-      totalOutcomes: entry.totalOutcomes,
-      costPerOutcome: entry.costPerOutcome,
-      completedRuns: entry.completedRuns,
-      email: entry.emailStats,
-    },
-  };
-}
-
-function aggregateSectionStats(scores: WorkflowScore[]) {
-  const totalCost = scores.reduce((s, e) => s + e.totalCost, 0);
-  const totalOutcomes = scores.reduce((s, e) => s + e.totalOutcomes, 0);
-  const completedRuns = scores.reduce((s, e) => s + e.completedRuns, 0);
-  const costPerOutcome = totalOutcomes > 0 ? totalCost / totalOutcomes : null;
-  const transactional = { ...EMPTY_EMAIL_STATS };
-  const broadcast = { ...EMPTY_EMAIL_STATS };
-  for (const e of scores) {
-    for (const key of Object.keys(EMPTY_EMAIL_STATS) as (keyof typeof EMPTY_EMAIL_STATS)[]) {
-      transactional[key] += e.emailStats.transactional[key];
-      broadcast[key] += e.emailStats.broadcast[key];
-    }
-  }
-  return { totalCostInUsdCents: totalCost, totalOutcomes, costPerOutcome, completedRuns, email: { transactional, broadcast } };
-}
-
-function handleExternalServiceError(err: unknown, res: import("express").Response, label: string) {
-  if (err instanceof Error && err.name === "ZodError") {
-    res.status(400).json({ error: "Validation error", details: err });
-    return true;
-  }
-  if (
-    err instanceof Error &&
-    (err.message.includes("RUNS_SERVICE_URL") ||
-      err.message.includes("EMAIL_GATEWAY_SERVICE_URL") ||
-      err.message.startsWith("email-gateway-service error:"))
-  ) {
-    console.error(`[workflow-service] ${label}: external service error:`, err.message);
-    res.status(502).json({ error: err.message });
-    return true;
-  }
-  return false;
-}
 
 // GET /workflows/ranked — Workflows ranked by cost-per-outcome, with optional groupBy=section
 router.get("/workflows/ranked", requireApiKey, async (req, res) => {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -474,6 +474,32 @@ export const RankedWorkflowGroupedResponseSchema = z
   })
   .openapi("RankedWorkflowGroupedResponse");
 
+// --- Public (no-auth) variants — same structure but without DAG ---
+
+export const PublicRankedWorkflowItemSchema = z
+  .object({
+    workflow: WorkflowMetadataSchema.describe("Workflow metadata."),
+    stats: WorkflowStatsSchema.describe("Aggregated performance stats for this workflow."),
+  })
+  .openapi("PublicRankedWorkflowItem");
+
+export const PublicRankedSectionSchema = z
+  .object({
+    sectionKey: z.string().describe("Section key in the format category-channel-audienceType."),
+    category: WorkflowCategorySchema,
+    channel: WorkflowChannelSchema,
+    audienceType: WorkflowAudienceTypeSchema,
+    stats: WorkflowStatsSchema.describe("Aggregated stats across all workflows in this section."),
+    workflows: z.array(PublicRankedWorkflowItemSchema).describe("Workflows in this section, ranked by performance."),
+  })
+  .openapi("PublicRankedSection");
+
+export const PublicRankedWorkflowResponseSchema = z
+  .object({
+    results: z.array(PublicRankedWorkflowItemSchema).describe("Workflows ranked by performance, best first."),
+  })
+  .openapi("PublicRankedWorkflowResponse");
+
 // --- Best Workflow schemas (hero records) ---
 
 export const BestWorkflowQuerySchema = z
@@ -1025,6 +1051,73 @@ registry.registerPath({
   security: [{ apiKey: [] }],
   request: {
     headers: IdentityHeaders,
+    query: BestWorkflowQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "Hero records found",
+      content: {
+        "application/json": { schema: BestWorkflowResponseSchema },
+      },
+    },
+    404: {
+      description: "No active workflows found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "External service unavailable",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+// --- Public endpoints (no auth, no identity headers) ---
+
+registry.registerPath({
+  method: "get",
+  path: "/public/workflows/ranked",
+  summary: "Public: Get workflows ranked by cost-per-outcome",
+  description:
+    "Public version of GET /workflows/ranked. No authentication required. " +
+    "Returns workflows ranked by performance with stats, but without DAG details. " +
+    "Stats are aggregated across the full upgrade chain. " +
+    "Use `groupBy=section` to group results by category-channel-audienceType.",
+  tags: ["Public"],
+  request: {
+    query: RankedWorkflowQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "Ranked workflows (flat list or grouped by section)",
+      content: {
+        "application/json": { schema: PublicRankedWorkflowResponseSchema },
+      },
+    },
+    404: {
+      description: "No workflows found matching the criteria",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    400: {
+      description: "Missing or invalid query parameters",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "External service unavailable",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/public/workflows/best",
+  summary: "Public: Get hero records — best cost-per-open and best cost-per-reply",
+  description:
+    "Public version of GET /workflows/best. No authentication required. " +
+    "Returns the single best workflow for cost-per-open and cost-per-reply across all active workflows. " +
+    "Stats are aggregated across the full upgrade chain.",
+  tags: ["Public"],
+  request: {
     query: BestWorkflowQuerySchema,
   },
   responses: {

--- a/tests/integration/public-workflows.test.ts
+++ b/tests/integration/public-workflows.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { VALID_LINEAR_DAG } from "../helpers/fixtures.js";
+
+// --- Mock DB with table awareness ---
+const mockWorkflowRows: Record<string, unknown>[] = [];
+const mockWorkflowRunRows: Record<string, unknown>[] = [];
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    insert: () => ({
+      values: (row: Record<string, unknown>) => {
+        const newRow = {
+          id: "wf-" + Math.random().toString(36).slice(2, 10),
+          ...row,
+          windmillWorkspace: row.windmillWorkspace ?? "prod",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+        mockWorkflowRows.push(newRow);
+        return {
+          returning: () => Promise.resolve([newRow]),
+        };
+      },
+    }),
+    select: () => ({
+      from: (table: unknown) => {
+        const isWorkflowRuns =
+          table &&
+          typeof table === "object" &&
+          "workflowId" in (table as Record<string, unknown>);
+
+        const rows = isWorkflowRuns ? mockWorkflowRunRows : mockWorkflowRows;
+        const result = Promise.resolve(rows);
+        (result as any).where = (_condition?: unknown) => Promise.resolve(rows);
+        return result;
+      },
+    }),
+    update: () => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => {
+          const row = mockWorkflowRows[mockWorkflowRows.length - 1];
+          if (row) Object.assign(row, values);
+          return {
+            returning: () => Promise.resolve([{ ...row, ...values }]),
+          };
+        },
+      }),
+    }),
+    delete: () => ({
+      where: () => Promise.resolve(),
+    }),
+  },
+  sql: {
+    end: () => Promise.resolve(),
+  },
+}));
+
+// --- Mock stats-client ---
+const mockFetchRunCosts = vi.fn();
+const mockFetchEmailStats = vi.fn();
+
+vi.mock("../../src/lib/stats-client.js", () => ({
+  fetchRunCosts: (...args: unknown[]) => mockFetchRunCosts(...args),
+  fetchEmailStats: (...args: unknown[]) => mockFetchEmailStats(...args),
+}));
+
+// --- Mock Windmill ---
+vi.mock("../../src/lib/windmill-client.js", () => ({
+  getWindmillClient: () => ({
+    createFlow: vi.fn().mockResolvedValue("f/workflows/test/flow"),
+    updateFlow: vi.fn().mockResolvedValue(undefined),
+    deleteFlow: vi.fn().mockResolvedValue(undefined),
+    getFlow: vi.fn().mockResolvedValue({ path: "f/workflows/test/flow" }),
+    healthCheck: vi.fn().mockResolvedValue(true),
+  }),
+  WindmillClient: vi.fn(),
+  resetWindmillClient: vi.fn(),
+}));
+
+// --- Mock key-service ---
+vi.mock("../../src/lib/key-service-client.js", () => ({
+  fetchProviderRequirements: vi.fn(),
+  fetchAnthropicKey: vi.fn(),
+}));
+
+import supertest from "supertest";
+import app from "../../src/index.js";
+
+const request = supertest(app);
+
+const EMPTY_STATS = {
+  sent: 0, delivered: 0, opened: 0, clicked: 0,
+  replied: 0, bounced: 0, unsubscribed: 0, recipients: 0,
+};
+
+function makeWorkflow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "wf-" + Math.random().toString(36).slice(2, 10),
+    orgId: "org1",
+    name: "sales-email-cold-outreach-alpha",
+    displayName: null,
+    brandId: null,
+    description: null,
+    category: "sales",
+    channel: "email",
+    audienceType: "cold-outreach",
+    signature: "sig-" + Math.random().toString(36).slice(2, 8),
+    signatureName: "alpha",
+    dag: VALID_LINEAR_DAG,
+    windmillFlowPath: "f/workflows/test/flow",
+    windmillWorkspace: "prod",
+    status: "active",
+    upgradedTo: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeRun(workflowId: string, runId: string) {
+  return {
+    id: "wr-" + Math.random().toString(36).slice(2, 10),
+    workflowId,
+    runId,
+    orgId: "org1",
+    campaignId: null,
+    subrequestId: null,
+    windmillJobId: "wm-job-1",
+    windmillWorkspace: "prod",
+    status: "completed",
+    inputs: null,
+    result: null,
+    error: null,
+    startedAt: new Date(),
+    completedAt: new Date(),
+    createdAt: new Date(),
+  };
+}
+
+// ==================== GET /public/workflows/ranked ====================
+
+describe("GET /public/workflows/ranked", () => {
+  beforeEach(() => {
+    mockWorkflowRows.length = 0;
+    mockWorkflowRunRows.length = 0;
+    mockFetchRunCosts.mockReset();
+    mockFetchEmailStats.mockReset();
+  });
+
+  it("returns ranked workflows without auth headers", async () => {
+    const wf = makeWorkflow({ id: "wf-pub" });
+    mockWorkflowRows.push(wf);
+    mockWorkflowRunRows.push(makeRun("wf-pub", "ext-run-1"));
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-1", totalCostInUsdCents: 100 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS, replied: 10 },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    const res = await request
+      .get("/public/workflows/ranked")
+      .query({ category: "sales", channel: "email", audienceType: "cold-outreach" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(1);
+    expect(res.body.results[0].workflow.id).toBe("wf-pub");
+    expect(res.body.results[0].stats.totalCostInUsdCents).toBe(100);
+    expect(res.body.results[0].stats.email.transactional.replied).toBe(10);
+  });
+
+  it("does NOT include dag field in response", async () => {
+    const wf = makeWorkflow({ id: "wf-nodag" });
+    mockWorkflowRows.push(wf);
+    mockWorkflowRunRows.push(makeRun("wf-nodag", "ext-run-1"));
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-1", totalCostInUsdCents: 50 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS, replied: 5 },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    const res = await request
+      .get("/public/workflows/ranked")
+      .query({ category: "sales", channel: "email", audienceType: "cold-outreach" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[0]).not.toHaveProperty("dag");
+  });
+
+  it("uses system identity for downstream calls", async () => {
+    const wf = makeWorkflow({ id: "wf-sys" });
+    mockWorkflowRows.push(wf);
+    mockWorkflowRunRows.push(makeRun("wf-sys", "ext-run-1"));
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-1", totalCostInUsdCents: 100 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    await request
+      .get("/public/workflows/ranked")
+      .query({ category: "sales", channel: "email", audienceType: "cold-outreach" });
+
+    // Verify system identity was passed to downstream services
+    expect(mockFetchEmailStats).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ orgId: "system", userId: "system", runId: "system-public" }),
+    );
+  });
+
+  it("supports groupBy=section", async () => {
+    const wf = makeWorkflow({ id: "wf-sec" });
+    mockWorkflowRows.push(wf);
+    mockWorkflowRunRows.push(makeRun("wf-sec", "ext-run-1"));
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-1", totalCostInUsdCents: 100 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS, replied: 5, sent: 50 },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    const res = await request
+      .get("/public/workflows/ranked")
+      .query({ groupBy: "section" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.sections).toBeDefined();
+    expect(res.body.sections).toHaveLength(1);
+    expect(res.body.sections[0].sectionKey).toBe("sales-email-cold-outreach");
+    expect(res.body.sections[0].workflows[0]).not.toHaveProperty("dag");
+  });
+
+  it("returns 404 when no workflows match", async () => {
+    const res = await request
+      .get("/public/workflows/ranked")
+      .query({ category: "sales", channel: "email", audienceType: "cold-outreach" });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ==================== GET /public/workflows/best ====================
+
+describe("GET /public/workflows/best", () => {
+  beforeEach(() => {
+    mockWorkflowRows.length = 0;
+    mockWorkflowRunRows.length = 0;
+    mockFetchRunCosts.mockReset();
+    mockFetchEmailStats.mockReset();
+  });
+
+  it("returns hero records without auth headers", async () => {
+    const wf = makeWorkflow({ id: "wf-hero-pub", brandId: "brand-abc" });
+    mockWorkflowRows.push(wf);
+    mockWorkflowRunRows.push(makeRun("wf-hero-pub", "ext-run-hero"));
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-hero", totalCostInUsdCents: 100 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    const res = await request
+      .get("/public/workflows/best");
+
+    expect(res.status).toBe(200);
+    expect(res.body.bestCostPerOpen).toBeDefined();
+    expect(res.body.bestCostPerOpen.workflowId).toBe("wf-hero-pub");
+    expect(res.body.bestCostPerOpen.brandId).toBe("brand-abc");
+    expect(res.body.bestCostPerOpen.value).toBe(10); // 100 / 10 opens
+    expect(res.body.bestCostPerReply.workflowId).toBe("wf-hero-pub");
+    expect(res.body.bestCostPerReply.value).toBe(20); // 100 / 5 replies
+  });
+
+  it("returns null when no opens or replies exist", async () => {
+    const wf = makeWorkflow({ id: "wf-no-out" });
+    mockWorkflowRows.push(wf);
+    mockWorkflowRunRows.push(makeRun("wf-no-out", "ext-run-no"));
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-no", totalCostInUsdCents: 100 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    const res = await request
+      .get("/public/workflows/best");
+
+    expect(res.status).toBe(200);
+    expect(res.body.bestCostPerOpen).toBeNull();
+    expect(res.body.bestCostPerReply).toBeNull();
+  });
+
+  it("returns 404 when no active workflows exist", async () => {
+    const res = await request
+      .get("/public/workflows/best");
+
+    expect(res.status).toBe(404);
+  });
+
+  it("uses system identity for downstream calls", async () => {
+    const wf = makeWorkflow({ id: "wf-sys-best" });
+    mockWorkflowRows.push(wf);
+    mockWorkflowRunRows.push(makeRun("wf-sys-best", "ext-run-1"));
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-1", totalCostInUsdCents: 100 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS, opened: 10 },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    await request.get("/public/workflows/best");
+
+    expect(mockFetchRunCosts).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ orgId: "system", userId: "system", runId: "system-public" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `GET /public/workflows/ranked` and `GET /public/workflows/best` — no auth required, no DAG in response, for landing pages and public dashboards
- Extract shared scoring logic (`computeWorkflowScores`, `rankScores`, `aggregateSectionStats`, etc.) into `src/lib/workflow-scoring.ts` to avoid duplication between auth'd and public routes
- Uses a system identity (`orgId: "system"`) for downstream service calls (runs-service, email-gateway) since these headers are only used for logging

## Test plan
- [x] 9 new integration tests for public endpoints (no-auth access, no-dag response, system identity, groupBy, 404s)
- [x] All 417 existing tests pass — refactor is backwards-compatible
- [x] OpenAPI spec regenerated with new `/public/` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)