### PR TITLE
fix: use GET instead of POST for email-gateway /stats

### DIFF
--- a/src/lib/stats-client.ts
+++ b/src/lib/stats-client.ts
@@ -155,22 +155,23 @@ export async function fetchEmailStats(
 
   const { baseUrl, apiKey } = getEmailGatewayConfig();
 
-  const res = await fetch(`${baseUrl}/stats`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": apiKey,
-      "x-org-id": identity.orgId,
-      "x-user-id": identity.userId,
-      "x-run-id": identity.runId,
+  const res = await fetch(
+    `${baseUrl}/stats?runIds=${runIds.join(",")}`,
+    {
+      method: "GET",
+      headers: {
+        "x-api-key": apiKey,
+        "x-org-id": identity.orgId,
+        "x-user-id": identity.userId,
+        "x-run-id": identity.runId,
+      },
     },
-    body: JSON.stringify({ runIds }),
-  });
+  );
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(
-      `email-gateway-service error: POST /stats -> ${res.status} ${res.statusText}: ${text}`
+      `email-gateway-service error: GET /stats -> ${res.status} ${res.statusText}: ${text}`
     );
   }
 


### PR DESCRIPTION
## Summary
- `fetchEmailStats` was calling `POST /stats` on email-gateway but the API is `GET /stats?runIds=...`
- This caused 404 errors on `/workflows/ranked` and `/workflows/best` in production
- `fetchEmailStatsPublic` was already correct (GET /stats/public)

## Test plan
- [x] Build passes
- [x] All 433 tests pass
- [ ] Verify ranked/best endpoints return data after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)