### PR TITLE
fix: use stored windmillFlowPath for startup sync

### DIFF
--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -360,31 +360,21 @@ async function syncFlowToWindmill(
   wf: Workflow,
   windmillClient: WindmillClient,
 ): Promise<void> {
+  if (!wf.windmillFlowPath) {
+    return; // No flow deployed — nothing to sync
+  }
+
   const dag = wf.dag as DAG;
   const openFlow = dagToOpenFlow(dag, wf.name);
-  const flowPath = `f/workflows/${wf.orgId}/${wf.name.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
 
-  try {
-    await windmillClient.updateFlow(flowPath, {
-      summary: wf.name,
-      description: wf.description ?? "",
-      value: openFlow.value,
-      schema: openFlow.schema,
-    });
-  } catch (updateErr) {
-    const msg = updateErr instanceof Error ? updateErr.message : String(updateErr);
-    if (msg.includes("not found") || msg.includes("404")) {
-      await windmillClient.createFlow({
-        path: flowPath,
-        summary: wf.name,
-        description: wf.description ?? "",
-        value: openFlow.value,
-        schema: openFlow.schema,
-      });
-    } else {
-      throw updateErr;
-    }
-  }
+  // Use the actual stored flow path — NOT a recalculated one.
+  // The path in DB is the source of truth for where the flow lives in Windmill.
+  await windmillClient.updateFlow(wf.windmillFlowPath, {
+    summary: wf.name,
+    description: wf.description ?? "",
+    value: openFlow.value,
+    schema: openFlow.schema,
+  });
 }
 
 async function deprecateWorkflow(

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -257,10 +257,10 @@ describe("validateAndUpgradeWorkflows", () => {
       } as any,
     });
 
-    // Should have synced the valid workflow's flow to Windmill
+    // Should have synced using the stored windmillFlowPath (not a recalculated one)
     expect(mockUpdateFlow).toHaveBeenCalledTimes(1);
     expect(mockUpdateFlow).toHaveBeenCalledWith(
-      expect.stringContaining("f/workflows/org-1/"),
+      "f/workflows/org-1/flow", // exact path from DB, not recalculated
       expect.objectContaining({
         summary: VALID_WORKFLOW.name,
         value: expect.any(Object),
@@ -693,9 +693,11 @@ describe("validateAndUpgradeWorkflows", () => {
       } as any,
     });
 
-    // Should have tried updateFlow first, then fallen back to createFlow (upgrade + sync)
+    // Upgrade: updateFlow fails → createFlow fallback (1 each)
+    // Sync: updateFlow on the newly-created workflow (may fail, caught by sync loop)
     expect(mockUpdateFlow).toHaveBeenCalledTimes(2);
-    expect(mockCreateFlow).toHaveBeenCalledTimes(2);
+    // createFlow only called once — during upgrade. Sync uses updateFlow with stored path, no fallback.
+    expect(mockCreateFlow).toHaveBeenCalledTimes(1);
 
     expect(dbInserts.length).toBe(1);
     expect(dbInserts[0].status).toBe("active");


### PR DESCRIPTION
## Summary
- `syncFlowToWindmill` was recalculating the Windmill flow path from the workflow name + orgId, producing a path that didn't match the actual stored `windmill_flow_path` in the DB (e.g. `headwater` suffix vs `mintaka`, different orgId prefix)
- This caused the startup sync to update the **wrong flow** in Windmill, so the condition expression fix from PR #141 never took effect on already-deployed workflows like `sales-email-cold-outreach-mintaka`
- Now uses `wf.windmillFlowPath` directly as the source of truth

## Test plan
- [x] Updated existing `startup-validator.test.ts` to verify sync uses exact stored path
- [x] All 434 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)