### PR TITLE
feat: pass workflowNames filter to runs-service costs endpoint

### DIFF
--- a/src/lib/stats-client.ts
+++ b/src/lib/stats-client.ts
@@ -51,9 +51,11 @@ export interface EmailStatsResponse {
 
 export async function fetchRunCostsAuth(
   identity: IdentityHeaders,
+  workflowNames?: string[],
 ): Promise<WorkflowNameCost[]> {
   const { baseUrl, apiKey } = getRunsServiceConfig();
   const params = new URLSearchParams({ groupBy: "workflowName" });
+  if (workflowNames?.length) params.set("workflowNames", workflowNames.join(","));
 
   const res = await fetch(`${baseUrl}/v1/stats/costs?${params}`, {
     method: "GET",
@@ -100,11 +102,13 @@ export interface WorkflowNameCost {
 export async function fetchRunCostsPublic(filters?: {
   brandId?: string;
   orgId?: string;
+  workflowNames?: string[];
 }): Promise<WorkflowNameCost[]> {
   const { baseUrl, apiKey } = getRunsServiceConfig();
   const params = new URLSearchParams({ groupBy: "workflowName" });
   if (filters?.brandId) params.set("brandId", filters.brandId);
   if (filters?.orgId) params.set("orgId", filters.orgId);
+  if (filters?.workflowNames?.length) params.set("workflowNames", filters.workflowNames.join(","));
 
   const res = await fetch(`${baseUrl}/v1/stats/public/costs?${params}`, {
     method: "GET",

--- a/src/lib/workflow-scoring.ts
+++ b/src/lib/workflow-scoring.ts
@@ -78,11 +78,18 @@ export async function computeWorkflowScores(
     ];
   }
 
-  // 2. Fetch costs aggregated by workflowName (no double-counting, no per-run calls)
+  // 2. Collect all unique workflow names across all dynasty chains
+  const allChainNames = [
+    ...new Set(
+      Object.values(chainWorkflowsById).flatMap((wfs) => wfs.map((w) => w.name))
+    ),
+  ];
+
+  // 3. Fetch costs aggregated by workflowName, filtered to dynasty names only
   const costGroups =
     mode.kind === "auth"
-      ? await fetchRunCostsAuth(mode.identity)
-      : await fetchRunCostsPublic({ brandId: mode.brandId, orgId: mode.orgId });
+      ? await fetchRunCostsAuth(mode.identity, allChainNames)
+      : await fetchRunCostsPublic({ brandId: mode.brandId, orgId: mode.orgId, workflowNames: allChainNames });
 
   const costByName = new Map(costGroups.map((g) => [g.workflowName, g.totalCostInUsdCents]));
 

--- a/tests/integration/best-workflow.test.ts
+++ b/tests/integration/best-workflow.test.ts
@@ -240,6 +240,32 @@ describe("GET /workflows/ranked", () => {
     expect(best.stats.completedRuns).toBe(2);
     expect(best.stats.email.transactional.replied).toBe(10);
     expect(best.stats.email.broadcast).toEqual(EMPTY_STATS);
+    // Verify workflowNames filter is passed to runs-service
+    expect(mockFetchRunCostsAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: "org-1" }),
+      [DEFAULT_WF_NAME],
+    );
+  });
+
+  it("passes all dynasty workflow names to costs endpoint", async () => {
+    const wfOldName = "sales-email-cold-outreach-old";
+    mockWorkflowRows.push(
+      makeWorkflow({ id: "wf-active" }),
+      makeWorkflow({ id: "wf-old", name: wfOldName, status: "deprecated", upgradedTo: "wf-active" }),
+    );
+    mockWorkflowRunRows.push(makeRun("wf-active", "ext-run-active"), makeRun("wf-old", "ext-run-old"));
+
+    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, [wfOldName]: { cost: 200, runCount: 1 } });
+    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 10 }, broadcast: { ...EMPTY_STATS } });
+
+    const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
+    expect(res.status).toBe(200);
+
+    // Both dynasty names should be passed to the costs endpoint
+    const calledNames = mockFetchRunCostsAuth.mock.calls[0][1] as string[];
+    expect(calledNames).toHaveLength(2);
+    expect(calledNames).toContain(DEFAULT_WF_NAME);
+    expect(calledNames).toContain(wfOldName);
   });
 
   it("uses clicks objective when specified", async () => {


### PR DESCRIPTION
## Summary
- Collects all unique workflow names from dynasty chains upfront and passes them as `workflowNames` parameter to `GET /v1/stats/costs?groupBy=workflowName&workflowNames=...`
- Runs-service now filters server-side (SQL `IN (...)`) instead of returning all workflows — leverages runs-service PR #44
- Supports both auth and public modes
- Adds test verifying dynasty names are passed to the costs endpoint

## Test plan
- [x] 436 tests pass (1 new test added)
- [x] Existing dynasty chain aggregation tests still pass
- [x] New test verifies `workflowNames` parameter is forwarded with all dynasty names

🤖 Generated with [Claude Code](https://claude.com/claude-code)