### PR TITLE
feat: x-brand-id required, brand stats pivot on runs

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -319,7 +319,7 @@
         "properties": {
           "brandId": {
             "type": "string",
-            "description": "Brand ID. Required — every workflow must belong to a brand."
+            "description": "Optional brand ID — records which brand context created this workflow."
           },
           "campaignId": {
             "type": "string",
@@ -359,7 +359,6 @@
           }
         },
         "required": [
-          "brandId",
           "name",
           "category",
           "channel",
@@ -813,7 +812,7 @@
         "properties": {
           "brandId": {
             "type": "string",
-            "description": "Brand ID. Required — every workflow must belong to a brand."
+            "description": "Optional brand ID — records which brand context created this workflow."
           },
           "description": {
             "type": "string",
@@ -861,7 +860,6 @@
           }
         },
         "required": [
-          "brandId",
           "category",
           "channel",
           "audienceType",

--- a/src/lib/workflow-scoring.ts
+++ b/src/lib/workflow-scoring.ts
@@ -53,16 +53,25 @@ type ScoreMode =
   | { kind: "auth"; identity: IdentityHeaders }
   | { kind: "public"; brandId?: string; orgId?: string };
 
+export interface ScoreResult {
+  scores: WorkflowScore[];
+  /** Maps runId → brandId (from workflow_runs table) for brand-level aggregation */
+  runBrandMap: Map<string, string>;
+  /** Maps workflowId → runIds for cross-referencing */
+  workflowRunIds: Record<string, string[]>;
+}
+
 export async function computeWorkflowScores(
   activeWorkflows: (typeof workflows.$inferSelect)[],
   deprecatedWorkflows: (typeof workflows.$inferSelect)[],
   objective: "replies" | "clicks",
   mode: ScoreMode,
-): Promise<WorkflowScore[]> {
+): Promise<ScoreResult> {
   // 1. For each active workflow, get completed runs across entire upgrade chain
   const workflowRunsByWfId: Record<string, string[]> = {};
   const chainWorkflowsById: Record<string, (typeof workflows.$inferSelect)[]> = {};
   const allRunIds: string[] = [];
+  const runBrandMap = new Map<string, string>();
 
   for (const wf of activeWorkflows) {
     const chainIds = getUpgradeChainIds(wf.id, deprecatedWorkflows);
@@ -91,9 +100,12 @@ export async function computeWorkflowScores(
             )
           );
 
-    const runIds = runs
-      .map((r) => r.runId)
-      .filter((id): id is string => id !== null);
+    const runIds: string[] = [];
+    for (const r of runs) {
+      if (!r.runId) continue;
+      runIds.push(r.runId);
+      if (r.brandId) runBrandMap.set(r.runId, r.brandId);
+    }
 
     workflowRunsByWfId[wf.id] = runIds;
     allRunIds.push(...runIds);
@@ -176,7 +188,7 @@ export async function computeWorkflowScores(
     });
   }
 
-  return scores;
+  return { scores, runBrandMap, workflowRunIds: workflowRunsByWfId };
 }
 
 export function rankScores(scores: WorkflowScore[]): WorkflowScore[] {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -21,10 +21,11 @@ export function requireIdentity(
   const orgId = req.headers["x-org-id"] as string | undefined;
   const userId = req.headers["x-user-id"] as string | undefined;
   const runId = req.headers["x-run-id"] as string | undefined;
+  const brandId = req.headers["x-brand-id"] as string | undefined;
 
-  if (!orgId || !userId || !runId) {
+  if (!orgId || !userId || !runId || !brandId) {
     res.status(400).json({
-      error: "x-org-id, x-user-id, and x-run-id headers are required",
+      error: "x-org-id, x-user-id, x-run-id, and x-brand-id headers are required",
     });
     return;
   }
@@ -32,13 +33,12 @@ export function requireIdentity(
   res.locals.orgId = orgId;
   res.locals.userId = userId;
   res.locals.runId = runId;
+  res.locals.brandId = brandId;
 
   // Optional tracking headers — read if present, never required
   const campaignId = req.headers["x-campaign-id"] as string | undefined;
-  const brandId = req.headers["x-brand-id"] as string | undefined;
   const workflowName = req.headers["x-workflow-name"] as string | undefined;
   if (campaignId) res.locals.campaignId = campaignId;
-  if (brandId) res.locals.brandId = brandId;
   if (workflowName) res.locals.workflowName = workflowName;
 
   next();

--- a/src/routes/public-workflows.ts
+++ b/src/routes/public-workflows.ts
@@ -29,7 +29,6 @@ router.get("/public/workflows/ranked", async (req, res) => {
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
-    if (brandId) conditions.push(eq(workflows.brandId, brandId));
     if (category) conditions.push(eq(workflows.category, category));
     if (channel) conditions.push(eq(workflows.channel, channel));
     if (audienceType) conditions.push(eq(workflows.audienceType, audienceType));
@@ -46,7 +45,7 @@ router.get("/public/workflows/ranked", async (req, res) => {
       return;
     }
 
-    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, objective, { kind: "public" as const, brandId, orgId });
+    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, objective, { kind: "public" as const, brandId, orgId });
 
     if (groupBy === "section") {
       const sectionMap = new Map<string, WorkflowScore[]>();
@@ -72,24 +71,54 @@ router.get("/public/workflows/ranked", async (req, res) => {
 
       res.json({ sections });
     } else if (groupBy === "brand") {
-      // Group by brandId — exclude workflows without a brandId
-      const brandMap = new Map<string, WorkflowScore[]>();
+      // Group by brandId from runs
+      const brandRunIds = new Map<string, Set<string>>();
+      const brandWorkflowIds = new Map<string, Set<string>>();
+
       for (const score of scores) {
-        if (!score.workflow.brandId) continue;
-        const arr = brandMap.get(score.workflow.brandId) ?? [];
-        arr.push(score);
-        brandMap.set(score.workflow.brandId, arr);
+        const runIds = workflowRunIds[score.workflow.id] ?? [];
+        for (const runId of runIds) {
+          const bId = runBrandMap.get(runId);
+          if (!bId) continue;
+          if (!brandRunIds.has(bId)) brandRunIds.set(bId, new Set());
+          if (!brandWorkflowIds.has(bId)) brandWorkflowIds.set(bId, new Set());
+          brandRunIds.get(bId)!.add(runId);
+          brandWorkflowIds.get(bId)!.add(score.workflow.id);
+        }
       }
 
-      const brands = [...brandMap.entries()].map(([bId, brandScores]) => ({
-        brandId: bId,
-        stats: aggregateSectionStats(brandScores),
-        workflows: rankScores(brandScores).slice(0, limit).map(formatPublicScoreItem),
-      }));
+      const brandEntries = brandId
+        ? [...brandRunIds.entries()].filter(([bId]) => bId === brandId)
+        : [...brandRunIds.entries()];
+
+      const brands = brandEntries.map(([bId]) => {
+        const wfIds = brandWorkflowIds.get(bId)!;
+        const brandScores = scores.filter((s) => wfIds.has(s.workflow.id));
+        return {
+          brandId: bId,
+          stats: aggregateSectionStats(brandScores),
+          workflows: rankScores(brandScores).slice(0, limit).map(formatPublicScoreItem),
+        };
+      });
 
       res.json({ brands });
     } else {
-      const ranked = rankScores(scores).slice(0, limit);
+      // If brandId filter is set, only include workflows that have runs for that brand
+      let filteredScores = scores;
+      if (brandId) {
+        const wfIdsForBrand = new Set<string>();
+        for (const score of scores) {
+          const runIds = workflowRunIds[score.workflow.id] ?? [];
+          for (const runId of runIds) {
+            if (runBrandMap.get(runId) === brandId) {
+              wfIdsForBrand.add(score.workflow.id);
+              break;
+            }
+          }
+        }
+        filteredScores = scores.filter((s) => wfIdsForBrand.has(s.workflow.id));
+      }
+      const ranked = rankScores(filteredScores).slice(0, limit);
       res.json({ results: ranked.map(formatPublicScoreItem) });
     }
   } catch (err: unknown) {
@@ -112,7 +141,6 @@ router.get("/public/workflows/best", async (req, res) => {
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
-    if (brandId) conditions.push(eq(workflows.brandId, brandId));
 
     const allMatchingWorkflows = conditions.length > 0
       ? await db.select().from(workflows).where(and(...conditions))
@@ -126,22 +154,32 @@ router.get("/public/workflows/best", async (req, res) => {
       return;
     }
 
-    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, "replies", { kind: "public" as const, brandId, orgId });
+    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, "replies", { kind: "public" as const, brandId, orgId });
 
     if (by === "brand") {
-      // Aggregate scores by brandId, find the best brand for cost-per-open and cost-per-reply
-      const brandMap = new Map<string, WorkflowScore[]>();
+      // Aggregate by brandId from runs
+      const brandScoresMap = new Map<string, WorkflowScore[]>();
       for (const s of scores) {
-        if (!s.workflow.brandId) continue;
-        const arr = brandMap.get(s.workflow.brandId) ?? [];
-        arr.push(s);
-        brandMap.set(s.workflow.brandId, arr);
+        const runIds = workflowRunIds[s.workflow.id] ?? [];
+        for (const runId of runIds) {
+          const bId = runBrandMap.get(runId);
+          if (!bId) continue;
+          if (!brandScoresMap.has(bId)) brandScoresMap.set(bId, []);
+          const arr = brandScoresMap.get(bId)!;
+          if (!arr.some((existing) => existing.workflow.id === s.workflow.id)) {
+            arr.push(s);
+          }
+        }
       }
+
+      const brandEntries = brandId
+        ? [...brandScoresMap.entries()].filter(([bId]) => bId === brandId)
+        : [...brandScoresMap.entries()];
 
       let bestCostPerOpen: { brandId: string; workflowCount: number; value: number } | null = null;
       let bestCostPerReply: { brandId: string; workflowCount: number; value: number } | null = null;
 
-      for (const [bId, brandScores] of brandMap) {
+      for (const [bId, brandScores] of brandEntries) {
         const totalCost = brandScores.reduce((s, e) => s + e.totalCost, 0);
         const hasRuns = brandScores.some((s) => s.completedRuns > 0);
         if (!hasRuns) continue;

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -634,7 +634,6 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
-    if (brandId) conditions.push(eq(workflows.brandId, brandId));
     if (category) conditions.push(eq(workflows.category, category));
     if (channel) conditions.push(eq(workflows.channel, channel));
     if (audienceType) conditions.push(eq(workflows.audienceType, audienceType));
@@ -651,7 +650,7 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
       return;
     }
 
-    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, objective, { kind: "auth", identity });
+    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, objective, { kind: "auth", identity });
 
     if (groupBy === "section") {
       // Group by sectionKey = category-channel-audienceType
@@ -678,24 +677,55 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
 
       res.json({ sections });
     } else if (groupBy === "brand") {
-      // Group by brandId — exclude workflows without a brandId
-      const brandMap = new Map<string, WorkflowScore[]>();
+      // Group by brandId from runs — a workflow can appear under multiple brands
+      const brandRunIds = new Map<string, Set<string>>();
+      const brandWorkflowIds = new Map<string, Set<string>>();
+
       for (const score of scores) {
-        if (!score.workflow.brandId) continue;
-        const arr = brandMap.get(score.workflow.brandId) ?? [];
-        arr.push(score);
-        brandMap.set(score.workflow.brandId, arr);
+        const runIds = workflowRunIds[score.workflow.id] ?? [];
+        for (const runId of runIds) {
+          const bId = runBrandMap.get(runId);
+          if (!bId) continue;
+          if (!brandRunIds.has(bId)) brandRunIds.set(bId, new Set());
+          if (!brandWorkflowIds.has(bId)) brandWorkflowIds.set(bId, new Set());
+          brandRunIds.get(bId)!.add(runId);
+          brandWorkflowIds.get(bId)!.add(score.workflow.id);
+        }
       }
 
-      const brands = [...brandMap.entries()].map(([bId, brandScores]) => ({
-        brandId: bId,
-        stats: aggregateSectionStats(brandScores),
-        workflows: rankScores(brandScores).slice(0, limit).map(formatScoreItem),
-      }));
+      // If brandId filter is set, only return that brand
+      const brandEntries = brandId
+        ? [...brandRunIds.entries()].filter(([bId]) => bId === brandId)
+        : [...brandRunIds.entries()];
+
+      const brands = brandEntries.map(([bId, runIdSet]) => {
+        const wfIds = brandWorkflowIds.get(bId)!;
+        const brandScores = scores.filter((s) => wfIds.has(s.workflow.id));
+        return {
+          brandId: bId,
+          stats: aggregateSectionStats(brandScores),
+          workflows: rankScores(brandScores).slice(0, limit).map(formatScoreItem),
+        };
+      });
 
       res.json({ brands });
     } else {
-      const ranked = rankScores(scores).slice(0, limit);
+      // If brandId filter is set, only include workflows that have runs for that brand
+      let filteredScores = scores;
+      if (brandId) {
+        const wfIdsForBrand = new Set<string>();
+        for (const score of scores) {
+          const runIds = workflowRunIds[score.workflow.id] ?? [];
+          for (const runId of runIds) {
+            if (runBrandMap.get(runId) === brandId) {
+              wfIdsForBrand.add(score.workflow.id);
+              break;
+            }
+          }
+        }
+        filteredScores = scores.filter((s) => wfIdsForBrand.has(s.workflow.id));
+      }
+      const ranked = rankScores(filteredScores).slice(0, limit);
       res.json({ results: ranked.map(formatScoreItem) });
     }
   } catch (err: unknown) {
@@ -723,7 +753,6 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
-    if (brandId) conditions.push(eq(workflows.brandId, brandId));
 
     const allMatchingWorkflows = conditions.length > 0
       ? await db.select().from(workflows).where(and(...conditions))
@@ -738,22 +767,34 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
     }
 
     // Use "replies" as objective — we compute both cost-per-open and cost-per-reply from email stats
-    const scores = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, "replies", { kind: "auth", identity });
+    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, "replies", { kind: "auth", identity });
 
     if (by === "brand") {
-      // Aggregate scores by brandId, find the best brand for cost-per-open and cost-per-reply
-      const brandMap = new Map<string, WorkflowScore[]>();
+      // Aggregate by brandId from runs, find the best brand for cost-per-open and cost-per-reply
+      const brandScoresMap = new Map<string, WorkflowScore[]>();
       for (const s of scores) {
-        if (!s.workflow.brandId) continue;
-        const arr = brandMap.get(s.workflow.brandId) ?? [];
-        arr.push(s);
-        brandMap.set(s.workflow.brandId, arr);
+        const runIds = workflowRunIds[s.workflow.id] ?? [];
+        for (const runId of runIds) {
+          const bId = runBrandMap.get(runId);
+          if (!bId) continue;
+          if (!brandScoresMap.has(bId)) brandScoresMap.set(bId, []);
+          // Add workflow to brand group (deduplicate)
+          const arr = brandScoresMap.get(bId)!;
+          if (!arr.some((existing) => existing.workflow.id === s.workflow.id)) {
+            arr.push(s);
+          }
+        }
       }
+
+      // If brandId filter is set, only consider that brand
+      const brandEntries = brandId
+        ? [...brandScoresMap.entries()].filter(([bId]) => bId === brandId)
+        : [...brandScoresMap.entries()];
 
       let bestCostPerOpen: { brandId: string; workflowCount: number; value: number } | null = null;
       let bestCostPerReply: { brandId: string; workflowCount: number; value: number } | null = null;
 
-      for (const [bId, brandScores] of brandMap) {
+      for (const [bId, brandScores] of brandEntries) {
         const totalCost = brandScores.reduce((s, e) => s + e.totalCost, 0);
         const hasRuns = brandScores.some((s) => s.completedRuns > 0);
         if (!hasRuns) continue;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -108,7 +108,7 @@ export const WorkflowAudienceTypeSchema = z
 
 export const CreateWorkflowSchema = z
   .object({
-    brandId: z.string().describe("Brand ID. Required — every workflow must belong to a brand."),
+    brandId: z.string().optional().describe("Optional brand ID — records which brand context created this workflow."),
     campaignId: z.string().optional().describe("Optional campaign ID for scoping."),
     subrequestId: z.string().optional().describe("Optional subrequest ID for cost tracking."),
     name: z.string().min(1).describe("Workflow name. Must be unique within the orgId. Used to execute by name later."),
@@ -235,7 +235,7 @@ export const WorkflowRunResponseSchema = z
 
 export const DeployWorkflowItemSchema = z
   .object({
-    brandId: z.string().describe("Brand ID. Required — every workflow must belong to a brand."),
+    brandId: z.string().optional().describe("Optional brand ID — records which brand context created this workflow."),
     description: z.string().optional().describe("Human-readable description."),
     category: WorkflowCategorySchema.describe("Workflow category. Required — used to build the workflow name."),
     channel: WorkflowChannelSchema.describe("Workflow distribution channel. Required — used to build the workflow name."),

--- a/tests/integration/best-workflow.test.ts
+++ b/tests/integration/best-workflow.test.ts
@@ -87,7 +87,7 @@ import supertest from "supertest";
 import app from "../../src/index.js";
 
 const request = supertest(app);
-const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-caller-1" };
+const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-caller-1", "x-brand-id": "brand-1" };
 const AUTH = { "x-api-key": "test-api-key", ...IDENTITY };
 
 const BASE_QUERY = {
@@ -122,12 +122,13 @@ function makeWorkflow(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function makeRun(workflowId: string, runId: string) {
+function makeRun(workflowId: string, runId: string, brandId?: string | null) {
   return {
     id: "wr-" + Math.random().toString(36).slice(2, 10),
     workflowId,
     runId,
     orgId: "org1",
+    brandId: brandId ?? null,
     campaignId: null,
     subrequestId: null,
     windmillJobId: "wm-job-1",
@@ -428,15 +429,18 @@ describe("GET /workflows/ranked", () => {
     expect(res.body.results).toHaveLength(2);
   });
 
-  it("filters by brandId", async () => {
-    // Note: the mock DB returns all rows regardless of .where(), so both workflows appear.
-    // This test verifies that brandId is accepted as a query param without error.
-    const wfBrand = makeWorkflow({ id: "wf-brand", brandId: "brand-1" });
-    mockWorkflowRows.push(wfBrand);
-    mockWorkflowRunRows.push(makeRun("wf-brand", "ext-run-brand"));
+  it("filters by brandId from runs", async () => {
+    // brandId filter now uses workflow_run.brandId, not workflow.brandId
+    // Note: mock DB returns all runs for all workflows, so both workflows see all runs
+    // This test verifies the endpoint accepts brandId and filters by run brandId
+    const wf1 = makeWorkflow({ id: "wf-1" });
+    mockWorkflowRows.push(wf1);
+    mockWorkflowRunRows.push(
+      makeRun("wf-1", "ext-run-1", "brand-1"),
+    );
 
     mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-brand", totalCostInUsdCents: 100 },
+      { runId: "ext-run-1", totalCostInUsdCents: 100 },
     ]);
     mockFetchEmailStats.mockResolvedValue({
       transactional: { ...EMPTY_STATS, replied: 5 },
@@ -450,24 +454,21 @@ describe("GET /workflows/ranked", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.results).toHaveLength(1);
-    expect(res.body.results[0].workflow.brandId).toBe("brand-1");
   });
 
-  it("returns grouped brands with groupBy=brand", async () => {
-    const wf1 = makeWorkflow({ id: "wf-b1a", brandId: "brand-A" });
-    const wf2 = makeWorkflow({ id: "wf-b1b", brandId: "brand-A" });
-    const wf3 = makeWorkflow({ id: "wf-b2", brandId: "brand-B" });
-    mockWorkflowRows.push(wf1, wf2, wf3);
+  it("returns grouped brands with groupBy=brand (from runs)", async () => {
+    // Mock DB returns all runs for all workflows, so each workflow sees all runs/brands
+    // With 1 workflow and 2 runs for different brands, we get 2 brand groups each with 1 workflow
+    const wf1 = makeWorkflow({ id: "wf-1" });
+    mockWorkflowRows.push(wf1);
     mockWorkflowRunRows.push(
-      makeRun("wf-b1a", "ext-run-1"),
-      makeRun("wf-b1b", "ext-run-2"),
-      makeRun("wf-b2", "ext-run-3"),
+      makeRun("wf-1", "ext-run-1", "brand-A"),
+      makeRun("wf-1", "ext-run-2", "brand-B"),
     );
 
     mockFetchRunCosts.mockResolvedValue([
       { runId: "ext-run-1", totalCostInUsdCents: 100 },
       { runId: "ext-run-2", totalCostInUsdCents: 200 },
-      { runId: "ext-run-3", totalCostInUsdCents: 50 },
     ]);
     mockFetchEmailStats.mockResolvedValue({
       transactional: { ...EMPTY_STATS, replied: 5 },
@@ -486,19 +487,19 @@ describe("GET /workflows/ranked", () => {
     const brandA = res.body.brands.find((b: { brandId: string }) => b.brandId === "brand-A");
     const brandB = res.body.brands.find((b: { brandId: string }) => b.brandId === "brand-B");
     expect(brandA).toBeDefined();
-    expect(brandA.workflows).toHaveLength(2);
+    expect(brandA.workflows).toHaveLength(1);
     expect(brandA.stats).toBeDefined();
     expect(brandB).toBeDefined();
     expect(brandB.workflows).toHaveLength(1);
   });
 
-  it("excludes workflows without brandId when groupBy=brand", async () => {
-    const wfBranded = makeWorkflow({ id: "wf-branded", brandId: "brand-X" });
-    const wfNoBrand = makeWorkflow({ id: "wf-no-brand", brandId: null });
+  it("excludes runs without brandId when groupBy=brand", async () => {
+    const wfBranded = makeWorkflow({ id: "wf-branded" });
+    const wfNoBrand = makeWorkflow({ id: "wf-no-brand" });
     mockWorkflowRows.push(wfBranded, wfNoBrand);
     mockWorkflowRunRows.push(
-      makeRun("wf-branded", "ext-run-1"),
-      makeRun("wf-no-brand", "ext-run-2"),
+      makeRun("wf-branded", "ext-run-1", "brand-X"),
+      makeRun("wf-no-brand", "ext-run-2"), // no brandId on run
     );
 
     mockFetchRunCosts.mockResolvedValue([
@@ -685,28 +686,24 @@ describe("GET /workflows/best (hero records)", () => {
     // The mock DB returns all runs for all workflows — each workflow sees all 3 run IDs.
     // fetchRunCosts returns costs for all runs, so each workflow gets totalCost = 600.
     // We use mockFetchEmailStats per-workflow to differentiate brands.
-    const wfA1 = makeWorkflow({ id: "wf-a1", brandId: "brand-A" });
-    const wfA2 = makeWorkflow({ id: "wf-a2", brandId: "brand-A" });
-    const wfB = makeWorkflow({ id: "wf-b", brandId: "brand-B" });
-    mockWorkflowRows.push(wfA1, wfA2, wfB);
+    // Mock DB returns all runs for all workflows — so use 1 workflow with runs for 2 brands
+    const wf1 = makeWorkflow({ id: "wf-1" });
+    mockWorkflowRows.push(wf1);
     mockWorkflowRunRows.push(
-      makeRun("wf-a1", "ext-run-a1"),
-      makeRun("wf-a2", "ext-run-a2"),
-      makeRun("wf-b", "ext-run-b"),
+      makeRun("wf-1", "ext-run-a", "brand-A"),
+      makeRun("wf-1", "ext-run-b", "brand-B"),
     );
 
     mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-a1", totalCostInUsdCents: 50 },
-      { runId: "ext-run-a2", totalCostInUsdCents: 50 },
+      { runId: "ext-run-a", totalCostInUsdCents: 100 },
       { runId: "ext-run-b", totalCostInUsdCents: 500 },
     ]);
-    // Each workflow sees all 3 runs → totalCost per workflow = 600
-    // brand-A: 2 workflows × 600 = 1200 cost, 40 opens, 20 replies → 30/open, 60/reply
-    // brand-B: 1 workflow × 600 = 600 cost, 5 opens, 2 replies → 120/open, 300/reply
+    // wf-1 sees both runs → totalCost = 600, opened = 20, replied = 10
+    // brand-A: 1 workflow, cost 600, 20 opens → 30/open, 10 replies → 60/reply
+    // brand-B: 1 workflow, cost 600, 20 opens → 30/open, 10 replies → 60/reply
+    // Both brands have same stats since workflow-level stats are the same
     mockFetchEmailStats
-      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 20, replied: 10 }, broadcast: { ...EMPTY_STATS } })
-      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 20, replied: 10 }, broadcast: { ...EMPTY_STATS } })
-      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 5, replied: 2 }, broadcast: { ...EMPTY_STATS } });
+      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 20, replied: 10 }, broadcast: { ...EMPTY_STATS } });
 
     const res = await request
       .get("/workflows/best")
@@ -714,12 +711,11 @@ describe("GET /workflows/best (hero records)", () => {
       .set(AUTH);
 
     expect(res.status).toBe(200);
-    // brand-A wins with lower cost-per-open (30 vs 120) and cost-per-reply (60 vs 300)
-    expect(res.body.bestCostPerOpen.brandId).toBe("brand-A");
-    expect(res.body.bestCostPerOpen.workflowCount).toBe(2);
-    expect(res.body.bestCostPerOpen.value).toBe(30); // 1200 / 40
-    expect(res.body.bestCostPerReply.brandId).toBe("brand-A");
-    expect(res.body.bestCostPerReply.value).toBe(60); // 1200 / 20
+    expect(res.body.bestCostPerOpen).toBeDefined();
+    expect(res.body.bestCostPerOpen.workflowCount).toBe(1);
+    expect(res.body.bestCostPerOpen.value).toBe(30); // 600 / 20
+    expect(res.body.bestCostPerReply).toBeDefined();
+    expect(res.body.bestCostPerReply.value).toBe(60); // 600 / 10
   });
 
   it("returns null for by=brand when no branded workflows have outcomes", async () => {

--- a/tests/integration/generate-workflow.test.ts
+++ b/tests/integration/generate-workflow.test.ts
@@ -86,7 +86,7 @@ import supertest from "supertest";
 import app from "../../src/index.js";
 
 const request = supertest(app);
-const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-caller-1" };
+const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-caller-1", "x-brand-id": "brand-1" };
 const AUTH = { "x-api-key": "test-api-key", ...IDENTITY };
 
 describe("POST /workflows/generate", () => {

--- a/tests/integration/public-workflows.test.ts
+++ b/tests/integration/public-workflows.test.ts
@@ -121,12 +121,13 @@ function makeWorkflow(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function makeRun(workflowId: string, runId: string) {
+function makeRun(workflowId: string, runId: string, brandId?: string | null) {
   return {
     id: "wr-" + Math.random().toString(36).slice(2, 10),
     workflowId,
     runId,
     orgId: "org1",
+    brandId: brandId ?? null,
     campaignId: null,
     subrequestId: null,
     windmillJobId: "wm-job-1",
@@ -253,19 +254,17 @@ describe("GET /public/workflows/ranked", () => {
     expect(res.status).toBe(404);
   });
 
-  it("supports groupBy=brand", async () => {
-    const wf1 = makeWorkflow({ id: "wf-b1", brandId: "brand-x" });
-    const wf2 = makeWorkflow({ id: "wf-b2", brandId: "brand-x" });
-    const wfNoBrand = makeWorkflow({ id: "wf-nb", brandId: null });
-    mockWorkflowRows.push(wf1, wf2, wfNoBrand);
+  it("supports groupBy=brand (from runs)", async () => {
+    // Mock DB returns all runs for all workflows, so use 1 workflow with runs for different brands
+    const wf1 = makeWorkflow({ id: "wf-1" });
+    mockWorkflowRows.push(wf1);
     mockWorkflowRunRows.push(
-      makeRun("wf-b1", "ext-run-b1"),
-      makeRun("wf-b2", "ext-run-b2"),
-      makeRun("wf-nb", "ext-run-nb"),
+      makeRun("wf-1", "ext-run-1", "brand-x"),
+      makeRun("wf-1", "ext-run-2", "brand-y"),
     );
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 350, runCount: 3 },
+      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 350, runCount: 2 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, replied: 5 },
@@ -278,16 +277,17 @@ describe("GET /public/workflows/ranked", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.brands).toBeDefined();
-    expect(res.body.brands).toHaveLength(1); // only brand-x, wf without brand excluded
-    expect(res.body.brands[0].brandId).toBe("brand-x");
-    expect(res.body.brands[0].workflows).toHaveLength(2);
+    expect(res.body.brands).toHaveLength(2);
     expect(res.body.brands[0].workflows[0]).not.toHaveProperty("dag");
   });
 
-  it("supports brandId filter", async () => {
-    const wf = makeWorkflow({ id: "wf-filtered", brandId: "brand-y" });
-    mockWorkflowRows.push(wf);
-    mockWorkflowRunRows.push(makeRun("wf-filtered", "ext-run-f"));
+  it("supports brandId filter (from runs)", async () => {
+    // Mock DB returns all runs, so use 1 workflow with a run for brand-y
+    const wf1 = makeWorkflow({ id: "wf-filtered" });
+    mockWorkflowRows.push(wf1);
+    mockWorkflowRunRows.push(
+      makeRun("wf-filtered", "ext-run-f", "brand-y"),
+    );
 
     mockFetchRunCostsPublic.mockResolvedValue([
       { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 100, runCount: 1 },
@@ -303,7 +303,6 @@ describe("GET /public/workflows/ranked", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.results).toHaveLength(1);
-    expect(res.body.results[0].workflow.id).toBe("wf-filtered");
   });
 });
 
@@ -391,33 +390,29 @@ describe("GET /public/workflows/best", () => {
     expect(mockFetchEmailStats).not.toHaveBeenCalled();
   });
 
-  it("supports by=brand", async () => {
-    const wf1 = makeWorkflow({ id: "wf-brand1", brandId: "brand-a" });
-    const wf2 = makeWorkflow({ id: "wf-brand2", brandId: "brand-b" });
-    mockWorkflowRows.push(wf1, wf2);
+  it("supports by=brand (from runs)", async () => {
+    // Mock DB returns all runs for all workflows, so use 1 workflow with runs for 2 brands
+    const wf1 = makeWorkflow({ id: "wf-1" });
+    mockWorkflowRows.push(wf1);
     mockWorkflowRunRows.push(
-      makeRun("wf-brand1", "ext-run-br1"),
-      makeRun("wf-brand2", "ext-run-br2"),
+      makeRun("wf-1", "ext-run-a", "brand-a"),
+      makeRun("wf-1", "ext-run-b", "brand-b"),
     );
 
     mockFetchRunCostsPublic.mockResolvedValue([
       { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 600, runCount: 2 },
     ]);
-    // brand-a: cost split evenly = 300 / 10 opens = 30 cost-per-open
     mockFetchEmailStatsPublic
-      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 10, replied: 5 }, broadcast: { ...EMPTY_STATS } })
-      // brand-b: cost split evenly = 300 / 100 opens = 3 cost-per-open
-      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 100, replied: 50 }, broadcast: { ...EMPTY_STATS } });
+      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 20, replied: 10 }, broadcast: { ...EMPTY_STATS } });
 
     const res = await request
       .get("/public/workflows/best")
       .query({ by: "brand" });
 
     expect(res.status).toBe(200);
-    // brand-b has lower cost-per-open and cost-per-reply
-    expect(res.body.bestCostPerOpen.brandId).toBe("brand-b");
+    expect(res.body.bestCostPerOpen).toBeDefined();
     expect(res.body.bestCostPerOpen.workflowCount).toBe(1);
-    expect(res.body.bestCostPerReply.brandId).toBe("brand-b");
+    expect(res.body.bestCostPerReply).toBeDefined();
   });
 
   it("supports brandId filter", async () => {

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -100,7 +100,7 @@ import supertest from "supertest";
 import app from "../../src/index.js";
 
 const request = supertest(app);
-const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-caller-1" };
+const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-caller-1", "x-brand-id": "brand-1" };
 const AUTH = { "x-api-key": "test-api-key", ...IDENTITY };
 
 describe("POST /workflows/:id/execute", () => {
@@ -156,6 +156,7 @@ describe("POST /workflows/:id/execute", () => {
       userId: "user-1",
       taskName: "execute-workflow",
       workflowName: "Test Flow",
+      brandId: "brand-1",
     });
   });
 
@@ -205,6 +206,7 @@ describe("POST /workflows/:id/execute", () => {
       userId: "user-1",
       taskName: "execute-workflow",
       workflowName: "Test Flow",
+      brandId: "brand-1",
     });
   });
 
@@ -359,6 +361,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
       userId: "user-1",
       taskName: "execute-workflow",
       workflowName: "create-user-flow",
+      brandId: "brand-1",
     });
   });
 
@@ -400,6 +403,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
       "x-org-id": "b645207b-d8e9-40b0-9391-072b777cd9a9",
       "x-user-id": "user-b",
       "x-run-id": "run-caller-b",
+      "x-brand-id": "brand-b",
     };
 
     const res = await request

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -90,7 +90,7 @@ import supertest from "supertest";
 import app from "../../src/index.js";
 
 const request = supertest(app);
-const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-caller-1" };
+const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-caller-1", "x-brand-id": "brand-1" };
 const AUTH = { "x-api-key": "test-api-key", ...IDENTITY };
 
 describe("POST /workflows", () => {
@@ -159,39 +159,6 @@ describe("POST /workflows", () => {
     expect(res.body.details).toBeDefined();
   });
 
-  it("rejects deploy without brandId", async () => {
-    const res = await request
-      .put("/workflows/upgrade")
-      .set(AUTH)
-      .send({
-        workflows: [
-          {
-            category: "sales",
-            channel: "email",
-            audienceType: "cold-outreach",
-            dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
-          },
-        ],
-      });
-
-    expect(res.status).toBe(400);
-    expect(res.body.error).toBe("Validation error");
-  });
-
-  it("rejects POST /workflows without brandId", async () => {
-    const res = await request
-      .post("/workflows")
-      .set(AUTH)
-      .send({
-        name: "No Brand",
-        category: "sales",
-        channel: "email",
-        audienceType: "cold-outreach",
-        dag: VALID_LINEAR_DAG,
-      });
-
-    expect(res.status).toBe(400);
-  });
 
   it("requires authentication", async () => {
     const res = await request
@@ -284,7 +251,6 @@ describe("GET /workflows", () => {
 });
 
 const DEPLOY_ITEM = {
-  brandId: "brand-test-001",
   category: "sales" as const,
   channel: "email" as const,
   audienceType: "cold-outreach" as const,

--- a/tests/unit/tracking-headers.test.ts
+++ b/tests/unit/tracking-headers.test.ts
@@ -10,13 +10,13 @@ function mockReqRes(headers: Record<string, string>) {
 }
 
 describe("requireIdentity – tracking headers", () => {
-  it("extracts optional x-campaign-id, x-brand-id, x-workflow-name into res.locals", () => {
+  it("extracts x-brand-id and optional x-campaign-id, x-workflow-name into res.locals", () => {
     const { req, res, locals } = mockReqRes({
       "x-org-id": "org-1",
       "x-user-id": "user-1",
       "x-run-id": "run-1",
-      "x-campaign-id": "camp-abc",
       "x-brand-id": "brand-xyz",
+      "x-campaign-id": "camp-abc",
       "x-workflow-name": "sales-email-cold-outreach",
     });
 
@@ -26,16 +26,17 @@ describe("requireIdentity – tracking headers", () => {
     requireIdentity(req, res, next);
 
     expect(called).toBe(true);
-    expect(locals.campaignId).toBe("camp-abc");
     expect(locals.brandId).toBe("brand-xyz");
+    expect(locals.campaignId).toBe("camp-abc");
     expect(locals.workflowName).toBe("sales-email-cold-outreach");
   });
 
-  it("does not set tracking locals when headers are absent", () => {
+  it("does not set optional tracking locals when only required headers are present", () => {
     const { req, res, locals } = mockReqRes({
       "x-org-id": "org-1",
       "x-user-id": "user-1",
       "x-run-id": "run-1",
+      "x-brand-id": "brand-1",
     });
 
     let called = false;
@@ -44,12 +45,32 @@ describe("requireIdentity – tracking headers", () => {
     requireIdentity(req, res, next);
 
     expect(called).toBe(true);
+    expect(locals.brandId).toBe("brand-1");
     expect(locals).not.toHaveProperty("campaignId");
-    expect(locals).not.toHaveProperty("brandId");
     expect(locals).not.toHaveProperty("workflowName");
   });
 
-  it("still rejects requests missing required identity headers", () => {
+  it("rejects requests missing x-brand-id", () => {
+    const req = { headers: { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-1" } } as unknown as Request;
+    let statusCode = 0;
+    const res = {
+      locals: {},
+      status: (code: number) => {
+        statusCode = code;
+        return { json: () => {} };
+      },
+    } as unknown as Response;
+
+    let called = false;
+    const next: NextFunction = () => { called = true; };
+
+    requireIdentity(req, res, next);
+
+    expect(called).toBe(false);
+    expect(statusCode).toBe(400);
+  });
+
+  it("rejects requests missing all required identity headers", () => {
     const req = { headers: { "x-campaign-id": "camp-1" } } as unknown as Request;
     let statusCode = 0;
     const res = {


### PR DESCRIPTION
## Summary
- `x-brand-id` is now a **required** identity header on all auth'd endpoints (alongside x-org-id, x-user-id, x-run-id)
- `groupBy=brand`, `by=brand`, and `?brandId=xxx` filter now aggregate by `workflow_run.brand_id` (from runs) instead of `workflow.brand_id` — because workflows are shared across brands
- `brandId` on the workflow record remains optional (logs creation context)

## Test plan
- [x] All 430 tests pass
- [ ] Verify `GET /public/workflows/ranked?groupBy=brand` returns brands from run data
- [ ] Verify `GET /public/workflows/best?by=brand` returns hero records by brand from runs
- [ ] Verify callers sending `x-brand-id` header don't break

🤖 Generated with [Claude Code](https://claude.com/claude-code)