### PR TITLE
feat: brandId filter + groupBy=brand + by=brand

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1205,9 +1205,10 @@
       "RankedWorkflowGroupBy": {
         "type": "string",
         "enum": [
-          "section"
+          "section",
+          "brand"
         ],
-        "description": "Group results by section. When omitted, returns a flat ranked list."
+        "description": "Group results by section or brand. When omitted, returns a flat ranked list."
       },
       "BestWorkflowRecord": {
         "type": "object",
@@ -1267,6 +1268,15 @@
           "bestCostPerOpen",
           "bestCostPerReply"
         ]
+      },
+      "BestWorkflowBy": {
+        "type": "string",
+        "enum": [
+          "workflow",
+          "brand"
+        ],
+        "default": "workflow",
+        "description": "Granularity: best workflow or best brand. Defaults to 'workflow'."
       },
       "PublicRankedWorkflowItem": {
         "type": "object",
@@ -2938,7 +2948,7 @@
     "/workflows/ranked": {
       "get": {
         "summary": "Get workflows ranked by cost-per-outcome",
-        "description": "Returns workflows ranked by lowest cost-per-reply or cost-per-click for the given dimensions. Stats are aggregated across the full upgrade chain (deprecated predecessors included). Use `groupBy=section` to group results by category-channel-audienceType with aggregated section stats. Workflows with no completed runs are included with zeroed stats.",
+        "description": "Returns workflows ranked by lowest cost-per-reply or cost-per-click for the given dimensions. Stats are aggregated across the full upgrade chain (deprecated predecessors included). Use `groupBy=section` to group by category-channel-audienceType, or `groupBy=brand` to group by brandId. When groupBy=brand, workflows without a brandId are excluded. Workflows with no completed runs are included with zeroed stats.",
         "tags": [
           "Workflows"
         ],
@@ -2956,6 +2966,16 @@
             "required": false,
             "description": "Organization ID. When omitted, searches across all orgs.",
             "name": "orgId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter workflows by brand ID."
+            },
+            "required": false,
+            "description": "Filter workflows by brand ID.",
+            "name": "brandId",
             "in": "query"
           },
           {
@@ -3021,10 +3041,10 @@
               "minimum": 1,
               "maximum": 100,
               "default": 10,
-              "description": "Max workflows per section (when groupBy=section) or total (when flat). Defaults to 10."
+              "description": "Max workflows per group (when groupBy is set) or total (when flat). Defaults to 10."
             },
             "required": false,
-            "description": "Max workflows per section (when groupBy=section) or total (when flat). Defaults to 10.",
+            "description": "Max workflows per group (when groupBy is set) or total (when flat). Defaults to 10.",
             "name": "limit",
             "in": "query"
           },
@@ -3033,7 +3053,7 @@
               "$ref": "#/components/schemas/RankedWorkflowGroupBy"
             },
             "required": false,
-            "description": "Group results by section. When omitted, returns a flat ranked list.",
+            "description": "Group results by section or brand. When omitted, returns a flat ranked list.",
             "name": "groupBy",
             "in": "query"
           },
