### PR TITLE
fix: remove fallback field name mapping in stats-client

### DIFF
--- a/src/lib/stats-client.ts
+++ b/src/lib/stats-client.ts
@@ -186,17 +186,16 @@ export async function fetchEmailStats(
 
 // --- Public: fetch email stats (no identity) ---
 
-/** Map email-gateway field names to our internal names. Handles both conventions:
- *  emailsOpened (GET /stats, GET /stats/public) and opened (POST /stats) */
+/** Map email-gateway field names (emailsOpened etc.) to our internal names (opened etc.) */
 export function mapGatewayStats(raw: Record<string, unknown>): EmailStats {
   return {
-    sent: Number(raw.emailsSent ?? raw.sent ?? 0),
-    delivered: Number(raw.emailsDelivered ?? raw.delivered ?? 0),
-    opened: Number(raw.emailsOpened ?? raw.opened ?? 0),
-    clicked: Number(raw.emailsClicked ?? raw.clicked ?? 0),
-    replied: Number(raw.emailsReplied ?? raw.replied ?? 0),
-    bounced: Number(raw.emailsBounced ?? raw.bounced ?? 0),
-    unsubscribed: Number(raw.repliesUnsubscribe ?? raw.unsubscribed ?? 0),
+    sent: Number(raw.emailsSent ?? 0),
+    delivered: Number(raw.emailsDelivered ?? 0),
+    opened: Number(raw.emailsOpened ?? 0),
+    clicked: Number(raw.emailsClicked ?? 0),
+    replied: Number(raw.emailsReplied ?? 0),
+    bounced: Number(raw.emailsBounced ?? 0),
+    unsubscribed: Number(raw.repliesUnsubscribe ?? 0),
     recipients: Number(raw.recipients ?? 0),
   };
 }
@@ -235,31 +234,3 @@ export async function fetchEmailStatsPublic(
   };
 }
 
-// --- Public: fetch email stats (no identity) ---
-
-export async function fetchEmailStatsPublic(
-  runIds: string[],
-): Promise<EmailStatsResponse> {
-  if (runIds.length === 0) {
-    return { transactional: { ...EMPTY_STATS }, broadcast: { ...EMPTY_STATS } };
-  }
-
-  const { baseUrl, apiKey } = getEmailGatewayConfig();
-
-  const res = await fetch(
-    `${baseUrl}/stats/public?runIds=${runIds.join(",")}`,
-    {
-      method: "GET",
-      headers: { "x-api-key": apiKey },
-    },
-  );
-
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(
-      `email-gateway-service error: GET /stats/public -> ${res.status} ${res.statusText}: ${text}`
-    );
-  }
-
-  return res.json() as Promise<EmailStatsResponse>;
-}

--- a/tests/unit/stats-client.test.ts
+++ b/tests/unit/stats-client.test.ts
@@ -28,32 +28,6 @@ describe("mapGatewayStats", () => {
     });
   });
 
-  it("maps short field names (opened) for backwards compat", () => {
-    const raw = {
-      sent: 10,
-      delivered: 9,
-      opened: 5,
-      clicked: 1,
-      replied: 1,
-      bounced: 0,
-      unsubscribed: 0,
-      recipients: 10,
-    };
-
-    const result = mapGatewayStats(raw);
-
-    expect(result).toEqual({
-      sent: 10,
-      delivered: 9,
-      opened: 5,
-      clicked: 1,
-      replied: 1,
-      bounced: 0,
-      unsubscribed: 0,
-      recipients: 10,
-    });
-  });
-
   it("defaults missing fields to 0", () => {
     const result = mapGatewayStats({});
 
@@ -67,15 +41,5 @@ describe("mapGatewayStats", () => {
       unsubscribed: 0,
       recipients: 0,
     });
-  });
-
-  it("prefers prefixed names over short names when both present", () => {
-    const raw = {
-      emailsOpened: 15,
-      opened: 999, // should be ignored — emailsOpened takes precedence
-    };
-
-    const result = mapGatewayStats(raw);
-    expect(result.opened).toBe(15);
   });
 });


### PR DESCRIPTION
## Summary
- Removed silent fallback from `mapGatewayStats` that accepted both `emailsOpened` and `opened` field names
- Now only maps email-gateway's documented field names (`emailsOpened`, `emailsReplied`, etc.)
- Also removed duplicate `fetchEmailStatsPublic` function that lacked the mapping

## Test plan
- [x] Unit tests for `mapGatewayStats` with gateway field names and missing fields
- [x] All 429 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)