### PR TITLE
fix: make x-brand-id optional on consultation endpoints

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -21,11 +21,10 @@ export function requireIdentity(
   const orgId = req.headers["x-org-id"] as string | undefined;
   const userId = req.headers["x-user-id"] as string | undefined;
   const runId = req.headers["x-run-id"] as string | undefined;
-  const brandId = req.headers["x-brand-id"] as string | undefined;
 
-  if (!orgId || !userId || !runId || !brandId) {
+  if (!orgId || !userId || !runId) {
     res.status(400).json({
-      error: "x-org-id, x-user-id, x-run-id, and x-brand-id headers are required",
+      error: "x-org-id, x-user-id, and x-run-id headers are required",
     });
     return;
   }
@@ -33,13 +32,30 @@ export function requireIdentity(
   res.locals.orgId = orgId;
   res.locals.userId = userId;
   res.locals.runId = runId;
-  res.locals.brandId = brandId;
 
-  // Optional tracking headers — read if present, never required
+  // Optional headers — read if present, never required
+  const brandId = req.headers["x-brand-id"] as string | undefined;
+  if (brandId) res.locals.brandId = brandId;
+
   const campaignId = req.headers["x-campaign-id"] as string | undefined;
   const workflowName = req.headers["x-workflow-name"] as string | undefined;
   if (campaignId) res.locals.campaignId = campaignId;
   if (workflowName) res.locals.workflowName = workflowName;
 
+  next();
+}
+
+export function requireBrandId(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const brandId = req.headers["x-brand-id"] as string | undefined;
+  if (!brandId && !req.body?.inputs?.brandId) {
+    res.status(400).json({
+      error: "x-brand-id header or inputs.brandId is required for execution endpoints",
+    });
+    return;
+  }
   next();
 }

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { eq, and } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { workflows, workflowRuns } from "../db/schema.js";
-import { requireApiKey } from "../middleware/auth.js";
+import { requireApiKey, requireBrandId } from "../middleware/auth.js";
 import { getWindmillClient } from "../lib/windmill-client.js";
 import { collectServiceEnvs } from "../lib/service-envs.js";
 import { createRun } from "../lib/runs-client.js";
@@ -23,6 +23,7 @@ function formatRun(r: typeof workflowRuns.$inferSelect) {
 router.post(
   "/workflows/by-name/:name/execute",
   requireApiKey,
+  requireBrandId,
   async (req, res) => {
     try {
       const body = ExecuteByNameSchema.parse(req.body);
@@ -189,7 +190,7 @@ router.post(
 );
 
 // POST /workflows/:id/execute — Execute a workflow
-router.post("/workflows/:id/execute", requireApiKey, async (req, res) => {
+router.post("/workflows/:id/execute", requireApiKey, requireBrandId, async (req, res) => {
   try {
     const body = ExecuteWorkflowSchema.parse(req.body ?? {});
     const orgId = res.locals.orgId as string;

--- a/tests/unit/tracking-headers.test.ts
+++ b/tests/unit/tracking-headers.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import type { Request, Response, NextFunction } from "express";
-import { requireIdentity } from "../../src/middleware/auth.js";
+import { requireIdentity, requireBrandId } from "../../src/middleware/auth.js";
 
-function mockReqRes(headers: Record<string, string>) {
-  const req = { headers } as unknown as Request;
+function mockReqRes(headers: Record<string, string>, body?: Record<string, unknown>) {
+  const req = { headers, body: body ?? {} } as unknown as Request;
   const locals: Record<string, unknown> = {};
   const res = { locals, status: () => ({ json: () => {} }) } as unknown as Response;
   return { req, res, locals };
@@ -31,7 +31,25 @@ describe("requireIdentity – tracking headers", () => {
     expect(locals.workflowName).toBe("sales-email-cold-outreach");
   });
 
-  it("does not set optional tracking locals when only required headers are present", () => {
+  it("passes without x-brand-id (now optional on identity middleware)", () => {
+    const { req, res, locals } = mockReqRes({
+      "x-org-id": "org-1",
+      "x-user-id": "user-1",
+      "x-run-id": "run-1",
+    });
+
+    let called = false;
+    const next: NextFunction = () => { called = true; };
+
+    requireIdentity(req, res, next);
+
+    expect(called).toBe(true);
+    expect(locals).not.toHaveProperty("brandId");
+    expect(locals).not.toHaveProperty("campaignId");
+    expect(locals).not.toHaveProperty("workflowName");
+  });
+
+  it("sets brandId in locals when x-brand-id header is present", () => {
     const { req, res, locals } = mockReqRes({
       "x-org-id": "org-1",
       "x-user-id": "user-1",
@@ -46,28 +64,6 @@ describe("requireIdentity – tracking headers", () => {
 
     expect(called).toBe(true);
     expect(locals.brandId).toBe("brand-1");
-    expect(locals).not.toHaveProperty("campaignId");
-    expect(locals).not.toHaveProperty("workflowName");
-  });
-
-  it("rejects requests missing x-brand-id", () => {
-    const req = { headers: { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-1" } } as unknown as Request;
-    let statusCode = 0;
-    const res = {
-      locals: {},
-      status: (code: number) => {
-        statusCode = code;
-        return { json: () => {} };
-      },
-    } as unknown as Response;
-
-    let called = false;
-    const next: NextFunction = () => { called = true; };
-
-    requireIdentity(req, res, next);
-
-    expect(called).toBe(false);
-    expect(statusCode).toBe(400);
   });
 
   it("rejects requests missing all required identity headers", () => {
@@ -88,5 +84,53 @@ describe("requireIdentity – tracking headers", () => {
 
     expect(called).toBe(false);
     expect(statusCode).toBe(400);
+  });
+});
+
+describe("requireBrandId – execution endpoints", () => {
+  it("passes when x-brand-id header is present", () => {
+    const { req, res } = mockReqRes({ "x-brand-id": "brand-1" });
+
+    let called = false;
+    const next: NextFunction = () => { called = true; };
+
+    requireBrandId(req, res, next);
+
+    expect(called).toBe(true);
+  });
+
+  it("passes when inputs.brandId is in request body", () => {
+    const { req, res } = mockReqRes({}, { inputs: { brandId: "brand-from-body" } });
+
+    let called = false;
+    const next: NextFunction = () => { called = true; };
+
+    requireBrandId(req, res, next);
+
+    expect(called).toBe(true);
+  });
+
+  it("rejects when neither header nor body has brandId", () => {
+    const req = { headers: {}, body: {} } as unknown as Request;
+    let statusCode = 0;
+    let errorBody: unknown;
+    const res = {
+      locals: {},
+      status: (code: number) => {
+        statusCode = code;
+        return { json: (b: unknown) => { errorBody = b; } };
+      },
+    } as unknown as Response;
+
+    let called = false;
+    const next: NextFunction = () => { called = true; };
+
+    requireBrandId(req, res, next);
+
+    expect(called).toBe(false);
+    expect(statusCode).toBe(400);
+    expect(errorBody).toEqual({
+      error: "x-brand-id header or inputs.brandId is required for execution endpoints",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- `x-brand-id` is no longer required on all authenticated endpoints — only on execution endpoints (`POST /workflows/:id/execute`, `POST /workflows/by-name/:name/execute`)
- Consultation endpoints (`GET /workflows/ranked`, `GET /workflows/best`, `GET /workflows`, etc.) now work without `x-brand-id`, fixing 400 errors from dashboard calls
- New `requireBrandId` middleware enforces brand ID (via header or `inputs.brandId`) specifically on execution routes

## Test plan
- [x] Unit tests for `requireIdentity` updated — passes without `x-brand-id`
- [x] Unit tests for new `requireBrandId` middleware added
- [x] All 433 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)