@@ -3100,7 +3120,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ranked workflows (flat list or grouped by section)",
+            "description": "Ranked workflows (flat list or grouped by section/brand)",
             "content": {
               "application/json": {
                 "schema": {
@@ -3145,7 +3165,7 @@
     "/workflows/best": {
       "get": {
         "summary": "Get hero records — best cost-per-open and best cost-per-reply",
-        "description": "Returns the single best workflow for cost-per-open and cost-per-reply across all active workflows. Stats are aggregated across the full upgrade chain. Use this for leaderboard hero/headline stats.",
+        "description": "Returns the single best workflow (or brand) for cost-per-open and cost-per-reply across all active workflows. Stats are aggregated across the full upgrade chain. Use `by=brand` to find the best brand instead of the best individual workflow. Use this for leaderboard hero/headline stats.",
         "tags": [
           "Workflows"
         ],
@@ -3163,6 +3183,25 @@
             "required": false,
             "description": "Organization ID. When omitted, searches across all orgs.",
             "name": "orgId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter workflows by brand ID."
+            },
+            "required": false,
+            "description": "Filter workflows by brand ID.",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/BestWorkflowBy"
+            },
+            "required": false,
+            "description": "Granularity: best workflow or best brand. Defaults to 'workflow'.",
+            "name": "by",
             "in": "query"
           },
           {
@@ -3280,6 +3319,16 @@
           },
           {
             "schema": {
+              "type": "string",
+              "description": "Filter workflows by brand ID."
+            },
+            "required": false,
+            "description": "Filter workflows by brand ID.",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
               "allOf": [
                 {
                   "$ref": "#/components/schemas/WorkflowCategory"
@@ -3341,10 +3390,10 @@
               "minimum": 1,
               "maximum": 100,
               "default": 10,
-              "description": "Max workflows per section (when groupBy=section) or total (when flat). Defaults to 10."
+              "description": "Max workflows per group (when groupBy is set) or total (when flat). Defaults to 10."
             },
             "required": false,
-            "description": "Max workflows per section (when groupBy=section) or total (when flat). Defaults to 10.",
+            "description": "Max workflows per group (when groupBy is set) or total (when flat). Defaults to 10.",
             "name": "limit",
             "in": "query"
           },
@@ -3353,7 +3402,7 @@
               "$ref": "#/components/schemas/RankedWorkflowGroupBy"
             },
             "required": false,
-            "description": "Group results by section. When omitted, returns a flat ranked list.",
+            "description": "Group results by section or brand. When omitted, returns a flat ranked list.",
             "name": "groupBy",
             "in": "query"
           }
@@ -3418,6 +3467,25 @@
             "required": false,
             "description": "Organization ID. When omitted, searches across all orgs.",
             "name": "orgId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter workflows by brand ID."
+            },
+            "required": false,
+            "description": "Filter workflows by brand ID.",
+            "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/BestWorkflowBy"
+            },
+            "required": false,
+            "description": "Granularity: best workflow or best brand. Defaults to 'workflow'.",
+            "name": "by",
             "in": "query"
           }
         ],

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -623,7 +623,7 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
       res.status(400).json({ error: "Validation error", details: query.error });
       return;
     }
-    const { orgId, category, channel, audienceType, objective, limit, groupBy } = query.data;
+    const { orgId, brandId, category, channel, audienceType, objective, limit, groupBy } = query.data;
     const identity = {
       orgId: res.locals.orgId as string,
       userId: res.locals.userId as string,
@@ -632,6 +632,7 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
+    if (brandId) conditions.push(eq(workflows.brandId, brandId));
     if (category) conditions.push(eq(workflows.category, category));
     if (channel) conditions.push(eq(workflows.channel, channel));
     if (audienceType) conditions.push(eq(workflows.audienceType, audienceType));
@@ -674,6 +675,23 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
       });
 
       res.json({ sections });
+    } else if (groupBy === "brand") {
+      // Group by brandId — exclude workflows without a brandId
+      const brandMap = new Map<string, WorkflowScore[]>();
+      for (const score of scores) {
+        if (!score.workflow.brandId) continue;
+        const arr = brandMap.get(score.workflow.brandId) ?? [];
+        arr.push(score);
+        brandMap.set(score.workflow.brandId, arr);
+      }
+
+      const brands = [...brandMap.entries()].map(([bId, brandScores]) => ({
+        brandId: bId,
+        stats: aggregateSectionStats(brandScores),
+        workflows: rankScores(brandScores).slice(0, limit).map(formatScoreItem),
+      }));
+
+      res.json({ brands });
     } else {
       const ranked = rankScores(scores).slice(0, limit);
       res.json({ results: ranked.map(formatScoreItem) });
@@ -694,7 +712,7 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
       res.status(400).json({ error: "Validation error", details: query.error });
       return;
     }
-    const { orgId } = query.data;
+    const { orgId, brandId, by } = query.data;
     const identity = {
       orgId: res.locals.orgId as string,
       userId: res.locals.userId as string,
@@ -703,6 +721,7 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
+    if (brandId) conditions.push(eq(workflows.brandId, brandId));
 
     const allMatchingWorkflows = conditions.length > 0
       ? await db.select().from(workflows).where(and(...conditions))
@@ -719,44 +738,89 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
     // Use "replies" as objective — we compute both cost-per-open and cost-per-reply from email stats
     const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, "replies", identity);
 
