### PR TITLE
fix: transform hyphenated node IDs in condition expressions

### DIFF
--- a/src/lib/dag-to-openflow.ts
+++ b/src/lib/dag-to-openflow.ts
@@ -271,12 +271,32 @@ function buildConditionModule(
   const seenExprs = new Set<string>();
   const branches: Array<{ summary?: string; expr: string; modules: FlowModule[] }> = [];
 
-  for (const edge of outEdges) {
-    const expr = edge.condition!;
-    if (seenExprs.has(expr)) continue;
-    seenExprs.add(expr);
+  // Collect all DAG node IDs that contain hyphens so we can replace them in expressions
+  const hyphenatedIds = dag.nodes
+    .map((n) => n.id)
+    .filter((id) => id.includes("-"))
+    .sort((a, b) => b.length - a.length); // longest first to avoid partial replacements
 
-    const branchNodeIds = info.branchNodeSets.get(expr) ?? new Set();
+  for (const edge of outEdges) {
+    const rawExpr = edge.condition!;
+    if (seenExprs.has(rawExpr)) continue;
+    seenExprs.add(rawExpr);
+
+    // Transform condition expression: replace hyphenated node IDs with underscored
+    // versions so they match Windmill's module IDs.
+    // Handles both bracket notation (results['fetch-lead']) and dot notation.
+    let expr = rawExpr;
+    for (const id of hyphenatedIds) {
+      const underscored = id.replace(/-/g, "_");
+      // Replace bracket-notation references: results['node-id'] or results["node-id"]
+      expr = expr.replaceAll(`['${id}']`, `.${underscored}`);
+      expr = expr.replaceAll(`["${id}"]`, `.${underscored}`);
+      // Replace dot-notation references: results.node-id (invalid JS but could appear)
+      // Only replace when preceded by 'results.' to avoid false positives
+      expr = expr.replaceAll(`results.${id}`, `results.${underscored}`);
+    }
+
+    const branchNodeIds = info.branchNodeSets.get(rawExpr) ?? new Set();
     const branchNodes = orderedNodes.filter((n) => branchNodeIds.has(n.id));
     const branchModules: FlowModule[] = [];
     for (const bn of branchNodes) {
@@ -284,7 +304,7 @@ function buildConditionModule(
       if (mod) branchModules.push(mod);
     }
 
-    branches.push({ summary: expr, expr, modules: branchModules });
+    branches.push({ summary: rawExpr, expr, modules: branchModules });
   }
 
   return {

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -572,3 +572,42 @@ export const POLARITY_WELCOME_DAG: DAG = {
   ],
   edges: [],
 };
+
+/**
+ * Regression: condition expression uses bracket notation with hyphenated node IDs.
+ * e.g. results['fetch-lead'].found — must be transformed to results.fetch_lead.found
+ * when translating to Windmill OpenFlow.
+ */
+export const DAG_WITH_HYPHENATED_CONDITION: DAG = {
+  nodes: [
+    {
+      id: "fetch-lead",
+      type: "http.call",
+      config: { service: "lead", method: "POST", path: "/buffer/next" },
+      retries: 0,
+    },
+    { id: "check-lead", type: "condition" },
+    {
+      id: "email-gen",
+      type: "http.call",
+      config: { service: "ai", method: "POST", path: "/generate" },
+    },
+    {
+      id: "email-send",
+      type: "http.call",
+      config: { service: "email", method: "POST", path: "/send" },
+    },
+    {
+      id: "end-run",
+      type: "http.call",
+      config: { service: "runs", method: "POST", path: "/runs/end" },
+    },
+  ],
+  edges: [
+    { from: "fetch-lead", to: "check-lead" },
+    { from: "check-lead", to: "email-gen", condition: "results['fetch-lead'].found == true" },
+    { from: "email-gen", to: "email-send" },
+    { from: "email-send", to: "end-run" },
+    { from: "check-lead", to: "end-run" },
+  ],
+};

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -19,6 +19,7 @@ import {
   DAG_WITH_CONDITION_CHAIN,
   DAG_WITH_TWO_BRANCHES,
   DAG_WITH_PATH_PARAMS,
+  DAG_WITH_HYPHENATED_CONDITION,
 } from "../helpers/fixtures.js";
 
 describe("dagToOpenFlow", () => {
@@ -575,6 +576,29 @@ describe("dagToOpenFlow", () => {
       // Nested metadata should merge static source with dynamic emailGenerationId
       expect(expr).toContain('"source"');
       expect(expr).toContain("results.email_generate?.id");
+    }
+  });
+
+  it("regression: transforms hyphenated node IDs in condition expressions to underscores", () => {
+    const result = dagToOpenFlow(DAG_WITH_HYPHENATED_CONDITION, "Hyphen Condition");
+
+    // Top-level: fetch-lead, check-lead (branchone), end-run
+    expect(result.value.modules).toHaveLength(3);
+    expect(result.value.modules[1].id).toBe("check_lead");
+
+    const condModule = result.value.modules[1];
+    expect(condModule.value.type).toBe("branchone");
+
+    if (condModule.value.type === "branchone") {
+      expect(condModule.value.branches).toHaveLength(1);
+      // The expression must use underscored IDs for Windmill compatibility
+      expect(condModule.value.branches[0].expr).toBe("results.fetch_lead.found == true");
+      // The summary keeps the original expression for readability
+      expect(condModule.value.branches[0].summary).toBe("results['fetch-lead'].found == true");
+      // email-gen and email-send are inside the branch
+      expect(condModule.value.branches[0].modules).toHaveLength(2);
+      expect(condModule.value.branches[0].modules[0].id).toBe("email_gen");
+      expect(condModule.value.branches[0].modules[1].id).toBe("email_send");
     }
   });
 


### PR DESCRIPTION
## Summary
- Condition expressions on DAG edges (e.g. `results['fetch-lead'].found`) were passed directly to Windmill without converting hyphenated node IDs to underscores
- Since Windmill stores results under underscored module IDs (`fetch_lead`), these conditions always evaluated to `undefined` → `false`, silently skipping the entire conditional branch
- This caused 40+ leads to be served but **zero emails generated or sent** for campaign `c164eea4` (workflow `sales-email-cold-outreach-mintaka`)

## Fix
- In `buildConditionModule()`, replace hyphenated node IDs with underscored versions in condition expressions before passing to Windmill
- Handles bracket notation (`results['fetch-lead']`), double-quote bracket notation (`results["fetch-lead"]`), and dot notation (`results.fetch-lead`)
- Summary field preserves the original expression for readability

## Test plan
- [x] Regression test: `DAG_WITH_HYPHENATED_CONDITION` fixture verifies bracket-notation condition `results['fetch-lead'].found == true` is transformed to `results.fetch_lead.found == true`
- [x] All 434 existing tests pass
- [ ] After deploy, re-run the mintaka campaign to confirm emails are now generated and sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)