### PR TITLE
fix: rename brandId to createdForBrandId in BestWorkflowRecordSchema

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1232,10 +1232,10 @@
             "nullable": true,
             "description": "Stable display name of the workflow family."
           },
-          "brandId": {
+          "createdForBrandId": {
             "type": "string",
             "nullable": true,
-            "description": "Brand ID associated with the workflow."
+            "description": "Brand ID that created this workflow (creation context, not execution brand)."
           },
           "value": {
             "type": "number",
@@ -1246,7 +1246,7 @@
           "workflowId",
           "workflowName",
           "displayName",
-          "brandId",
+          "createdForBrandId",
           "value"
         ],
         "description": "Workflow with the lowest cost per email open. Null if no data."

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -544,7 +544,7 @@ export const BestWorkflowRecordSchema = z
     workflowId: z.string().uuid().describe("ID of the workflow holding the record."),
     workflowName: z.string().describe("Name of the workflow."),
     displayName: z.string().nullable().describe("Stable display name of the workflow family."),
-    brandId: z.string().nullable().describe("Brand ID associated with the workflow."),
+    createdForBrandId: z.string().nullable().describe("Brand ID that created this workflow (creation context, not execution brand)."),
     value: z.number().describe("The record value in USD cents."),
   })
   .openapi("BestWorkflowRecord");


### PR DESCRIPTION
## Summary
- Missed `BestWorkflowRecordSchema.brandId` in PR #136 — renames to `createdForBrandId`
- Regenerated `openapi.json`

## Test plan
- [x] `npm run build` passes
- [x] All 430 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)