### PR TITLE
fix: public endpoints use public downstream APIs

### DIFF
--- a/src/lib/stats-client.ts
+++ b/src/lib/stats-client.ts
@@ -86,6 +86,52 @@ export async function fetchRunCosts(runIds: string[], identity: IdentityHeaders)
   return costs;
 }
 
+// --- Public: fetch aggregated costs from runs-service (no identity) ---
+
+export interface WorkflowNameCost {
+  workflowName: string;
+  totalCostInUsdCents: number;
+  runCount: number;
+}
+
+export async function fetchRunCostsPublic(filters?: {
+  brandId?: string;
+  orgId?: string;
+}): Promise<WorkflowNameCost[]> {
+  const { baseUrl, apiKey } = getRunsServiceConfig();
+  const params = new URLSearchParams({ groupBy: "workflowName" });
+  if (filters?.brandId) params.set("brandId", filters.brandId);
+  if (filters?.orgId) params.set("orgId", filters.orgId);
+
+  const res = await fetch(`${baseUrl}/v1/stats/public/costs?${params}`, {
+    method: "GET",
+    headers: { "x-api-key": apiKey },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `runs-service error: GET /v1/stats/public/costs -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  const body = (await res.json()) as {
+    groups: Array<{
+      dimensions: Record<string, string | null>;
+      totalCostInUsdCents: string;
+      runCount: number;
+    }>;
+  };
+
+  return body.groups
+    .filter((g) => g.dimensions.workflowName != null)
+    .map((g) => ({
+      workflowName: g.dimensions.workflowName!,
+      totalCostInUsdCents: Number(g.totalCostInUsdCents) || 0,
+      runCount: g.runCount,
+    }));
+}
+
 // --- Fetch email stats from email-gateway-service ---
 
 const EMPTY_STATS: EmailStats = {
@@ -125,6 +171,35 @@ export async function fetchEmailStats(
     const text = await res.text().catch(() => "");
     throw new Error(
       `email-gateway-service error: POST /stats -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  return res.json() as Promise<EmailStatsResponse>;
+}
+
+// --- Public: fetch email stats (no identity) ---
+
+export async function fetchEmailStatsPublic(
+  runIds: string[],
+): Promise<EmailStatsResponse> {
+  if (runIds.length === 0) {
+    return { transactional: { ...EMPTY_STATS }, broadcast: { ...EMPTY_STATS } };
+  }
+
+  const { baseUrl, apiKey } = getEmailGatewayConfig();
+
+  const res = await fetch(
+    `${baseUrl}/stats/public?runIds=${runIds.join(",")}`,
+    {
+      method: "GET",
+      headers: { "x-api-key": apiKey },
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `email-gateway-service error: GET /stats/public -> ${res.status} ${res.statusText}: ${text}`
     );
   }
 

--- a/src/lib/workflow-scoring.ts
+++ b/src/lib/workflow-scoring.ts
@@ -1,7 +1,7 @@
 import { eq, and, inArray } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { workflows, workflowRuns } from "../db/schema.js";
-import { fetchRunCosts, fetchEmailStats } from "./stats-client.js";
+import { fetchRunCosts, fetchEmailStats, fetchRunCostsPublic, fetchEmailStatsPublic } from "./stats-client.js";
 import type { IdentityHeaders } from "./key-service-client.js";
 
 export const EMPTY_EMAIL_STATS = {
@@ -49,18 +49,27 @@ export function getUpgradeChainIds(
   return chainIds;
 }
 
+type ScoreMode =
+  | { kind: "auth"; identity: IdentityHeaders }
+  | { kind: "public"; brandId?: string; orgId?: string };
+
 export async function computeWorkflowScores(
   activeWorkflows: (typeof workflows.$inferSelect)[],
-  deprecatedWorkflows: { id: string; upgradedTo: string | null }[],
+  deprecatedWorkflows: (typeof workflows.$inferSelect)[],
   objective: "replies" | "clicks",
-  identity: IdentityHeaders,
+  mode: ScoreMode,
 ): Promise<WorkflowScore[]> {
   // 1. For each active workflow, get completed runs across entire upgrade chain
   const workflowRunsByWfId: Record<string, string[]> = {};
+  const chainWorkflowsById: Record<string, (typeof workflows.$inferSelect)[]> = {};
   const allRunIds: string[] = [];
 
   for (const wf of activeWorkflows) {
     const chainIds = getUpgradeChainIds(wf.id, deprecatedWorkflows);
+    chainWorkflowsById[wf.id] = [
+      wf,
+      ...deprecatedWorkflows.filter((d) => chainIds.includes(d.id) && d.id !== wf.id),
+    ];
 
     const runs = chainIds.length === 1
       ? await db
@@ -90,12 +99,34 @@ export async function computeWorkflowScores(
     allRunIds.push(...runIds);
   }
 
-  // 2. Batch fetch costs from runs-service (only if there are runs)
+  // 2. Fetch costs (different strategy per mode)
   const costByRunId = new Map<string, number>();
+  const costByWorkflowId = new Map<string, number>();
+
   if (allRunIds.length > 0) {
-    const runCosts = await fetchRunCosts(allRunIds, identity);
-    for (const c of runCosts) {
-      costByRunId.set(c.runId, c.totalCostInUsdCents);
+    if (mode.kind === "auth") {
+      const runCosts = await fetchRunCosts(allRunIds, mode.identity);
+      for (const c of runCosts) {
+        costByRunId.set(c.runId, c.totalCostInUsdCents);
+      }
+    } else {
+      // Public: fetch costs aggregated by workflowName from runs-service
+      const costGroups = await fetchRunCostsPublic({
+        brandId: mode.brandId,
+        orgId: mode.orgId,
+      });
+      const costByName = new Map(costGroups.map((g) => [g.workflowName, g.totalCostInUsdCents]));
+
+      // Map aggregated costs to each active workflow via its upgrade chain names
+      for (const wf of activeWorkflows) {
+        const chainWfs = chainWorkflowsById[wf.id] ?? [];
+        const chainNames = new Set(chainWfs.map((w) => w.name));
+        let total = 0;
+        for (const name of chainNames) {
+          total += costByName.get(name) ?? 0;
+        }
+        costByWorkflowId.set(wf.id, total);
+      }
     }
   }
 
@@ -117,12 +148,14 @@ export async function computeWorkflowScores(
       continue;
     }
 
-    const totalCost = runIds.reduce(
-      (sum, id) => sum + (costByRunId.get(id) ?? 0),
-      0
-    );
+    const totalCost = mode.kind === "auth"
+      ? runIds.reduce((sum, id) => sum + (costByRunId.get(id) ?? 0), 0)
+      : costByWorkflowId.get(wf.id) ?? 0;
 
-    const stats = await fetchEmailStats(runIds, identity);
+    const stats = mode.kind === "auth"
+      ? await fetchEmailStats(runIds, mode.identity)
+      : await fetchEmailStatsPublic(runIds);
+
     const outcomes =
       objective === "replies"
         ? (stats.transactional?.replied ?? 0) + (stats.broadcast?.replied ?? 0)
@@ -236,9 +269,3 @@ export function handleExternalServiceError(err: unknown, res: import("express").
   return false;
 }
 
-/** System identity for public endpoints — used only for logging by downstream services */
-export const SYSTEM_IDENTITY = {
-  orgId: "system",
-  userId: "system",
-  runId: "system-public",
-};

--- a/src/routes/public-workflows.ts
+++ b/src/routes/public-workflows.ts
@@ -12,7 +12,6 @@ import {
   formatPublicScoreItem,
   aggregateSectionStats,
   handleExternalServiceError,
-  SYSTEM_IDENTITY,
   type WorkflowScore,
 } from "../lib/workflow-scoring.js";
 
@@ -47,7 +46,7 @@ router.get("/public/workflows/ranked", async (req, res) => {
       return;
     }
 
-    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, objective, SYSTEM_IDENTITY);
+    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, objective, { kind: "public" as const, brandId, orgId });
 
     if (groupBy === "section") {
       const sectionMap = new Map<string, WorkflowScore[]>();
@@ -127,7 +126,7 @@ router.get("/public/workflows/best", async (req, res) => {
       return;
     }
 
-    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, "replies", SYSTEM_IDENTITY);
+    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, "replies", { kind: "public" as const, brandId, orgId });
 
     if (by === "brand") {
       // Aggregate scores by brandId, find the best brand for cost-per-open and cost-per-reply

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -649,7 +649,7 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
       return;
     }
 
-    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, objective, identity);
+    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, objective, { kind: "auth", identity });
 
     if (groupBy === "section") {
       // Group by sectionKey = category-channel-audienceType
@@ -736,7 +736,7 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
     }
 
     // Use "replies" as objective — we compute both cost-per-open and cost-per-reply from email stats
-    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, "replies", identity);
+    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, "replies", { kind: "auth", identity });
 
     if (by === "brand") {
       // Aggregate scores by brandId, find the best brand for cost-per-open and cost-per-reply

--- a/tests/integration/public-workflows.test.ts
+++ b/tests/integration/public-workflows.test.ts
@@ -58,10 +58,14 @@ vi.mock("../../src/db/index.js", () => ({
 // --- Mock stats-client ---
 const mockFetchRunCosts = vi.fn();
 const mockFetchEmailStats = vi.fn();
+const mockFetchRunCostsPublic = vi.fn();
+const mockFetchEmailStatsPublic = vi.fn();
 
 vi.mock("../../src/lib/stats-client.js", () => ({
   fetchRunCosts: (...args: unknown[]) => mockFetchRunCosts(...args),
   fetchEmailStats: (...args: unknown[]) => mockFetchEmailStats(...args),
+  fetchRunCostsPublic: (...args: unknown[]) => mockFetchRunCostsPublic(...args),
+  fetchEmailStatsPublic: (...args: unknown[]) => mockFetchEmailStatsPublic(...args),
 }));
 
 // --- Mock Windmill ---
@@ -145,6 +149,8 @@ describe("GET /public/workflows/ranked", () => {
     mockWorkflowRunRows.length = 0;
     mockFetchRunCosts.mockReset();
     mockFetchEmailStats.mockReset();
+    mockFetchRunCostsPublic.mockReset();
+    mockFetchEmailStatsPublic.mockReset();
   });
 
   it("returns ranked workflows without auth headers", async () => {
@@ -152,10 +158,10 @@ describe("GET /public/workflows/ranked", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-pub", "ext-run-1"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 100 },
+    mockFetchRunCostsPublic.mockResolvedValue([
+      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 100, runCount: 1 },
     ]);
-    mockFetchEmailStats.mockResolvedValue({
+    mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, replied: 10 },
       broadcast: { ...EMPTY_STATS },
     });
@@ -176,10 +182,10 @@ describe("GET /public/workflows/ranked", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-nodag", "ext-run-1"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 50 },
+    mockFetchRunCostsPublic.mockResolvedValue([
+      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 50, runCount: 1 },
     ]);
-    mockFetchEmailStats.mockResolvedValue({
+    mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, replied: 5 },
       broadcast: { ...EMPTY_STATS },
     });
@@ -192,15 +198,13 @@ describe("GET /public/workflows/ranked", () => {
     expect(res.body.results[0]).not.toHaveProperty("dag");
   });
 
-  it("uses system identity for downstream calls", async () => {
+  it("calls public fetch functions without identity", async () => {
     const wf = makeWorkflow({ id: "wf-sys" });
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-sys", "ext-run-1"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 100 },
-    ]);
-    mockFetchEmailStats.mockResolvedValue({
+    mockFetchRunCostsPublic.mockResolvedValue([]);
+    mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS },
       broadcast: { ...EMPTY_STATS },
     });
@@ -209,11 +213,12 @@ describe("GET /public/workflows/ranked", () => {
       .get("/public/workflows/ranked")
       .query({ category: "sales", channel: "email", audienceType: "cold-outreach" });
 
-    // Verify system identity was passed to downstream services
-    expect(mockFetchEmailStats).toHaveBeenCalledWith(
-      expect.any(Array),
-      expect.objectContaining({ orgId: "system", userId: "system", runId: "system-public" }),
-    );
+    // Verify public functions are called (no identity arg)
+    expect(mockFetchRunCostsPublic).toHaveBeenCalled();
+    expect(mockFetchEmailStatsPublic).toHaveBeenCalled();
+    // Verify auth functions are NOT called
+    expect(mockFetchRunCosts).not.toHaveBeenCalled();
+    expect(mockFetchEmailStats).not.toHaveBeenCalled();
   });
 
   it("supports groupBy=section", async () => {
@@ -221,10 +226,10 @@ describe("GET /public/workflows/ranked", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-sec", "ext-run-1"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 100 },
+    mockFetchRunCostsPublic.mockResolvedValue([
+      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 100, runCount: 1 },
     ]);
-    mockFetchEmailStats.mockResolvedValue({
+    mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, replied: 5, sent: 50 },
       broadcast: { ...EMPTY_STATS },
     });
@@ -259,12 +264,10 @@ describe("GET /public/workflows/ranked", () => {
       makeRun("wf-nb", "ext-run-nb"),
     );
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-b1", totalCostInUsdCents: 100 },
-      { runId: "ext-run-b2", totalCostInUsdCents: 200 },
-      { runId: "ext-run-nb", totalCostInUsdCents: 50 },
+    mockFetchRunCostsPublic.mockResolvedValue([
+      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 350, runCount: 3 },
     ]);
-    mockFetchEmailStats.mockResolvedValue({
+    mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, replied: 5 },
       broadcast: { ...EMPTY_STATS },
     });
@@ -286,10 +289,10 @@ describe("GET /public/workflows/ranked", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-filtered", "ext-run-f"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-f", totalCostInUsdCents: 100 },
+    mockFetchRunCostsPublic.mockResolvedValue([
+      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 100, runCount: 1 },
     ]);
-    mockFetchEmailStats.mockResolvedValue({
+    mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, replied: 10 },
       broadcast: { ...EMPTY_STATS },
     });
@@ -312,6 +315,8 @@ describe("GET /public/workflows/best", () => {
     mockWorkflowRunRows.length = 0;
     mockFetchRunCosts.mockReset();
     mockFetchEmailStats.mockReset();
+    mockFetchRunCostsPublic.mockReset();
+    mockFetchEmailStatsPublic.mockReset();
   });
 
   it("returns hero records without auth headers", async () => {
@@ -319,10 +324,10 @@ describe("GET /public/workflows/best", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-hero-pub", "ext-run-hero"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-hero", totalCostInUsdCents: 100 },
+    mockFetchRunCostsPublic.mockResolvedValue([
+      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 100, runCount: 1 },
     ]);
-    mockFetchEmailStats.mockResolvedValue({
+    mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
       broadcast: { ...EMPTY_STATS },
     });
@@ -344,10 +349,10 @@ describe("GET /public/workflows/best", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-no-out", "ext-run-no"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-no", totalCostInUsdCents: 100 },
+    mockFetchRunCostsPublic.mockResolvedValue([
+      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 100, runCount: 1 },
     ]);
-    mockFetchEmailStats.mockResolvedValue({
+    mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS },
       broadcast: { ...EMPTY_STATS },
     });
@@ -367,25 +372,23 @@ describe("GET /public/workflows/best", () => {
     expect(res.status).toBe(404);
   });
 
-  it("uses system identity for downstream calls", async () => {
+  it("calls public fetch functions without identity", async () => {
     const wf = makeWorkflow({ id: "wf-sys-best" });
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-sys-best", "ext-run-1"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 100 },
-    ]);
-    mockFetchEmailStats.mockResolvedValue({
+    mockFetchRunCostsPublic.mockResolvedValue([]);
+    mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, opened: 10 },
       broadcast: { ...EMPTY_STATS },
     });
 
     await request.get("/public/workflows/best");
 
-    expect(mockFetchRunCosts).toHaveBeenCalledWith(
-      expect.any(Array),
-      expect.objectContaining({ orgId: "system", userId: "system", runId: "system-public" }),
-    );
+    expect(mockFetchRunCostsPublic).toHaveBeenCalled();
+    expect(mockFetchEmailStatsPublic).toHaveBeenCalled();
+    expect(mockFetchRunCosts).not.toHaveBeenCalled();
+    expect(mockFetchEmailStats).not.toHaveBeenCalled();
   });
 
   it("supports by=brand", async () => {
@@ -397,14 +400,13 @@ describe("GET /public/workflows/best", () => {
       makeRun("wf-brand2", "ext-run-br2"),
     );
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-br1", totalCostInUsdCents: 100 },
-      { runId: "ext-run-br2", totalCostInUsdCents: 500 },
+    mockFetchRunCostsPublic.mockResolvedValue([
+      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 600, runCount: 2 },
     ]);
-    // brand-a: 100 cost / 10 opens = 10 cost-per-open, 100 / 5 replies = 20 cost-per-reply
-    mockFetchEmailStats
+    // brand-a: cost split evenly = 300 / 10 opens = 30 cost-per-open
+    mockFetchEmailStatsPublic
       .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 10, replied: 5 }, broadcast: { ...EMPTY_STATS } })
-      // brand-b: 500 cost / 100 opens = 5 cost-per-open, 500 / 50 replies = 10 cost-per-reply
+      // brand-b: cost split evenly = 300 / 100 opens = 3 cost-per-open
       .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 100, replied: 50 }, broadcast: { ...EMPTY_STATS } });
 
     const res = await request
