### PR TITLE
fix: use aggregated costs endpoint and dynasty chain for stats

### DIFF
--- a/src/lib/stats-client.ts
+++ b/src/lib/stats-client.ts
@@ -47,43 +47,46 @@ export interface EmailStatsResponse {
   broadcast: EmailStats;
 }
 
-// --- Fetch run costs from runs-service ---
+// --- Fetch aggregated costs from runs-service (auth) ---
 
-export async function fetchRunCosts(runIds: string[], identity: IdentityHeaders): Promise<RunCost[]> {
-  if (runIds.length === 0) return [];
-
+export async function fetchRunCostsAuth(
+  identity: IdentityHeaders,
+): Promise<WorkflowNameCost[]> {
   const { baseUrl, apiKey } = getRunsServiceConfig();
-  const costs: RunCost[] = [];
+  const params = new URLSearchParams({ groupBy: "workflowName" });
 
-  await Promise.all(
-    runIds.map(async (runId) => {
-      const res = await fetch(`${baseUrl}/v1/runs/${runId}`, {
-        method: "GET",
-        headers: {
-          "x-api-key": apiKey,
-          "x-org-id": identity.orgId,
-          "x-user-id": identity.userId,
-          "x-run-id": identity.runId,
-        },
-      });
-      if (!res.ok) {
-        console.warn(
-          `[stats-client] Failed to fetch run ${runId}: ${res.status}`
-        );
-        return;
-      }
-      const body = (await res.json()) as {
-        id: string;
-        totalCostInUsdCents: string;
-      };
-      costs.push({
-        runId: body.id,
-        totalCostInUsdCents: Number(body.totalCostInUsdCents) || 0,
-      });
-    })
-  );
+  const res = await fetch(`${baseUrl}/v1/stats/costs?${params}`, {
+    method: "GET",
+    headers: {
+      "x-api-key": apiKey,
+      "x-org-id": identity.orgId,
+      "x-user-id": identity.userId,
+      "x-run-id": identity.runId,
+    },
+  });
 
-  return costs;
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `runs-service error: GET /v1/stats/costs -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  const body = (await res.json()) as {
+    groups: Array<{
+      dimensions: Record<string, string | null>;
+      totalCostInUsdCents: string;
+      runCount: number;
+    }>;
+  };
+
+  return body.groups
+    .filter((g) => g.dimensions.workflowName != null)
+    .map((g) => ({
+      workflowName: g.dimensions.workflowName!,
+      totalCostInUsdCents: Number(g.totalCostInUsdCents) || 0,
+      runCount: g.runCount,
+    }));
 }
 
 // --- Public: fetch aggregated costs from runs-service (no identity) ---

--- a/src/lib/workflow-scoring.ts
+++ b/src/lib/workflow-scoring.ts
@@ -1,7 +1,7 @@
 import { eq, and, inArray } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { workflows, workflowRuns } from "../db/schema.js";
-import { fetchRunCosts, fetchEmailStats, fetchRunCostsPublic, fetchEmailStatsPublic } from "./stats-client.js";
+import { fetchRunCostsAuth, fetchEmailStats, fetchRunCostsPublic, fetchEmailStatsPublic } from "./stats-client.js";
 import type { IdentityHeaders } from "./key-service-client.js";
 
 export const EMPTY_EMAIL_STATS = {
@@ -67,11 +67,8 @@ export async function computeWorkflowScores(
   objective: "replies" | "clicks",
   mode: ScoreMode,
 ): Promise<ScoreResult> {
-  // 1. For each active workflow, get completed runs across entire upgrade chain
-  const workflowRunsByWfId: Record<string, string[]> = {};
+  // 1. Build dynasty chains: for each active workflow, collect all workflow names in its upgrade chain
   const chainWorkflowsById: Record<string, (typeof workflows.$inferSelect)[]> = {};
-  const allRunIds: string[] = [];
-  const runBrandMap = new Map<string, string>();
 
   for (const wf of activeWorkflows) {
     const chainIds = getUpgradeChainIds(wf.id, deprecatedWorkflows);
@@ -79,70 +76,49 @@ export async function computeWorkflowScores(
       wf,
       ...deprecatedWorkflows.filter((d) => chainIds.includes(d.id) && d.id !== wf.id),
     ];
+  }
 
+  // 2. Fetch costs aggregated by workflowName (no double-counting, no per-run calls)
+  const costGroups =
+    mode.kind === "auth"
+      ? await fetchRunCostsAuth(mode.identity)
+      : await fetchRunCostsPublic({ brandId: mode.brandId, orgId: mode.orgId });
+
+  const costByName = new Map(costGroups.map((g) => [g.workflowName, g.totalCostInUsdCents]));
+
+  // 3. For each active workflow, aggregate costs across the dynasty chain + get run IDs for email stats
+  const workflowRunsByWfId: Record<string, string[]> = {};
+  const costByWorkflowId = new Map<string, number>();
+  const runBrandMap = new Map<string, string>();
+
+  for (const wf of activeWorkflows) {
+    const chainWfs = chainWorkflowsById[wf.id] ?? [];
+    const chainIds = chainWfs.map((w) => w.id);
+    const chainNames = new Set(chainWfs.map((w) => w.name));
+
+    // Costs: aggregate across all dynasty workflow names
+    let totalCost = 0;
+    for (const name of chainNames) {
+      totalCost += costByName.get(name) ?? 0;
+    }
+    costByWorkflowId.set(wf.id, totalCost);
+
+    // Run IDs for email stats: from local workflow_runs table
+    // TODO: replace with email-gateway workflowName filter once available
     const runs = chainIds.length === 1
-      ? await db
-          .select()
-          .from(workflowRuns)
-          .where(
-            and(
-              eq(workflowRuns.workflowId, chainIds[0]),
-              eq(workflowRuns.status, "completed"),
-            )
-          )
-      : await db
-          .select()
-          .from(workflowRuns)
-          .where(
-            and(
-              inArray(workflowRuns.workflowId, chainIds),
-              eq(workflowRuns.status, "completed"),
-            )
-          );
-
-    const runIds: string[] = [];
+      ? await db.select().from(workflowRuns).where(
+          and(eq(workflowRuns.workflowId, chainIds[0]), eq(workflowRuns.status, "completed")))
+      : await db.select().from(workflowRuns).where(
+          and(inArray(workflowRuns.workflowId, chainIds), eq(workflowRuns.status, "completed")));
+    const runIds = runs.filter((r) => r.runId).map((r) => r.runId!);
     for (const r of runs) {
-      if (!r.runId) continue;
-      runIds.push(r.runId);
-      if (r.brandId) runBrandMap.set(r.runId, r.brandId);
+      if (r.runId && r.brandId) runBrandMap.set(r.runId, r.brandId);
     }
 
     workflowRunsByWfId[wf.id] = runIds;
-    allRunIds.push(...runIds);
   }
 
-  // 2. Fetch costs (different strategy per mode)
-  const costByRunId = new Map<string, number>();
-  const costByWorkflowId = new Map<string, number>();
-
-  if (allRunIds.length > 0) {
-    if (mode.kind === "auth") {
-      const runCosts = await fetchRunCosts(allRunIds, mode.identity);
-      for (const c of runCosts) {
-        costByRunId.set(c.runId, c.totalCostInUsdCents);
-      }
-    } else {
-      // Public: fetch costs aggregated by workflowName from runs-service
-      const costGroups = await fetchRunCostsPublic({
-        brandId: mode.brandId,
-        orgId: mode.orgId,
-      });
-      const costByName = new Map(costGroups.map((g) => [g.workflowName, g.totalCostInUsdCents]));
-
-      // Map aggregated costs to each active workflow via its upgrade chain names
-      for (const wf of activeWorkflows) {
-        const chainWfs = chainWorkflowsById[wf.id] ?? [];
-        const chainNames = new Set(chainWfs.map((w) => w.name));
-        let total = 0;
-        for (const name of chainNames) {
-          total += costByName.get(name) ?? 0;
-        }
-        costByWorkflowId.set(wf.id, total);
-      }
-    }
-  }
-
-  // 3. Per-workflow: compute cost + fetch email stats
+  // 4. Per-workflow: fetch email stats and compute outcomes
   const scores: WorkflowScore[] = [];
 
   for (const wf of activeWorkflows) {
@@ -160,9 +136,7 @@ export async function computeWorkflowScores(
       continue;
     }
 
-    const totalCost = mode.kind === "auth"
-      ? runIds.reduce((sum, id) => sum + (costByRunId.get(id) ?? 0), 0)
-      : costByWorkflowId.get(wf.id) ?? 0;
+    const totalCost = costByWorkflowId.get(wf.id) ?? 0;
 
     const stats = mode.kind === "auth"
       ? await fetchEmailStats(runIds, mode.identity)

--- a/tests/integration/best-workflow.test.ts
+++ b/tests/integration/best-workflow.test.ts
@@ -5,6 +5,30 @@ import { VALID_LINEAR_DAG } from "../helpers/fixtures.js";
 const mockWorkflowRows: Record<string, unknown>[] = [];
 const mockWorkflowRunRows: Record<string, unknown>[] = [];
 
+// Track the last queried workflow IDs so mock .where() can filter workflow_runs
+let lastQueriedWorkflowIds: string[] | null = null;
+
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    eq: (...args: unknown[]) => {
+      // eq(workflowRuns.workflowId, id) — capture the single ID (skip status strings like "completed")
+      if (args.length === 2 && typeof args[1] === "string" && args[1].startsWith("wf-")) {
+        lastQueriedWorkflowIds = [args[1]];
+      }
+      return (actual.eq as Function)(...args);
+    },
+    inArray: (...args: unknown[]) => {
+      // inArray(workflowRuns.workflowId, ids) — capture the array
+      if (args.length === 2 && Array.isArray(args[1]) && args[1].length > 0 && typeof args[1][0] === "string" && args[1][0].startsWith("wf-")) {
+        lastQueriedWorkflowIds = args[1] as string[];
+      }
+      return (actual.inArray as Function)(...args);
+    },
+  };
+});
+
 vi.mock("../../src/db/index.js", () => ({
   db: {
     insert: () => ({
@@ -29,7 +53,22 @@ vi.mock("../../src/db/index.js", () => ({
           typeof table === "object" &&
           "workflowId" in (table as Record<string, unknown>);
 
-        const rows = isWorkflowRuns ? mockWorkflowRunRows : mockWorkflowRows;
+        if (isWorkflowRuns) {
+          const result = Promise.resolve(mockWorkflowRunRows);
+          (result as any).where = (_condition?: unknown) => {
+            const ids = lastQueriedWorkflowIds;
+            lastQueriedWorkflowIds = null;
+            if (ids) {
+              return Promise.resolve(
+                mockWorkflowRunRows.filter((r) => ids.includes(r.workflowId as string))
+              );
+            }
+            return Promise.resolve(mockWorkflowRunRows);
+          };
+          return result;
+        }
+
+        const rows = mockWorkflowRows;
         const result = Promise.resolve(rows);
         (result as any).where = (_condition?: unknown) => Promise.resolve(rows);
         return result;
@@ -56,11 +95,11 @@ vi.mock("../../src/db/index.js", () => ({
 }));
 
 // --- Mock stats-client ---
-const mockFetchRunCosts = vi.fn();
+const mockFetchRunCostsAuth = vi.fn();
 const mockFetchEmailStats = vi.fn();
 
 vi.mock("../../src/lib/stats-client.js", () => ({
-  fetchRunCosts: (...args: unknown[]) => mockFetchRunCosts(...args),
+  fetchRunCostsAuth: (...args: unknown[]) => mockFetchRunCostsAuth(...args),
   fetchEmailStats: (...args: unknown[]) => mockFetchEmailStats(...args),
 }));
 
@@ -98,11 +137,13 @@ const BASE_QUERY = {
   objective: "replies",
 };
 
+const DEFAULT_WF_NAME = "sales-email-cold-outreach-alpha";
+
 function makeWorkflow(overrides: Record<string, unknown> = {}) {
   return {
     id: "wf-" + Math.random().toString(36).slice(2, 10),
     orgId: "org1",
-    name: "sales-email-cold-outreach-alpha",
+    name: DEFAULT_WF_NAME,
     displayName: null,
     createdForBrandId: null,
     description: null,
@@ -121,6 +162,17 @@ function makeWorkflow(overrides: Record<string, unknown> = {}) {
     ...overrides,
   };
 }
+
+const EMPTY_STATS = {
+  sent: 0,
+  delivered: 0,
+  opened: 0,
+  clicked: 0,
+  replied: 0,
+  bounced: 0,
+  unsubscribed: 0,
+  recipients: 0,
+};
 
 function makeRun(workflowId: string, runId: string, brandId?: string | null) {
   return {
@@ -143,16 +195,16 @@ function makeRun(workflowId: string, runId: string, brandId?: string | null) {
   };
 }
 
-const EMPTY_STATS = {
-  sent: 0,
-  delivered: 0,
-  opened: 0,
-  clicked: 0,
-  replied: 0,
-  bounced: 0,
-  unsubscribed: 0,
-  recipients: 0,
-};
+// Helper: setup cost mocks from runs-service
+function setupCostsMock(costsByName: Record<string, { cost: number; runCount: number }>) {
+  mockFetchRunCostsAuth.mockResolvedValue(
+    Object.entries(costsByName).map(([workflowName, { cost, runCount }]) => ({
+      workflowName,
+      totalCostInUsdCents: cost,
+      runCount,
+    }))
+  );
+}
 
 // ==================== GET /workflows/ranked ====================
 
@@ -160,31 +212,22 @@ describe("GET /workflows/ranked", () => {
   beforeEach(() => {
     mockWorkflowRows.length = 0;
     mockWorkflowRunRows.length = 0;
-    mockFetchRunCosts.mockReset();
+    mockFetchRunCostsAuth.mockReset();
     mockFetchEmailStats.mockReset();
   });
 
   it("returns ranked workflows with stats", async () => {
     const wf = makeWorkflow({ id: "wf-a" });
     mockWorkflowRows.push(wf);
-    mockWorkflowRunRows.push(
-      makeRun("wf-a", "ext-run-1"),
-      makeRun("wf-a", "ext-run-2"),
-    );
+    mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-1"), makeRun("wf-a", "ext-run-2"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 100 },
-      { runId: "ext-run-2", totalCostInUsdCents: 200 },
-    ]);
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 300, runCount: 2 } });
     mockFetchEmailStats.mockResolvedValue({
       transactional: { ...EMPTY_STATS, replied: 10 },
       broadcast: { ...EMPTY_STATS },
     });
 
-    const res = await request
-      .get("/workflows/ranked")
-      .query(BASE_QUERY)
-      .set(AUTH);
+    const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
 
     expect(res.status).toBe(200);
     expect(res.body.results).toHaveLength(1);
@@ -200,35 +243,24 @@ describe("GET /workflows/ranked", () => {
   });
 
   it("uses clicks objective when specified", async () => {
-    const wf = makeWorkflow({ id: "wf-a" });
-    mockWorkflowRows.push(wf);
+    mockWorkflowRows.push(makeWorkflow({ id: "wf-a" }));
     mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-1"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 500 },
-    ]);
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 500, runCount: 1 } });
     mockFetchEmailStats.mockResolvedValue({
       transactional: { ...EMPTY_STATS, clicked: 25 },
       broadcast: { ...EMPTY_STATS, clicked: 25 },
     });
 
-    const res = await request
-      .get("/workflows/ranked")
-      .query({ ...BASE_QUERY, objective: "clicks" })
-      .set(AUTH);
+    const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, objective: "clicks" }).set(AUTH);
 
     expect(res.status).toBe(200);
-    const best = res.body.results[0];
-    expect(best.stats.totalOutcomes).toBe(50);
-    expect(best.stats.costPerOutcome).toBe(10);
+    expect(res.body.results[0].stats.totalOutcomes).toBe(50);
+    expect(res.body.results[0].stats.costPerOutcome).toBe(10);
   });
 
   it("returns 404 when no workflows match", async () => {
-    const res = await request
-      .get("/workflows/ranked")
-      .query(BASE_QUERY)
-      .set(AUTH);
-
+    const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(404);
     expect(res.body.error).toMatch(/No workflows found/);
   });
@@ -237,30 +269,18 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRows.push(makeWorkflow({ id: "wf-a" }));
     mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-1"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 100 },
-    ]);
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
     mockFetchEmailStats.mockRejectedValue(
-      new Error(
-        "email-gateway-service error: POST /stats -> 500 Internal Server Error: boom"
-      )
+      new Error("email-gateway-service error: POST /stats -> 500 Internal Server Error: boom")
     );
 
-    const res = await request
-      .get("/workflows/ranked")
-      .query(BASE_QUERY)
-      .set(AUTH);
-
+    const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(502);
     expect(res.body.error).toMatch(/email-gateway-service error/);
   });
 
   it("requires authentication", async () => {
-    const res = await request
-      .get("/workflows/ranked")
-      .set(IDENTITY)
-      .query(BASE_QUERY);
-
+    const res = await request.get("/workflows/ranked").set(IDENTITY).query(BASE_QUERY);
     expect(res.status).toBe(401);
   });
 
@@ -268,48 +288,27 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRows.push(makeWorkflow({ id: "wf-a" }));
     mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-1"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 100 },
-    ]);
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS },
-      broadcast: { ...EMPTY_STATS },
-    });
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
+    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS }, broadcast: { ...EMPTY_STATS } });
 
-    const res = await request
-      .get("/workflows/ranked")
-      .query(BASE_QUERY)
-      .set(AUTH);
-
+    const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(200);
     expect(res.body.results[0].stats.costPerOutcome).toBeNull();
     expect(res.body.results[0].stats.completedRuns).toBe(1);
   });
 
   it("includes runs from deprecated predecessor in stats", async () => {
+    const wfOldName = "sales-email-cold-outreach-old";
     mockWorkflowRows.push(
       makeWorkflow({ id: "wf-active" }),
-      makeWorkflow({ id: "wf-old", status: "deprecated", upgradedTo: "wf-active" }),
+      makeWorkflow({ id: "wf-old", name: wfOldName, status: "deprecated", upgradedTo: "wf-active" }),
     );
-    mockWorkflowRunRows.push(
-      makeRun("wf-active", "ext-run-active"),
-      makeRun("wf-old", "ext-run-old"),
-    );
+    mockWorkflowRunRows.push(makeRun("wf-active", "ext-run-active"), makeRun("wf-old", "ext-run-old"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-active", totalCostInUsdCents: 100 },
-      { runId: "ext-run-old", totalCostInUsdCents: 200 },
-    ]);
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 10 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, [wfOldName]: { cost: 200, runCount: 1 } });
+    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 10 }, broadcast: { ...EMPTY_STATS } });
 
-    const res = await request
-      .get("/workflows/ranked")
-      .query(BASE_QUERY)
-      .set(AUTH);
-
+    const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(200);
     expect(res.body.results[0].workflow.id).toBe("wf-active");
     expect(res.body.results[0].stats.totalCostInUsdCents).toBe(300);
@@ -317,32 +316,19 @@ describe("GET /workflows/ranked", () => {
   });
 
   it("aggregates across deep upgrade chain (3 levels)", async () => {
+    const nameV2 = "sales-email-cold-outreach-v2";
+    const nameV1 = "sales-email-cold-outreach-v1";
     mockWorkflowRows.push(
       makeWorkflow({ id: "wf-v3" }),
-      makeWorkflow({ id: "wf-v2", status: "deprecated", upgradedTo: "wf-v3" }),
-      makeWorkflow({ id: "wf-v1", status: "deprecated", upgradedTo: "wf-v2" }),
+      makeWorkflow({ id: "wf-v2", name: nameV2, status: "deprecated", upgradedTo: "wf-v3" }),
+      makeWorkflow({ id: "wf-v1", name: nameV1, status: "deprecated", upgradedTo: "wf-v2" }),
     );
-    mockWorkflowRunRows.push(
-      makeRun("wf-v3", "ext-run-v3"),
-      makeRun("wf-v2", "ext-run-v2"),
-      makeRun("wf-v1", "ext-run-v1"),
-    );
+    mockWorkflowRunRows.push(makeRun("wf-v3", "ext-run-v3"), makeRun("wf-v2", "ext-run-v2"), makeRun("wf-v1", "ext-run-v1"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-v3", totalCostInUsdCents: 50 },
-      { runId: "ext-run-v2", totalCostInUsdCents: 100 },
-      { runId: "ext-run-v1", totalCostInUsdCents: 150 },
-    ]);
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 15 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 50, runCount: 1 }, [nameV2]: { cost: 100, runCount: 1 }, [nameV1]: { cost: 150, runCount: 1 } });
+    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 15 }, broadcast: { ...EMPTY_STATS } });
 
-    const res = await request
-      .get("/workflows/ranked")
-      .query(BASE_QUERY)
-      .set(AUTH);
-
+    const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(200);
     expect(res.body.results[0].workflow.id).toBe("wf-v3");
     expect(res.body.results[0].stats.totalCostInUsdCents).toBe(300);
@@ -350,208 +336,125 @@ describe("GET /workflows/ranked", () => {
   });
 
   it("returns multiple workflows ranked when limit > 1", async () => {
-    const wfA = makeWorkflow({ id: "wf-a", signatureName: "alpha" });
-    const wfB = makeWorkflow({ id: "wf-b", signatureName: "beta" });
-    const wfC = makeWorkflow({ id: "wf-c", signatureName: "gamma" });
-    mockWorkflowRows.push(wfA, wfB, wfC);
-    mockWorkflowRunRows.push(
-      makeRun("wf-a", "ext-run-a"),
-      makeRun("wf-b", "ext-run-b"),
-      makeRun("wf-c", "ext-run-c"),
+    const nameA = "sales-email-cold-outreach-alpha";
+    const nameB = "sales-email-cold-outreach-beta";
+    const nameC = "sales-email-cold-outreach-gamma";
+    mockWorkflowRows.push(
+      makeWorkflow({ id: "wf-a", name: nameA, signatureName: "alpha" }),
+      makeWorkflow({ id: "wf-b", name: nameB, signatureName: "beta" }),
+      makeWorkflow({ id: "wf-c", name: nameC, signatureName: "gamma" }),
     );
+    mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-a"), makeRun("wf-b", "ext-run-b"), makeRun("wf-c", "ext-run-c"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-a", totalCostInUsdCents: 100 },
-      { runId: "ext-run-b", totalCostInUsdCents: 200 },
-      { runId: "ext-run-c", totalCostInUsdCents: 50 },
-    ]);
+    setupCostsMock({ [nameA]: { cost: 100, runCount: 1 }, [nameB]: { cost: 200, runCount: 1 }, [nameC]: { cost: 50, runCount: 1 } });
     mockFetchEmailStats
       .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, replied: 10 }, broadcast: { ...EMPTY_STATS } })
       .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, replied: 5 }, broadcast: { ...EMPTY_STATS } })
       .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, replied: 25 }, broadcast: { ...EMPTY_STATS } });
 
-    const res = await request
-      .get("/workflows/ranked")
-      .query({ ...BASE_QUERY, limit: "3" })
-      .set(AUTH);
-
+    const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, limit: "3" }).set(AUTH);
     expect(res.status).toBe(200);
     expect(res.body.results).toHaveLength(3);
-    // Sorted by costPerOutcome: wf-c (2), wf-a (10), wf-b (40)
     expect(res.body.results[0].workflow.id).toBe("wf-c");
     expect(res.body.results[1].workflow.id).toBe("wf-a");
     expect(res.body.results[2].workflow.id).toBe("wf-b");
   });
 
   it("includes displayName and createdForBrandId in workflow response", async () => {
-    const wf = makeWorkflow({ id: "wf-dn", displayName: "sales-email-cold-outreach-jasmine", createdForBrandId: "brand-123" });
-    mockWorkflowRows.push(wf);
+    mockWorkflowRows.push(makeWorkflow({ id: "wf-dn", displayName: "sales-email-cold-outreach-jasmine", createdForBrandId: "brand-123" }));
     mockWorkflowRunRows.push(makeRun("wf-dn", "ext-run-dn"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-dn", totalCostInUsdCents: 100 },
-    ]);
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
+    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 5 }, broadcast: { ...EMPTY_STATS } });
 
-    const res = await request
-      .get("/workflows/ranked")
-      .query(BASE_QUERY)
-      .set(AUTH);
-
+    const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(200);
     expect(res.body.results[0].workflow.displayName).toBe("sales-email-cold-outreach-jasmine");
     expect(res.body.results[0].workflow.createdForBrandId).toBe("brand-123");
   });
 
   it("respects limit to cap results", async () => {
+    const costs: Record<string, { cost: number; runCount: number }> = {};
     for (let i = 0; i < 5; i++) {
-      mockWorkflowRows.push(makeWorkflow({ id: `wf-${i}` }));
+      const name = `sales-email-cold-outreach-wf${i}`;
+      mockWorkflowRows.push(makeWorkflow({ id: `wf-${i}`, name }));
       mockWorkflowRunRows.push(makeRun(`wf-${i}`, `ext-run-${i}`));
+      costs[name] = { cost: 100, runCount: 1 };
     }
 
-    mockFetchRunCosts.mockResolvedValue(
-      Array.from({ length: 5 }, (_, i) => ({ runId: `ext-run-${i}`, totalCostInUsdCents: 100 }))
-    );
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    setupCostsMock(costs);
+    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 5 }, broadcast: { ...EMPTY_STATS } });
 
-    const res = await request
-      .get("/workflows/ranked")
-      .query({ ...BASE_QUERY, limit: "2" })
-      .set(AUTH);
-
+    const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, limit: "2" }).set(AUTH);
     expect(res.status).toBe(200);
     expect(res.body.results).toHaveLength(2);
   });
 
   it("filters by brandId from runs", async () => {
-    // brandId filter now uses workflow_run.brandId, not workflow.brandId
-    // Note: mock DB returns all runs for all workflows, so both workflows see all runs
-    // This test verifies the endpoint accepts brandId and filters by run brandId
-    const wf1 = makeWorkflow({ id: "wf-1" });
-    mockWorkflowRows.push(wf1);
-    mockWorkflowRunRows.push(
-      makeRun("wf-1", "ext-run-1", "brand-1"),
-    );
+    mockWorkflowRows.push(makeWorkflow({ id: "wf-1", createdForBrandId: "brand-1" }));
+    mockWorkflowRunRows.push(makeRun("wf-1", "ext-run-1", "brand-1"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 100 },
-    ]);
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
+    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 5 }, broadcast: { ...EMPTY_STATS } });
 
-    const res = await request
-      .get("/workflows/ranked")
-      .query({ ...BASE_QUERY, brandId: "brand-1" })
-      .set(AUTH);
-
+    const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, brandId: "brand-1" }).set(AUTH);
     expect(res.status).toBe(200);
     expect(res.body.results).toHaveLength(1);
   });
 
   it("returns grouped brands with groupBy=brand (from runs)", async () => {
-    // Mock DB returns all runs for all workflows, so each workflow sees all runs/brands
-    // With 1 workflow and 2 runs for different brands, we get 2 brand groups each with 1 workflow
-    const wf1 = makeWorkflow({ id: "wf-1" });
-    mockWorkflowRows.push(wf1);
-    mockWorkflowRunRows.push(
-      makeRun("wf-1", "ext-run-1", "brand-A"),
-      makeRun("wf-1", "ext-run-2", "brand-B"),
+    mockWorkflowRows.push(
+      makeWorkflow({ id: "wf-1", createdForBrandId: "brand-A" }),
+      makeWorkflow({ id: "wf-2", name: "sales-email-cold-outreach-beta", createdForBrandId: "brand-B" }),
     );
+    mockWorkflowRunRows.push(makeRun("wf-1", "ext-run-1", "brand-A"), makeRun("wf-2", "ext-run-2", "brand-B"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 100 },
-      { runId: "ext-run-2", totalCostInUsdCents: 200 },
-    ]);
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, "sales-email-cold-outreach-beta": { cost: 200, runCount: 1 } });
+    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 5 }, broadcast: { ...EMPTY_STATS } });
 
-    const res = await request
-      .get("/workflows/ranked")
-      .query({ ...BASE_QUERY, groupBy: "brand" })
-      .set(AUTH);
-
+    const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, groupBy: "brand" }).set(AUTH);
     expect(res.status).toBe(200);
     expect(res.body.brands).toBeDefined();
     expect(res.body.brands).toHaveLength(2);
-
     const brandA = res.body.brands.find((b: { brandId: string }) => b.brandId === "brand-A");
     const brandB = res.body.brands.find((b: { brandId: string }) => b.brandId === "brand-B");
     expect(brandA).toBeDefined();
     expect(brandA.workflows).toHaveLength(1);
-    expect(brandA.stats).toBeDefined();
     expect(brandB).toBeDefined();
     expect(brandB.workflows).toHaveLength(1);
   });
 
   it("excludes runs without brandId when groupBy=brand", async () => {
-    const wfBranded = makeWorkflow({ id: "wf-branded" });
-    const wfNoBrand = makeWorkflow({ id: "wf-no-brand" });
-    mockWorkflowRows.push(wfBranded, wfNoBrand);
-    mockWorkflowRunRows.push(
-      makeRun("wf-branded", "ext-run-1", "brand-X"),
-      makeRun("wf-no-brand", "ext-run-2"), // no brandId on run
+    mockWorkflowRows.push(
+      makeWorkflow({ id: "wf-branded", createdForBrandId: "brand-X" }),
+      makeWorkflow({ id: "wf-no-brand", name: "sales-email-cold-outreach-nobrand" }),
     );
+    mockWorkflowRunRows.push(makeRun("wf-branded", "ext-run-1", "brand-X"), makeRun("wf-no-brand", "ext-run-2"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 100 },
-      { runId: "ext-run-2", totalCostInUsdCents: 200 },
-    ]);
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, "sales-email-cold-outreach-nobrand": { cost: 200, runCount: 1 } });
+    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 5 }, broadcast: { ...EMPTY_STATS } });
 
-    const res = await request
-      .get("/workflows/ranked")
-      .query({ ...BASE_QUERY, groupBy: "brand" })
-      .set(AUTH);
-
+    const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, groupBy: "brand" }).set(AUTH);
     expect(res.status).toBe(200);
     expect(res.body.brands).toHaveLength(1);
     expect(res.body.brands[0].brandId).toBe("brand-X");
   });
 
   it("returns grouped sections with groupBy=section", async () => {
-    const wfSales = makeWorkflow({ id: "wf-sales", category: "sales", channel: "email", audienceType: "cold-outreach" });
-    const wfSales2 = makeWorkflow({ id: "wf-sales2", category: "sales", channel: "email", audienceType: "cold-outreach" });
-    mockWorkflowRows.push(wfSales, wfSales2);
-    mockWorkflowRunRows.push(
-      makeRun("wf-sales", "ext-run-s1"),
-      makeRun("wf-sales2", "ext-run-s2"),
-    );
+    const nameS1 = "sales-email-cold-outreach-s1";
+    const nameS2 = "sales-email-cold-outreach-s2";
+    mockWorkflowRows.push(makeWorkflow({ id: "wf-sales", name: nameS1 }), makeWorkflow({ id: "wf-sales2", name: nameS2 }));
+    mockWorkflowRunRows.push(makeRun("wf-sales", "ext-run-s1"), makeRun("wf-sales2", "ext-run-s2"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-s1", totalCostInUsdCents: 100 },
-      { runId: "ext-run-s2", totalCostInUsdCents: 200 },
-    ]);
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 5, sent: 50, opened: 20 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    setupCostsMock({ [nameS1]: { cost: 100, runCount: 1 }, [nameS2]: { cost: 200, runCount: 1 } });
+    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 5, sent: 50, opened: 20 }, broadcast: { ...EMPTY_STATS } });
 
-    const res = await request
-      .get("/workflows/ranked")
-      .query({ ...BASE_QUERY, groupBy: "section" })
-      .set(AUTH);
-
+    const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, groupBy: "section" }).set(AUTH);
     expect(res.status).toBe(200);
     expect(res.body.sections).toBeDefined();
     expect(res.body.sections).toHaveLength(1);
     const section = res.body.sections[0];
     expect(section.sectionKey).toBe("sales-email-cold-outreach");
-    expect(section.category).toBe("sales");
-    expect(section.channel).toBe("email");
-    expect(section.audienceType).toBe("cold-outreach");
     expect(section.stats).toBeDefined();
     expect(section.stats.email).toBeDefined();
     expect(section.workflows).toHaveLength(2);
@@ -564,7 +467,7 @@ describe("GET /workflows/best (hero records)", () => {
   beforeEach(() => {
     mockWorkflowRows.length = 0;
     mockWorkflowRunRows.length = 0;
-    mockFetchRunCosts.mockReset();
+    mockFetchRunCostsAuth.mockReset();
     mockFetchEmailStats.mockReset();
   });
 
@@ -573,9 +476,7 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-hero", "ext-run-hero"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-hero", totalCostInUsdCents: 100 },
-    ]);
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
     mockFetchEmailStats.mockResolvedValue({
       transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
       broadcast: { ...EMPTY_STATS },
@@ -600,9 +501,7 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-no-outcomes", "ext-run-no"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-no", totalCostInUsdCents: 100 },
-    ]);
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
     mockFetchEmailStats.mockResolvedValue({
       transactional: { ...EMPTY_STATS },
       broadcast: { ...EMPTY_STATS },
@@ -638,9 +537,7 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-dn-hero", "ext-run-dn"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-dn", totalCostInUsdCents: 100 },
-    ]);
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
     mockFetchEmailStats.mockResolvedValue({
       transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
       broadcast: { ...EMPTY_STATS },
@@ -657,16 +554,11 @@ describe("GET /workflows/best (hero records)", () => {
 
   it("filters by brandId", async () => {
     const wf1 = makeWorkflow({ id: "wf-b1", createdForBrandId: "brand-target" });
-    const wf2 = makeWorkflow({ id: "wf-b2", createdForBrandId: "brand-other" });
+    const wf2 = makeWorkflow({ id: "wf-b2", name: "sales-email-cold-outreach-other", createdForBrandId: "brand-other" });
     mockWorkflowRows.push(wf1, wf2);
-    mockWorkflowRunRows.push(
-      makeRun("wf-b1", "ext-run-b1"),
-      makeRun("wf-b2", "ext-run-b2"),
-    );
+    mockWorkflowRunRows.push(makeRun("wf-b1", "ext-run-b1", "brand-target"), makeRun("wf-b2", "ext-run-b2", "brand-other"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-b1", totalCostInUsdCents: 100 },
-    ]);
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, "sales-email-cold-outreach-other": { cost: 200, runCount: 1 } });
     mockFetchEmailStats.mockResolvedValue({
       transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
       broadcast: { ...EMPTY_STATS },
@@ -682,26 +574,11 @@ describe("GET /workflows/best (hero records)", () => {
   });
 
   it("returns best brand with by=brand", async () => {
-    // Two brands: brand-A (2 workflows) and brand-B (1 workflow)
-    // The mock DB returns all runs for all workflows — each workflow sees all 3 run IDs.
-    // fetchRunCosts returns costs for all runs, so each workflow gets totalCost = 600.
-    // We use mockFetchEmailStats per-workflow to differentiate brands.
-    // Mock DB returns all runs for all workflows — so use 1 workflow with runs for 2 brands
-    const wf1 = makeWorkflow({ id: "wf-1" });
+    const wf1 = makeWorkflow({ id: "wf-1", createdForBrandId: "brand-A" });
     mockWorkflowRows.push(wf1);
-    mockWorkflowRunRows.push(
-      makeRun("wf-1", "ext-run-a", "brand-A"),
-      makeRun("wf-1", "ext-run-b", "brand-B"),
-    );
+    mockWorkflowRunRows.push(makeRun("wf-1", "ext-run-a", "brand-A"), makeRun("wf-1", "ext-run-b", "brand-A"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-a", totalCostInUsdCents: 100 },
-      { runId: "ext-run-b", totalCostInUsdCents: 500 },
-    ]);
-    // wf-1 sees both runs → totalCost = 600, opened = 20, replied = 10
-    // brand-A: 1 workflow, cost 600, 20 opens → 30/open, 10 replies → 60/reply
-    // brand-B: 1 workflow, cost 600, 20 opens → 30/open, 10 replies → 60/reply
-    // Both brands have same stats since workflow-level stats are the same
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 600, runCount: 2 } });
     mockFetchEmailStats
       .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 20, replied: 10 }, broadcast: { ...EMPTY_STATS } });
 
@@ -723,9 +600,7 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-no-brand", "ext-run-nb"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-nb", totalCostInUsdCents: 100 },
-    ]);
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
     mockFetchEmailStats.mockResolvedValue({
       transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
       broadcast: { ...EMPTY_STATS },
@@ -742,21 +617,14 @@ describe("GET /workflows/best (hero records)", () => {
   });
 
   it("picks the best from multiple workflows", async () => {
-    // Mock DB returns all runs for all workflows, so both workflows see the same runs.
-    // To test ranking, we use different mockFetchEmailStats responses per workflow call.
-    // wf-expensive gets called first (higher cost-per-outcome), wf-cheap second (lower).
-    const wfExpensive = makeWorkflow({ id: "wf-expensive" });
-    const wfCheap = makeWorkflow({ id: "wf-cheap" });
+    const nameExp = "sales-email-cold-outreach-expensive";
+    const nameCheap = "sales-email-cold-outreach-cheap";
+    const wfExpensive = makeWorkflow({ id: "wf-expensive", name: nameExp });
+    const wfCheap = makeWorkflow({ id: "wf-cheap", name: nameCheap });
     mockWorkflowRows.push(wfExpensive, wfCheap);
-    mockWorkflowRunRows.push(
-      makeRun("wf-expensive", "ext-run-1"),
-      makeRun("wf-cheap", "ext-run-2"),
-    );
+    mockWorkflowRunRows.push(makeRun("wf-expensive", "ext-run-1"), makeRun("wf-cheap", "ext-run-2"));
 
-    mockFetchRunCosts.mockResolvedValue([
-      { runId: "ext-run-1", totalCostInUsdCents: 500 },
-      { runId: "ext-run-2", totalCostInUsdCents: 500 },
-    ]);
+    setupCostsMock({ [nameExp]: { cost: 500, runCount: 1 }, [nameCheap]: { cost: 500, runCount: 1 } });
     // First call (wf-expensive): low opens/replies → high cost-per
     mockFetchEmailStats
       .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 2, replied: 1 }, broadcast: { ...EMPTY_STATS } })
@@ -768,7 +636,7 @@ describe("GET /workflows/best (hero records)", () => {
       .set(AUTH);
 
     expect(res.status).toBe(200);
-    // wf-cheap has lower cost-per-open (1000/100=10 vs 1000/2=500) and cost-per-reply
+    // wf-cheap has lower cost-per-open (500/100=5 vs 500/2=250) and cost-per-reply
     expect(res.body.bestCostPerOpen.workflowId).toBe("wf-cheap");
     expect(res.body.bestCostPerReply.workflowId).toBe("wf-cheap");
   });

--- a/tests/integration/public-workflows.test.ts
+++ b/tests/integration/public-workflows.test.ts
@@ -56,13 +56,15 @@ vi.mock("../../src/db/index.js", () => ({
 }));
 
 // --- Mock stats-client ---
-const mockFetchRunCosts = vi.fn();
+const mockFetchRunIdsByWorkflow = vi.fn();
+const mockFetchRunCostsAuth = vi.fn();
 const mockFetchEmailStats = vi.fn();
 const mockFetchRunCostsPublic = vi.fn();
 const mockFetchEmailStatsPublic = vi.fn();
 
 vi.mock("../../src/lib/stats-client.js", () => ({
-  fetchRunCosts: (...args: unknown[]) => mockFetchRunCosts(...args),
+  fetchRunIdsByWorkflow: (...args: unknown[]) => mockFetchRunIdsByWorkflow(...args),
+  fetchRunCostsAuth: (...args: unknown[]) => mockFetchRunCostsAuth(...args),
   fetchEmailStats: (...args: unknown[]) => mockFetchEmailStats(...args),
   fetchRunCostsPublic: (...args: unknown[]) => mockFetchRunCostsPublic(...args),
   fetchEmailStatsPublic: (...args: unknown[]) => mockFetchEmailStatsPublic(...args),
@@ -97,11 +99,13 @@ const EMPTY_STATS = {
   replied: 0, bounced: 0, unsubscribed: 0, recipients: 0,
 };
 
+const DEFAULT_WF_NAME = "sales-email-cold-outreach-alpha";
+
 function makeWorkflow(overrides: Record<string, unknown> = {}) {
   return {
     id: "wf-" + Math.random().toString(36).slice(2, 10),
     orgId: "org1",
-    name: "sales-email-cold-outreach-alpha",
+    name: DEFAULT_WF_NAME,
     displayName: null,
     createdForBrandId: null,
     description: null,
@@ -148,7 +152,8 @@ describe("GET /public/workflows/ranked", () => {
   beforeEach(() => {
     mockWorkflowRows.length = 0;
     mockWorkflowRunRows.length = 0;
-    mockFetchRunCosts.mockReset();
+    mockFetchRunIdsByWorkflow.mockReset();
+    mockFetchRunCostsAuth.mockReset();
     mockFetchEmailStats.mockReset();
     mockFetchRunCostsPublic.mockReset();
     mockFetchEmailStatsPublic.mockReset();
@@ -160,7 +165,7 @@ describe("GET /public/workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-pub", "ext-run-1"));
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 100, runCount: 1 },
+      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, replied: 10 },
@@ -184,7 +189,7 @@ describe("GET /public/workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-nodag", "ext-run-1"));
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 50, runCount: 1 },
+      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 50, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, replied: 5 },
@@ -218,7 +223,8 @@ describe("GET /public/workflows/ranked", () => {
     expect(mockFetchRunCostsPublic).toHaveBeenCalled();
     expect(mockFetchEmailStatsPublic).toHaveBeenCalled();
     // Verify auth functions are NOT called
-    expect(mockFetchRunCosts).not.toHaveBeenCalled();
+    expect(mockFetchRunIdsByWorkflow).not.toHaveBeenCalled();
+    expect(mockFetchRunCostsAuth).not.toHaveBeenCalled();
     expect(mockFetchEmailStats).not.toHaveBeenCalled();
   });
 
@@ -228,7 +234,7 @@ describe("GET /public/workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-sec", "ext-run-1"));
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 100, runCount: 1 },
+      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, replied: 5, sent: 50 },
@@ -255,7 +261,6 @@ describe("GET /public/workflows/ranked", () => {
   });
 
   it("supports groupBy=brand (from runs)", async () => {
-    // Mock DB returns all runs for all workflows, so use 1 workflow with runs for different brands
     const wf1 = makeWorkflow({ id: "wf-1" });
     mockWorkflowRows.push(wf1);
     mockWorkflowRunRows.push(
@@ -264,7 +269,7 @@ describe("GET /public/workflows/ranked", () => {
     );
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 350, runCount: 2 },
+      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 350, runCount: 2 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, replied: 5 },
@@ -282,7 +287,6 @@ describe("GET /public/workflows/ranked", () => {
   });
 
   it("supports brandId filter (from runs)", async () => {
-    // Mock DB returns all runs, so use 1 workflow with a run for brand-y
     const wf1 = makeWorkflow({ id: "wf-filtered" });
     mockWorkflowRows.push(wf1);
     mockWorkflowRunRows.push(
@@ -290,7 +294,7 @@ describe("GET /public/workflows/ranked", () => {
     );
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 100, runCount: 1 },
+      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, replied: 10 },
@@ -312,7 +316,8 @@ describe("GET /public/workflows/best", () => {
   beforeEach(() => {
     mockWorkflowRows.length = 0;
     mockWorkflowRunRows.length = 0;
-    mockFetchRunCosts.mockReset();
+    mockFetchRunIdsByWorkflow.mockReset();
+    mockFetchRunCostsAuth.mockReset();
     mockFetchEmailStats.mockReset();
     mockFetchRunCostsPublic.mockReset();
     mockFetchEmailStatsPublic.mockReset();
@@ -324,7 +329,7 @@ describe("GET /public/workflows/best", () => {
     mockWorkflowRunRows.push(makeRun("wf-hero-pub", "ext-run-hero"));
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 100, runCount: 1 },
+      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
@@ -349,7 +354,7 @@ describe("GET /public/workflows/best", () => {
     mockWorkflowRunRows.push(makeRun("wf-no-out", "ext-run-no"));
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 100, runCount: 1 },
+      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS },
@@ -386,12 +391,12 @@ describe("GET /public/workflows/best", () => {
 
     expect(mockFetchRunCostsPublic).toHaveBeenCalled();
     expect(mockFetchEmailStatsPublic).toHaveBeenCalled();
-    expect(mockFetchRunCosts).not.toHaveBeenCalled();
+    expect(mockFetchRunIdsByWorkflow).not.toHaveBeenCalled();
+    expect(mockFetchRunCostsAuth).not.toHaveBeenCalled();
     expect(mockFetchEmailStats).not.toHaveBeenCalled();
   });
 
   it("supports by=brand (from runs)", async () => {
-    // Mock DB returns all runs for all workflows, so use 1 workflow with runs for 2 brands
     const wf1 = makeWorkflow({ id: "wf-1" });
     mockWorkflowRows.push(wf1);
     mockWorkflowRunRows.push(
@@ -400,7 +405,7 @@ describe("GET /public/workflows/best", () => {
     );
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 600, runCount: 2 },
+      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 600, runCount: 2 },
     ]);
     mockFetchEmailStatsPublic
       .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 20, replied: 10 }, broadcast: { ...EMPTY_STATS } });
@@ -421,7 +426,7 @@ describe("GET /public/workflows/best", () => {
     mockWorkflowRunRows.push(makeRun("wf-brand-filter", "ext-run-bz"));
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: "sales-email-cold-outreach-alpha", totalCostInUsdCents: 100, runCount: 1 },
+      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue({
       transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },


### PR DESCRIPTION
## Summary
- **Fixes double-counting bug**: Replaced per-run cost fetching (`GET /v1/runs/{id}`) with aggregated endpoint (`GET /v1/stats/costs?groupBy=workflowName`) — costs are now summed at the `runs_costs` level, no parent/child overlap
- **Dynasty-aware aggregation**: Stats now aggregate across all workflow names in the upgrade chain (e.g., jasmine → guardian → ... → cedar), not just the latest active workflow
- **Email stats fallback**: Still uses local `workflow_runs` table for run IDs sent to email-gateway (until email-gateway supports `?workflowName=` filtering)

## Test plan
- [x] All 435 tests pass
- [x] `GET /workflows/ranked` tests updated with `setupCostsMock` and `mockWorkflowRunRows`
- [x] `GET /workflows/best` tests updated with `setupCostsMock` and `mockWorkflowRunRows`
- [x] Public workflows tests verify public endpoints called, auth endpoints not called
- [x] Dynasty chain aggregation test (3-level deep upgrade chain)
- [x] Brand grouping test with filtered mock DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)