### PR TITLE
feat: add migration 0017 to rename brand_id to created_for_brand_id

### DIFF
--- a/drizzle/0017_rename_brand_id_to_created_for_brand_id.sql
+++ b/drizzle/0017_rename_brand_id_to_created_for_brand_id.sql
@@ -1,0 +1,4 @@
+-- Rename brand_id to created_for_brand_id on workflows table
+-- This column only records which brand context created the workflow,
+-- not the execution-context brand (which lives on workflow_runs.brand_id).
+ALTER TABLE "workflows" RENAME COLUMN "brand_id" TO "created_for_brand_id";

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1772448306410,
       "tag": "0016_add_forked_from",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1772534706410,
+      "tag": "0017_rename_brand_id_to_created_for_brand_id",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds Drizzle migration `0017_rename_brand_id_to_created_for_brand_id.sql`
- Runs `ALTER TABLE workflows RENAME COLUMN brand_id TO created_for_brand_id` automatically at startup
- Completes the rename started in PR #136 and #137

## Test plan
- [x] `npm run build` passes
- [x] All 433 tests pass
- [ ] Verify service restarts cleanly after deploy (migration runs at startup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)