-    let bestCostPerOpen: { score: WorkflowScore; value: number } | null = null;
-    let bestCostPerReply: { score: WorkflowScore; value: number } | null = null;
+    if (by === "brand") {
+      // Aggregate scores by brandId, find the best brand for cost-per-open and cost-per-reply
+      const brandMap = new Map<string, WorkflowScore[]>();
+      for (const s of scores) {
+        if (!s.workflow.brandId) continue;
+        const arr = brandMap.get(s.workflow.brandId) ?? [];
+        arr.push(s);
+        brandMap.set(s.workflow.brandId, arr);
+      }
 
-    for (const s of scores) {
-      if (s.completedRuns === 0) continue;
+      let bestCostPerOpen: { brandId: string; workflowCount: number; value: number } | null = null;
+      let bestCostPerReply: { brandId: string; workflowCount: number; value: number } | null = null;
 
-      const totalOpened = s.emailStats.transactional.opened + s.emailStats.broadcast.opened;
-      if (totalOpened > 0) {
-        const costPerOpen = s.totalCost / totalOpened;
-        if (!bestCostPerOpen || costPerOpen < bestCostPerOpen.value) {
-          bestCostPerOpen = { score: s, value: costPerOpen };
+      for (const [bId, brandScores] of brandMap) {
+        const totalCost = brandScores.reduce((s, e) => s + e.totalCost, 0);
+        const hasRuns = brandScores.some((s) => s.completedRuns > 0);
+        if (!hasRuns) continue;
+
+        const totalOpened = brandScores.reduce(
+          (s, e) => s + e.emailStats.transactional.opened + e.emailStats.broadcast.opened,
+          0,
+        );
+        if (totalOpened > 0) {
+          const costPerOpen = totalCost / totalOpened;
+          if (!bestCostPerOpen || costPerOpen < bestCostPerOpen.value) {
+            bestCostPerOpen = { brandId: bId, workflowCount: brandScores.length, value: Math.round(costPerOpen * 100) / 100 };
+          }
+        }
+
+        const totalReplied = brandScores.reduce(
+          (s, e) => s + e.emailStats.transactional.replied + e.emailStats.broadcast.replied,
+          0,
+        );
+        if (totalReplied > 0) {
+          const costPerReply = totalCost / totalReplied;
+          if (!bestCostPerReply || costPerReply < bestCostPerReply.value) {
+            bestCostPerReply = { brandId: bId, workflowCount: brandScores.length, value: Math.round(costPerReply * 100) / 100 };
+          }
         }
       }
 
-      const totalReplied = s.emailStats.transactional.replied + s.emailStats.broadcast.replied;
-      if (totalReplied > 0) {
-        const costPerReply = s.totalCost / totalReplied;
-        if (!bestCostPerReply || costPerReply < bestCostPerReply.value) {
-          bestCostPerReply = { score: s, value: costPerReply };
+      res.json({ bestCostPerOpen, bestCostPerReply });
+    } else {
+      // by=workflow (default) — existing behavior
+      let bestCostPerOpen: { score: WorkflowScore; value: number } | null = null;
+      let bestCostPerReply: { score: WorkflowScore; value: number } | null = null;
+
+      for (const s of scores) {
+        if (s.completedRuns === 0) continue;
+
+        const totalOpened = s.emailStats.transactional.opened + s.emailStats.broadcast.opened;
+        if (totalOpened > 0) {
+          const costPerOpen = s.totalCost / totalOpened;
+          if (!bestCostPerOpen || costPerOpen < bestCostPerOpen.value) {
+            bestCostPerOpen = { score: s, value: costPerOpen };
+          }
+        }
+
+        const totalReplied = s.emailStats.transactional.replied + s.emailStats.broadcast.replied;
+        if (totalReplied > 0) {
+          const costPerReply = s.totalCost / totalReplied;
+          if (!bestCostPerReply || costPerReply < bestCostPerReply.value) {
+            bestCostPerReply = { score: s, value: costPerReply };
+          }
         }
       }
-    }
 
-    function formatRecord(entry: { score: WorkflowScore; value: number } | null) {
-      if (!entry) return null;
-      return {
-        workflowId: entry.score.workflow.id,
-        workflowName: entry.score.workflow.name,
-        displayName: entry.score.workflow.displayName,
-        brandId: entry.score.workflow.brandId,
-        value: Math.round(entry.value * 100) / 100,
-      };
-    }
+      function formatRecord(entry: { score: WorkflowScore; value: number } | null) {
+        if (!entry) return null;
+        return {
+          workflowId: entry.score.workflow.id,
+          workflowName: entry.score.workflow.name,
+          displayName: entry.score.workflow.displayName,
+          brandId: entry.score.workflow.brandId,
+          value: Math.round(entry.value * 100) / 100,
+        };
+      }
 
-    res.json({
-      bestCostPerOpen: formatRecord(bestCostPerOpen),
-      bestCostPerReply: formatRecord(bestCostPerReply),
-    });
+      res.json({
+        bestCostPerOpen: formatRecord(bestCostPerOpen),
+        bestCostPerReply: formatRecord(bestCostPerReply),
+      });
+    }
   } catch (err: unknown) {
     if (!handleExternalServiceError(err, res, "best")) {
       console.error("[workflow-service] GET best error:", err);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -425,21 +425,24 @@ export const RankedWorkflowObjectiveSchema = z
   .openapi("RankedWorkflowObjective");
 
 export const RankedWorkflowGroupBySchema = z
-  .enum(["section"])
+  .enum(["section", "brand"])
   .describe(
-    'Group results by section (category-channel-audienceType). Each section includes aggregated stats and its workflows ranked within.'
+    'Group results by section (category-channel-audienceType) or brand (brandId). ' +
+    'Each group includes aggregated stats and its workflows ranked within. ' +
+    'When groupBy=brand, workflows without a brandId are excluded.'
   )
   .openapi("RankedWorkflowGroupBy");
 
 export const RankedWorkflowQuerySchema = z
   .object({
     orgId: z.string().optional().describe("Organization ID. When omitted, searches across all orgs."),
+    brandId: z.string().optional().describe("Filter workflows by brand ID."),
     category: WorkflowCategorySchema.optional().describe("Filter workflows by category."),
     channel: WorkflowChannelSchema.optional().describe("Filter workflows by channel."),
     audienceType: WorkflowAudienceTypeSchema.optional().describe("Filter workflows by audience type."),
     objective: RankedWorkflowObjectiveSchema.default("replies").describe("Which metric to optimize for. Defaults to 'replies'."),
-    limit: z.coerce.number().int().min(1).max(100).default(10).describe("Max workflows per section (when groupBy=section) or total (when flat). Defaults to 10."),
-    groupBy: RankedWorkflowGroupBySchema.optional().describe("Group results by section. When omitted, returns a flat ranked list."),
+    limit: z.coerce.number().int().min(1).max(100).default(10).describe("Max workflows per group (when groupBy is set) or total (when flat). Defaults to 10."),
+    groupBy: RankedWorkflowGroupBySchema.optional().describe("Group results by section or brand. When omitted, returns a flat ranked list."),
   })
   .openapi("RankedWorkflowQuery");
 
@@ -468,9 +471,18 @@ export const RankedWorkflowResponseSchema = z
   })
   .openapi("RankedWorkflowResponse");
 
+export const RankedBrandGroupSchema = z
+  .object({
+    brandId: z.string().describe("Brand ID."),
+    stats: WorkflowStatsSchema.describe("Aggregated stats across all workflows for this brand."),
+    workflows: z.array(RankedWorkflowItemSchema).describe("Workflows for this brand, ranked by performance."),
+  })
+  .openapi("RankedBrandGroup");
+
 export const RankedWorkflowGroupedResponseSchema = z
   .object({
-    sections: z.array(RankedSectionSchema).describe("Workflow sections grouped by category-channel-audienceType."),
+    sections: z.array(RankedSectionSchema).optional().describe("Workflow sections grouped by category-channel-audienceType."),
+    brands: z.array(RankedBrandGroupSchema).optional().describe("Workflow groups by brand ID."),
   })
   .openapi("RankedWorkflowGroupedResponse");
 
@@ -502,9 +514,19 @@ export const PublicRankedWorkflowResponseSchema = z
 
 // --- Best Workflow schemas (hero records) ---
 
+export const BestWorkflowBySchema = z
+  .enum(["workflow", "brand"])
+  .describe(
+    'Granularity for best records. "workflow" (default) finds the best individual workflow. ' +
+    '"brand" aggregates all workflows per brand and finds the best brand.'
+  )
+  .openapi("BestWorkflowBy");
+
 export const BestWorkflowQuerySchema = z
   .object({
     orgId: z.string().optional().describe("Organization ID. When omitted, searches across all orgs."),
+    brandId: z.string().optional().describe("Filter workflows by brand ID."),
+    by: BestWorkflowBySchema.default("workflow").describe("Granularity: best workflow or best brand. Defaults to 'workflow'."),
   })
   .openapi("BestWorkflowQuery");
 
@@ -518,12 +540,27 @@ export const BestWorkflowRecordSchema = z
   })
   .openapi("BestWorkflowRecord");
 
+export const BestBrandRecordSchema = z
+  .object({
+    brandId: z.string().describe("Brand ID holding the record."),
+    workflowCount: z.number().int().describe("Number of workflows aggregated for this brand."),
+    value: z.number().describe("The record value in USD cents."),
+  })
+  .openapi("BestBrandRecord");
+
 export const BestWorkflowResponseSchema = z
   .object({
     bestCostPerOpen: BestWorkflowRecordSchema.nullable().describe("Workflow with the lowest cost per email open. Null if no data."),
     bestCostPerReply: BestWorkflowRecordSchema.nullable().describe("Workflow with the lowest cost per reply. Null if no data."),
   })
   .openapi("BestWorkflowResponse");
+
+export const BestBrandResponseSchema = z
+  .object({
+    bestCostPerOpen: BestBrandRecordSchema.nullable().describe("Brand with the lowest cost per email open. Null if no data."),
+    bestCostPerReply: BestBrandRecordSchema.nullable().describe("Brand with the lowest cost per reply. Null if no data."),
+  })
+  .openapi("BestBrandResponse");
 
 // --- Provider Requirements schemas ---
 
@@ -1009,7 +1046,8 @@ registry.registerPath({
   description:
     "Returns workflows ranked by lowest cost-per-reply or cost-per-click for the given dimensions. " +
     "Stats are aggregated across the full upgrade chain (deprecated predecessors included). " +
-    "Use `groupBy=section` to group results by category-channel-audienceType with aggregated section stats. " +
+    "Use `groupBy=section` to group by category-channel-audienceType, or `groupBy=brand` to group by brandId. " +
+    "When groupBy=brand, workflows without a brandId are excluded. " +
     "Workflows with no completed runs are included with zeroed stats.",
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
@@ -1019,7 +1057,7 @@ registry.registerPath({
   },
   responses: {
     200: {
-      description: "Ranked workflows (flat list or grouped by section)",
+      description: "Ranked workflows (flat list or grouped by section/brand)",
       content: {
         "application/json": { schema: RankedWorkflowResponseSchema },
       },
@@ -1044,8 +1082,9 @@ registry.registerPath({
   path: "/workflows/best",
   summary: "Get hero records — best cost-per-open and best cost-per-reply",
   description:
-    "Returns the single best workflow for cost-per-open and cost-per-reply across all active workflows. " +
+    "Returns the single best workflow (or brand) for cost-per-open and cost-per-reply across all active workflows. " +
     "Stats are aggregated across the full upgrade chain. " +
+    "Use `by=brand` to find the best brand instead of the best individual workflow. " +
     "Use this for leaderboard hero/headline stats.",
   tags: ["Workflows"],
   security: [{ apiKey: [] }],

--- a/tests/integration/best-workflow.test.ts
+++ b/tests/integration/best-workflow.test.ts
@@ -428,6 +428,98 @@ describe("GET /workflows/ranked", () => {
     expect(res.body.results).toHaveLength(2);
   });
 
+  it("filters by brandId", async () => {
+    // Note: the mock DB returns all rows regardless of .where(), so both workflows appear.
+    // This test verifies that brandId is accepted as a query param without error.
+    const wfBrand = makeWorkflow({ id: "wf-brand", brandId: "brand-1" });
+    mockWorkflowRows.push(wfBrand);
+    mockWorkflowRunRows.push(makeRun("wf-brand", "ext-run-brand"));
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-brand", totalCostInUsdCents: 100 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS, replied: 5 },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    const res = await request
+      .get("/workflows/ranked")
+      .query({ ...BASE_QUERY, brandId: "brand-1" })
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(1);
+    expect(res.body.results[0].workflow.brandId).toBe("brand-1");
+  });
+
+  it("returns grouped brands with groupBy=brand", async () => {
+    const wf1 = makeWorkflow({ id: "wf-b1a", brandId: "brand-A" });
+    const wf2 = makeWorkflow({ id: "wf-b1b", brandId: "brand-A" });
+    const wf3 = makeWorkflow({ id: "wf-b2", brandId: "brand-B" });
+    mockWorkflowRows.push(wf1, wf2, wf3);
+    mockWorkflowRunRows.push(
+      makeRun("wf-b1a", "ext-run-1"),
+      makeRun("wf-b1b", "ext-run-2"),
+      makeRun("wf-b2", "ext-run-3"),
+    );
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-1", totalCostInUsdCents: 100 },
+      { runId: "ext-run-2", totalCostInUsdCents: 200 },
+      { runId: "ext-run-3", totalCostInUsdCents: 50 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS, replied: 5 },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    const res = await request
+      .get("/workflows/ranked")
+      .query({ ...BASE_QUERY, groupBy: "brand" })
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.brands).toBeDefined();
+    expect(res.body.brands).toHaveLength(2);
+
+    const brandA = res.body.brands.find((b: { brandId: string }) => b.brandId === "brand-A");
+    const brandB = res.body.brands.find((b: { brandId: string }) => b.brandId === "brand-B");
+    expect(brandA).toBeDefined();
+    expect(brandA.workflows).toHaveLength(2);
+    expect(brandA.stats).toBeDefined();
+    expect(brandB).toBeDefined();
+    expect(brandB.workflows).toHaveLength(1);
+  });
+
+  it("excludes workflows without brandId when groupBy=brand", async () => {
+    const wfBranded = makeWorkflow({ id: "wf-branded", brandId: "brand-X" });
+    const wfNoBrand = makeWorkflow({ id: "wf-no-brand", brandId: null });
+    mockWorkflowRows.push(wfBranded, wfNoBrand);
+    mockWorkflowRunRows.push(
+      makeRun("wf-branded", "ext-run-1"),
+      makeRun("wf-no-brand", "ext-run-2"),
+    );
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-1", totalCostInUsdCents: 100 },
+      { runId: "ext-run-2", totalCostInUsdCents: 200 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS, replied: 5 },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    const res = await request
+      .get("/workflows/ranked")
+      .query({ ...BASE_QUERY, groupBy: "brand" })
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.brands).toHaveLength(1);
+    expect(res.body.brands[0].brandId).toBe("brand-X");
+  });
+
   it("returns grouped sections with groupBy=section", async () => {
     const wfSales = makeWorkflow({ id: "wf-sales", category: "sales", channel: "email", audienceType: "cold-outreach" });
     const wfSales2 = makeWorkflow({ id: "wf-sales2", category: "sales", channel: "email", audienceType: "cold-outreach" });
@@ -560,6 +652,97 @@ describe("GET /workflows/best (hero records)", () => {
     expect(res.status).toBe(200);
     expect(res.body.bestCostPerOpen.displayName).toBe("sales-email-cold-outreach-jasmine");
     expect(res.body.bestCostPerReply.displayName).toBe("sales-email-cold-outreach-jasmine");
+  });
+
+  it("filters by brandId", async () => {
+    const wf1 = makeWorkflow({ id: "wf-b1", brandId: "brand-target" });
+    const wf2 = makeWorkflow({ id: "wf-b2", brandId: "brand-other" });
+    mockWorkflowRows.push(wf1, wf2);
+    mockWorkflowRunRows.push(
+      makeRun("wf-b1", "ext-run-b1"),
+      makeRun("wf-b2", "ext-run-b2"),
+    );
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-b1", totalCostInUsdCents: 100 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    const res = await request
+      .get("/workflows/best")
+      .query({ brandId: "brand-target" })
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.bestCostPerOpen.brandId).toBe("brand-target");
+  });
+
+  it("returns best brand with by=brand", async () => {
+    // Two brands: brand-A (2 workflows) and brand-B (1 workflow)
+    // The mock DB returns all runs for all workflows — each workflow sees all 3 run IDs.
+    // fetchRunCosts returns costs for all runs, so each workflow gets totalCost = 600.
+    // We use mockFetchEmailStats per-workflow to differentiate brands.
+    const wfA1 = makeWorkflow({ id: "wf-a1", brandId: "brand-A" });
+    const wfA2 = makeWorkflow({ id: "wf-a2", brandId: "brand-A" });
+    const wfB = makeWorkflow({ id: "wf-b", brandId: "brand-B" });
+    mockWorkflowRows.push(wfA1, wfA2, wfB);
+    mockWorkflowRunRows.push(
+      makeRun("wf-a1", "ext-run-a1"),
+      makeRun("wf-a2", "ext-run-a2"),
+      makeRun("wf-b", "ext-run-b"),
+    );
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-a1", totalCostInUsdCents: 50 },
+      { runId: "ext-run-a2", totalCostInUsdCents: 50 },
+      { runId: "ext-run-b", totalCostInUsdCents: 500 },
+    ]);
+    // Each workflow sees all 3 runs → totalCost per workflow = 600
+    // brand-A: 2 workflows × 600 = 1200 cost, 40 opens, 20 replies → 30/open, 60/reply
+    // brand-B: 1 workflow × 600 = 600 cost, 5 opens, 2 replies → 120/open, 300/reply
+    mockFetchEmailStats
+      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 20, replied: 10 }, broadcast: { ...EMPTY_STATS } })
+      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 20, replied: 10 }, broadcast: { ...EMPTY_STATS } })
+      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 5, replied: 2 }, broadcast: { ...EMPTY_STATS } });
+
+    const res = await request
+      .get("/workflows/best")
+      .query({ by: "brand" })
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    // brand-A wins with lower cost-per-open (30 vs 120) and cost-per-reply (60 vs 300)
+    expect(res.body.bestCostPerOpen.brandId).toBe("brand-A");
+    expect(res.body.bestCostPerOpen.workflowCount).toBe(2);
+    expect(res.body.bestCostPerOpen.value).toBe(30); // 1200 / 40
+    expect(res.body.bestCostPerReply.brandId).toBe("brand-A");
+    expect(res.body.bestCostPerReply.value).toBe(60); // 1200 / 20
+  });
+
+  it("returns null for by=brand when no branded workflows have outcomes", async () => {
+    const wf = makeWorkflow({ id: "wf-no-brand", brandId: null });
+    mockWorkflowRows.push(wf);
+    mockWorkflowRunRows.push(makeRun("wf-no-brand", "ext-run-nb"));
+
+    mockFetchRunCosts.mockResolvedValue([
+      { runId: "ext-run-nb", totalCostInUsdCents: 100 },
+    ]);
+    mockFetchEmailStats.mockResolvedValue({
+      transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
+      broadcast: { ...EMPTY_STATS },
+    });
+
+    const res = await request
+      .get("/workflows/best")
+      .query({ by: "brand" })
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.bestCostPerOpen).toBeNull();
+    expect(res.body.bestCostPerReply).toBeNull();
   });
 
   it("picks the best from multiple workflows", async () => {


### PR DESCRIPTION
## Summary
- Adds `brandId` as a query filter on `GET /workflows/ranked` and `GET /workflows/best`
- Adds `groupBy=brand` on `/workflows/ranked` — groups stats by brandId (excludes workflows without brandId)
- Adds `by=brand` on `/workflows/best` — finds the best brand (aggregated across all its workflows) instead of the best individual workflow
- New response schemas: `RankedBrandGroup`, `BestBrandRecord`, `BestBrandResponse`

## Test plan
- [x] brandId filter accepted on /ranked (1 test)
- [x] groupBy=brand returns grouped brands with stats (1 test)
- [x] groupBy=brand excludes workflows without brandId (1 test)
- [x] brandId filter accepted on /best (1 test)
- [x] by=brand returns best brand with workflowCount (1 test)
- [x] by=brand returns null when no branded workflows have outcomes (1 test)
- [x] All 414 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)