@@ -412,7 +414,7 @@ describe("GET /public/workflows/best", () => {
       .query({ by: "brand" });
 
     expect(res.status).toBe(200);
-    // brand-b has lower cost-per-open (5) and cost-per-reply (10)
+    // brand-b has lower cost-per-open and cost-per-reply
     expect(res.body.bestCostPerOpen.brandId).toBe("brand-b");
     expect(res.body.bestCostPerOpen.workflowCount).toBe(1);
     expect(res.body.bestCostPerReply.brandId).toBe("brand-b");
@@ -423,10 +425,10 @@ describe("GET /public/workflows/best", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-brand-filter", "ext-run-bz"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-bz", totalCostInUsdCents: 100 },
+    mockFetchRunCostsPublic.mockResolvedValue([
+      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 100, runCount: 1 },
     ]);
-    mockFetchEmailStats.mockResolvedValue({
+    mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
       broadcast: { ...EMPTY_STATS },
     });


### PR DESCRIPTION
## Summary
- Public `/workflows/ranked` and `/workflows/best` were returning 502 because they called runs-service and email-gateway with a fake `SYSTEM_IDENTITY` (orgId: "system") that downstream services rejected
- `computeWorkflowScores` now accepts a `mode` discriminated union: `{ kind: "auth", identity }` or `{ kind: "public", brandId?, orgId? }`
- In public mode, costs are fetched via `GET /v1/stats/public/costs?groupBy=workflowName` (runs-service) and email stats via `GET /stats/public?runIds=...` (email-gateway) — no identity headers needed
- Removed `SYSTEM_IDENTITY` entirely

## Test plan
- [x] All 427 tests pass
- [x] Public endpoint tests verify that `fetchRunCostsPublic` and `fetchEmailStatsPublic` are called (not the auth versions)
- [ ] Verify on staging that `/public/workflows/ranked` and `/public/workflows/best` return 200 with stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)