### PR TITLE
feat: use email-gateway groupBy=workflowName instead of N per-run calls

### DIFF
--- a/src/lib/stats-client.ts
+++ b/src/lib/stats-client.ts
@@ -152,48 +152,6 @@ const EMPTY_STATS: EmailStats = {
   recipients: 0,
 };
 
-export async function fetchEmailStats(
-  runIds: string[],
-  identity: IdentityHeaders,
-): Promise<EmailStatsResponse> {
-  if (runIds.length === 0) {
-    return { transactional: { ...EMPTY_STATS }, broadcast: { ...EMPTY_STATS } };
-  }
-
-  const { baseUrl, apiKey } = getEmailGatewayConfig();
-
-  const res = await fetch(
-    `${baseUrl}/stats?runIds=${runIds.join(",")}`,
-    {
-      method: "GET",
-      headers: {
-        "x-api-key": apiKey,
-        "x-org-id": identity.orgId,
-        "x-user-id": identity.userId,
-        "x-run-id": identity.runId,
-      },
-    },
-  );
-
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(
-      `email-gateway-service error: GET /stats -> ${res.status} ${res.statusText}: ${text}`
-    );
-  }
-
-  const body = (await res.json()) as Record<string, unknown>;
-  const rawTransactional = (body.transactional ?? {}) as Record<string, unknown>;
-  const rawBroadcast = (body.broadcast ?? {}) as Record<string, unknown>;
-
-  return {
-    transactional: mapGatewayStats(rawTransactional),
-    broadcast: mapGatewayStats(rawBroadcast),
-  };
-}
-
-// --- Public: fetch email stats (no identity) ---
-
 /** Map email-gateway field names (emailsOpened etc.) to our internal names (opened etc.) */
 export function mapGatewayStats(raw: Record<string, unknown>): EmailStats {
   return {
@@ -208,22 +166,61 @@ export function mapGatewayStats(raw: Record<string, unknown>): EmailStats {
   };
 }
 
-export async function fetchEmailStatsPublic(
-  runIds: string[],
-): Promise<EmailStatsResponse> {
-  if (runIds.length === 0) {
-    return { transactional: { ...EMPTY_STATS }, broadcast: { ...EMPTY_STATS } };
-  }
+// --- Fetch email stats grouped by workflowName ---
+
+export interface EmailStatsGroup {
+  workflowName: string;
+  transactional: EmailStats;
+  broadcast: EmailStats;
+}
+
+export async function fetchEmailStatsAuth(
+  workflowNames: string[],
+  identity: IdentityHeaders,
+): Promise<EmailStatsGroup[]> {
+  if (workflowNames.length === 0) return [];
 
   const { baseUrl, apiKey } = getEmailGatewayConfig();
+  const params = new URLSearchParams({
+    groupBy: "workflowName",
+    workflowNames: workflowNames.join(","),
+  });
 
-  const res = await fetch(
-    `${baseUrl}/stats/public?runIds=${runIds.join(",")}`,
-    {
-      method: "GET",
-      headers: { "x-api-key": apiKey },
+  const res = await fetch(`${baseUrl}/stats?${params}`, {
+    method: "GET",
+    headers: {
+      "x-api-key": apiKey,
+      "x-org-id": identity.orgId,
+      "x-user-id": identity.userId,
+      "x-run-id": identity.runId,
     },
-  );
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `email-gateway-service error: GET /stats -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  return parseEmailStatsGroups(await res.json());
+}
+
+export async function fetchEmailStatsPublic(
+  workflowNames: string[],
+): Promise<EmailStatsGroup[]> {
+  if (workflowNames.length === 0) return [];
+
+  const { baseUrl, apiKey } = getEmailGatewayConfig();
+  const params = new URLSearchParams({
+    groupBy: "workflowName",
+    workflowNames: workflowNames.join(","),
+  });
+
+  const res = await fetch(`${baseUrl}/stats/public?${params}`, {
+    method: "GET",
+    headers: { "x-api-key": apiKey },
+  });
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
@@ -232,13 +229,22 @@ export async function fetchEmailStatsPublic(
     );
   }
 
-  const body = (await res.json()) as Record<string, unknown>;
-  const rawTransactional = (body.transactional ?? {}) as Record<string, unknown>;
-  const rawBroadcast = (body.broadcast ?? {}) as Record<string, unknown>;
+  return parseEmailStatsGroups(await res.json());
+}
 
-  return {
-    transactional: mapGatewayStats(rawTransactional),
-    broadcast: mapGatewayStats(rawBroadcast),
+function parseEmailStatsGroups(body: unknown): EmailStatsGroup[] {
+  const { groups } = body as {
+    groups: Array<{
+      workflowName: string;
+      transactional?: Record<string, unknown>;
+      broadcast?: Record<string, unknown>;
+    }>;
   };
+
+  return (groups ?? []).map((g) => ({
+    workflowName: g.workflowName,
+    transactional: mapGatewayStats(g.transactional ?? {}),
+    broadcast: mapGatewayStats(g.broadcast ?? {}),
+  }));
 }
 

--- a/src/lib/workflow-scoring.ts
+++ b/src/lib/workflow-scoring.ts
@@ -1,7 +1,7 @@
 import { eq, and, inArray } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { workflows, workflowRuns } from "../db/schema.js";
-import { fetchRunCostsAuth, fetchEmailStats, fetchRunCostsPublic, fetchEmailStatsPublic } from "./stats-client.js";
+import { fetchRunCostsAuth, fetchRunCostsPublic, fetchEmailStatsAuth, fetchEmailStatsPublic } from "./stats-client.js";
 import type { IdentityHeaders } from "./key-service-client.js";
 
 export const EMPTY_EMAIL_STATS = {
@@ -93,10 +93,18 @@ export async function computeWorkflowScores(
 
   const costByName = new Map(costGroups.map((g) => [g.workflowName, g.totalCostInUsdCents]));
 
-  // 3. For each active workflow, aggregate costs across the dynasty chain + get run IDs for email stats
+  // 4. Fetch email stats grouped by workflowName (1 call for all dynasty names)
+  const emailGroups =
+    mode.kind === "auth"
+      ? await fetchEmailStatsAuth(allChainNames, mode.identity)
+      : await fetchEmailStatsPublic(allChainNames);
+
+  const emailByName = new Map(emailGroups.map((g) => [g.workflowName, g]));
+
+  // 5. For each active workflow, aggregate costs + email stats across dynasty chain + build brand map
   const workflowRunsByWfId: Record<string, string[]> = {};
-  const costByWorkflowId = new Map<string, number>();
   const runBrandMap = new Map<string, string>();
+  const scores: WorkflowScore[] = [];
 
   for (const wf of activeWorkflows) {
     const chainWfs = chainWorkflowsById[wf.id] ?? [];
@@ -108,10 +116,20 @@ export async function computeWorkflowScores(
     for (const name of chainNames) {
       totalCost += costByName.get(name) ?? 0;
     }
-    costByWorkflowId.set(wf.id, totalCost);
 
-    // Run IDs for email stats: from local workflow_runs table
-    // TODO: replace with email-gateway workflowName filter once available
+    // Email stats: aggregate across all dynasty workflow names
+    const transactional = { ...EMPTY_EMAIL_STATS };
+    const broadcast = { ...EMPTY_EMAIL_STATS };
+    for (const name of chainNames) {
+      const eg = emailByName.get(name);
+      if (!eg) continue;
+      for (const key of Object.keys(EMPTY_EMAIL_STATS) as (keyof typeof EMPTY_EMAIL_STATS)[]) {
+        transactional[key] += eg.transactional[key];
+        broadcast[key] += eg.broadcast[key];
+      }
+    }
+
+    // Run IDs + brand map: still from local workflow_runs table (needed for brand grouping)
     const runs = chainIds.length === 1
       ? await db.select().from(workflowRuns).where(
           and(eq(workflowRuns.workflowId, chainIds[0]), eq(workflowRuns.status, "completed")))
@@ -121,38 +139,12 @@ export async function computeWorkflowScores(
     for (const r of runs) {
       if (r.runId && r.brandId) runBrandMap.set(r.runId, r.brandId);
     }
-
     workflowRunsByWfId[wf.id] = runIds;
-  }
-
-  // 4. Per-workflow: fetch email stats and compute outcomes
-  const scores: WorkflowScore[] = [];
-
-  for (const wf of activeWorkflows) {
-    const runIds = workflowRunsByWfId[wf.id] ?? [];
-
-    if (runIds.length === 0) {
-      scores.push({
-        workflow: wf,
-        totalCost: 0,
-        totalOutcomes: 0,
-        costPerOutcome: null,
-        completedRuns: 0,
-        emailStats: { transactional: { ...EMPTY_EMAIL_STATS }, broadcast: { ...EMPTY_EMAIL_STATS } },
-      });
-      continue;
-    }
-
-    const totalCost = costByWorkflowId.get(wf.id) ?? 0;
-
-    const stats = mode.kind === "auth"
-      ? await fetchEmailStats(runIds, mode.identity)
-      : await fetchEmailStatsPublic(runIds);
 
     const outcomes =
       objective === "replies"
-        ? (stats.transactional?.replied ?? 0) + (stats.broadcast?.replied ?? 0)
-        : (stats.transactional?.clicked ?? 0) + (stats.broadcast?.clicked ?? 0);
+        ? transactional.replied + broadcast.replied
+        : transactional.clicked + broadcast.clicked;
 
     const costPerOutcome = outcomes > 0 ? totalCost / outcomes : null;
 
@@ -162,10 +154,7 @@ export async function computeWorkflowScores(
       totalOutcomes: outcomes,
       costPerOutcome,
       completedRuns: runIds.length,
-      emailStats: {
-        transactional: stats.transactional ?? { ...EMPTY_EMAIL_STATS },
-        broadcast: stats.broadcast ?? { ...EMPTY_EMAIL_STATS },
-      },
+      emailStats: { transactional, broadcast },
     });
   }
 

--- a/tests/integration/best-workflow.test.ts
+++ b/tests/integration/best-workflow.test.ts
@@ -96,11 +96,11 @@ vi.mock("../../src/db/index.js", () => ({
 
 // --- Mock stats-client ---
 const mockFetchRunCostsAuth = vi.fn();
-const mockFetchEmailStats = vi.fn();
+const mockFetchEmailStatsAuth = vi.fn();
 
 vi.mock("../../src/lib/stats-client.js", () => ({
   fetchRunCostsAuth: (...args: unknown[]) => mockFetchRunCostsAuth(...args),
-  fetchEmailStats: (...args: unknown[]) => mockFetchEmailStats(...args),
+  fetchEmailStatsAuth: (...args: unknown[]) => mockFetchEmailStatsAuth(...args),
 }));
 
 // --- Mock Windmill ---
@@ -195,6 +195,18 @@ function makeRun(workflowId: string, runId: string, brandId?: string | null) {
   };
 }
 
+// Helper: setup email stats mock grouped by workflowName
+type StatsOverrides = { sent?: number; delivered?: number; opened?: number; clicked?: number; replied?: number; bounced?: number; unsubscribed?: number; recipients?: number };
+function setupEmailMock(statsByName: Record<string, { transactional?: StatsOverrides; broadcast?: StatsOverrides }>) {
+  mockFetchEmailStatsAuth.mockResolvedValue(
+    Object.entries(statsByName).map(([workflowName, s]) => ({
+      workflowName,
+      transactional: { ...EMPTY_STATS, ...s.transactional },
+      broadcast: { ...EMPTY_STATS, ...s.broadcast },
+    }))
+  );
+}
+
 // Helper: setup cost mocks from runs-service
 function setupCostsMock(costsByName: Record<string, { cost: number; runCount: number }>) {
   mockFetchRunCostsAuth.mockResolvedValue(
@@ -213,7 +225,7 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRows.length = 0;
     mockWorkflowRunRows.length = 0;
     mockFetchRunCostsAuth.mockReset();
-    mockFetchEmailStats.mockReset();
+    mockFetchEmailStatsAuth.mockReset();
   });
 
   it("returns ranked workflows with stats", async () => {
@@ -222,10 +234,7 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-1"), makeRun("wf-a", "ext-run-2"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 300, runCount: 2 } });
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 10 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 10 } } });
 
     const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
 
@@ -240,14 +249,18 @@ describe("GET /workflows/ranked", () => {
     expect(best.stats.completedRuns).toBe(2);
     expect(best.stats.email.transactional.replied).toBe(10);
     expect(best.stats.email.broadcast).toEqual(EMPTY_STATS);
-    // Verify workflowNames filter is passed to runs-service
+    // Verify workflowNames filter is passed to both endpoints
     expect(mockFetchRunCostsAuth).toHaveBeenCalledWith(
       expect.objectContaining({ orgId: "org-1" }),
       [DEFAULT_WF_NAME],
     );
+    expect(mockFetchEmailStatsAuth).toHaveBeenCalledWith(
+      [DEFAULT_WF_NAME],
+      expect.objectContaining({ orgId: "org-1" }),
+    );
   });
 
-  it("passes all dynasty workflow names to costs endpoint", async () => {
+  it("passes all dynasty workflow names to costs and email endpoints", async () => {
     const wfOldName = "sales-email-cold-outreach-old";
     mockWorkflowRows.push(
       makeWorkflow({ id: "wf-active" }),
@@ -256,16 +269,21 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-active", "ext-run-active"), makeRun("wf-old", "ext-run-old"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, [wfOldName]: { cost: 200, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 10 }, broadcast: { ...EMPTY_STATS } });
+    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 5 } }, [wfOldName]: { transactional: { replied: 5 } } });
 
     const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(200);
 
-    // Both dynasty names should be passed to the costs endpoint
-    const calledNames = mockFetchRunCostsAuth.mock.calls[0][1] as string[];
-    expect(calledNames).toHaveLength(2);
-    expect(calledNames).toContain(DEFAULT_WF_NAME);
-    expect(calledNames).toContain(wfOldName);
+    // Both dynasty names should be passed to both endpoints
+    const costNames = mockFetchRunCostsAuth.mock.calls[0][1] as string[];
+    expect(costNames).toHaveLength(2);
+    expect(costNames).toContain(DEFAULT_WF_NAME);
+    expect(costNames).toContain(wfOldName);
+
+    const emailNames = mockFetchEmailStatsAuth.mock.calls[0][0] as string[];
+    expect(emailNames).toHaveLength(2);
+    expect(emailNames).toContain(DEFAULT_WF_NAME);
+    expect(emailNames).toContain(wfOldName);
   });
 
   it("uses clicks objective when specified", async () => {
@@ -273,10 +291,7 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-1"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 500, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, clicked: 25 },
-      broadcast: { ...EMPTY_STATS, clicked: 25 },
-    });
+    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { clicked: 25 }, broadcast: { clicked: 25 } } });
 
     const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, objective: "clicks" }).set(AUTH);
 
@@ -296,8 +311,8 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-1"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    mockFetchEmailStats.mockRejectedValue(
-      new Error("email-gateway-service error: POST /stats -> 500 Internal Server Error: boom")
+    mockFetchEmailStatsAuth.mockRejectedValue(
+      new Error("email-gateway-service error: GET /stats -> 500 Internal Server Error: boom")
     );
 
     const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
@@ -315,7 +330,7 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-1"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS }, broadcast: { ...EMPTY_STATS } });
+    setupEmailMock({ [DEFAULT_WF_NAME]: {} });
 
     const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(200);
@@ -332,12 +347,13 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-active", "ext-run-active"), makeRun("wf-old", "ext-run-old"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, [wfOldName]: { cost: 200, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 10 }, broadcast: { ...EMPTY_STATS } });
+    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 5 } }, [wfOldName]: { transactional: { replied: 5 } } });
 
     const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(200);
     expect(res.body.results[0].workflow.id).toBe("wf-active");
     expect(res.body.results[0].stats.totalCostInUsdCents).toBe(300);
+    expect(res.body.results[0].stats.totalOutcomes).toBe(10);
     expect(res.body.results[0].stats.completedRuns).toBe(2);
   });
 
@@ -352,12 +368,13 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-v3", "ext-run-v3"), makeRun("wf-v2", "ext-run-v2"), makeRun("wf-v1", "ext-run-v1"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 50, runCount: 1 }, [nameV2]: { cost: 100, runCount: 1 }, [nameV1]: { cost: 150, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 15 }, broadcast: { ...EMPTY_STATS } });
+    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 5 } }, [nameV2]: { transactional: { replied: 5 } }, [nameV1]: { transactional: { replied: 5 } } });
 
     const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(200);
     expect(res.body.results[0].workflow.id).toBe("wf-v3");
     expect(res.body.results[0].stats.totalCostInUsdCents).toBe(300);
+    expect(res.body.results[0].stats.totalOutcomes).toBe(15);
     expect(res.body.results[0].stats.completedRuns).toBe(3);
   });
 
@@ -373,10 +390,11 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-a"), makeRun("wf-b", "ext-run-b"), makeRun("wf-c", "ext-run-c"));
 
     setupCostsMock({ [nameA]: { cost: 100, runCount: 1 }, [nameB]: { cost: 200, runCount: 1 }, [nameC]: { cost: 50, runCount: 1 } });
-    mockFetchEmailStats
-      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, replied: 10 }, broadcast: { ...EMPTY_STATS } })
-      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, replied: 5 }, broadcast: { ...EMPTY_STATS } })
-      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, replied: 25 }, broadcast: { ...EMPTY_STATS } });
+    setupEmailMock({
+      [nameA]: { transactional: { replied: 10 } },
+      [nameB]: { transactional: { replied: 5 } },
+      [nameC]: { transactional: { replied: 25 } },
+    });
 
     const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, limit: "3" }).set(AUTH);
     expect(res.status).toBe(200);
@@ -391,7 +409,7 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-dn", "ext-run-dn"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 5 }, broadcast: { ...EMPTY_STATS } });
+    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 5 } } });
 
     const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(200);
@@ -401,15 +419,17 @@ describe("GET /workflows/ranked", () => {
 
   it("respects limit to cap results", async () => {
     const costs: Record<string, { cost: number; runCount: number }> = {};
+    const emails: Record<string, { transactional?: StatsOverrides }> = {};
     for (let i = 0; i < 5; i++) {
       const name = `sales-email-cold-outreach-wf${i}`;
       mockWorkflowRows.push(makeWorkflow({ id: `wf-${i}`, name }));
       mockWorkflowRunRows.push(makeRun(`wf-${i}`, `ext-run-${i}`));
       costs[name] = { cost: 100, runCount: 1 };
+      emails[name] = { transactional: { replied: 5 } };
     }
 
     setupCostsMock(costs);
-    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 5 }, broadcast: { ...EMPTY_STATS } });
+    setupEmailMock(emails);
 
     const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, limit: "2" }).set(AUTH);
     expect(res.status).toBe(200);
@@ -421,7 +441,7 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-1", "ext-run-1", "brand-1"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 5 }, broadcast: { ...EMPTY_STATS } });
+    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 5 } } });
 
     const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, brandId: "brand-1" }).set(AUTH);
     expect(res.status).toBe(200);
@@ -436,7 +456,7 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-1", "ext-run-1", "brand-A"), makeRun("wf-2", "ext-run-2", "brand-B"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, "sales-email-cold-outreach-beta": { cost: 200, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 5 }, broadcast: { ...EMPTY_STATS } });
+    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 5 } }, "sales-email-cold-outreach-beta": { transactional: { replied: 5 } } });
 
     const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, groupBy: "brand" }).set(AUTH);
     expect(res.status).toBe(200);
@@ -458,7 +478,7 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-branded", "ext-run-1", "brand-X"), makeRun("wf-no-brand", "ext-run-2"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, "sales-email-cold-outreach-nobrand": { cost: 200, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 5 }, broadcast: { ...EMPTY_STATS } });
+    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 5 } }, "sales-email-cold-outreach-nobrand": { transactional: { replied: 5 } } });
 
     const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, groupBy: "brand" }).set(AUTH);
     expect(res.status).toBe(200);
@@ -473,7 +493,7 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-sales", "ext-run-s1"), makeRun("wf-sales2", "ext-run-s2"));
 
     setupCostsMock({ [nameS1]: { cost: 100, runCount: 1 }, [nameS2]: { cost: 200, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({ transactional: { ...EMPTY_STATS, replied: 5, sent: 50, opened: 20 }, broadcast: { ...EMPTY_STATS } });
+    setupEmailMock({ [nameS1]: { transactional: { replied: 5, sent: 50, opened: 20 } }, [nameS2]: { transactional: { replied: 5, sent: 50, opened: 20 } } });
 
     const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, groupBy: "section" }).set(AUTH);
     expect(res.status).toBe(200);
@@ -494,7 +514,7 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRows.length = 0;
     mockWorkflowRunRows.length = 0;
     mockFetchRunCostsAuth.mockReset();
-    mockFetchEmailStats.mockReset();
+    mockFetchEmailStatsAuth.mockReset();
   });
 
   it("returns bestCostPerOpen and bestCostPerReply", async () => {
@@ -503,10 +523,7 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRunRows.push(makeRun("wf-hero", "ext-run-hero"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { opened: 10, replied: 5 } } });
 
     const res = await request
       .get("/workflows/best")
@@ -528,10 +545,7 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRunRows.push(makeRun("wf-no-outcomes", "ext-run-no"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS },
-      broadcast: { ...EMPTY_STATS },
-    });
+    setupEmailMock({ [DEFAULT_WF_NAME]: {} });
 
     const res = await request
       .get("/workflows/best")
@@ -564,10 +578,7 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRunRows.push(makeRun("wf-dn-hero", "ext-run-dn"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { opened: 10, replied: 5 } } });
 
     const res = await request
       .get("/workflows/best")
@@ -585,9 +596,9 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRunRows.push(makeRun("wf-b1", "ext-run-b1", "brand-target"), makeRun("wf-b2", "ext-run-b2", "brand-other"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, "sales-email-cold-outreach-other": { cost: 200, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
+    setupEmailMock({
+      [DEFAULT_WF_NAME]: { transactional: { opened: 10, replied: 5 } },
+      "sales-email-cold-outreach-other": { transactional: { opened: 10, replied: 5 } },
     });
 
     const res = await request
@@ -605,8 +616,7 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRunRows.push(makeRun("wf-1", "ext-run-a", "brand-A"), makeRun("wf-1", "ext-run-b", "brand-A"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 600, runCount: 2 } });
-    mockFetchEmailStats
-      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 20, replied: 10 }, broadcast: { ...EMPTY_STATS } });
+    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { opened: 20, replied: 10 } } });
 
     const res = await request
       .get("/workflows/best")
@@ -627,10 +637,7 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRunRows.push(makeRun("wf-no-brand", "ext-run-nb"));
 
     setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    mockFetchEmailStats.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { opened: 10, replied: 5 } } });
 
     const res = await request
       .get("/workflows/best")
@@ -651,11 +658,10 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRunRows.push(makeRun("wf-expensive", "ext-run-1"), makeRun("wf-cheap", "ext-run-2"));
 
     setupCostsMock({ [nameExp]: { cost: 500, runCount: 1 }, [nameCheap]: { cost: 500, runCount: 1 } });
-    // First call (wf-expensive): low opens/replies → high cost-per
-    mockFetchEmailStats
-      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 2, replied: 1 }, broadcast: { ...EMPTY_STATS } })
-      // Second call (wf-cheap): high opens/replies → low cost-per
-      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 100, replied: 50 }, broadcast: { ...EMPTY_STATS } });
+    setupEmailMock({
+      [nameExp]: { transactional: { opened: 2, replied: 1 } },
+      [nameCheap]: { transactional: { opened: 100, replied: 50 } },
+    });
 
     const res = await request
       .get("/workflows/best")

--- a/tests/integration/public-workflows.test.ts
+++ b/tests/integration/public-workflows.test.ts
@@ -56,16 +56,14 @@ vi.mock("../../src/db/index.js", () => ({
 }));
 
 // --- Mock stats-client ---
-const mockFetchRunIdsByWorkflow = vi.fn();
 const mockFetchRunCostsAuth = vi.fn();
-const mockFetchEmailStats = vi.fn();
+const mockFetchEmailStatsAuth = vi.fn();
 const mockFetchRunCostsPublic = vi.fn();
 const mockFetchEmailStatsPublic = vi.fn();
 
 vi.mock("../../src/lib/stats-client.js", () => ({
-  fetchRunIdsByWorkflow: (...args: unknown[]) => mockFetchRunIdsByWorkflow(...args),
   fetchRunCostsAuth: (...args: unknown[]) => mockFetchRunCostsAuth(...args),
-  fetchEmailStats: (...args: unknown[]) => mockFetchEmailStats(...args),
+  fetchEmailStatsAuth: (...args: unknown[]) => mockFetchEmailStatsAuth(...args),
   fetchRunCostsPublic: (...args: unknown[]) => mockFetchRunCostsPublic(...args),
   fetchEmailStatsPublic: (...args: unknown[]) => mockFetchEmailStatsPublic(...args),
 }));
@@ -146,15 +144,22 @@ function makeRun(workflowId: string, runId: string, brandId?: string | null) {
   };
 }
 
+function makeEmailGroup(workflowName: string, overrides: { transactional?: Partial<typeof EMPTY_STATS>; broadcast?: Partial<typeof EMPTY_STATS> } = {}) {
+  return {
+    workflowName,
+    transactional: { ...EMPTY_STATS, ...overrides.transactional },
+    broadcast: { ...EMPTY_STATS, ...overrides.broadcast },
+  };
+}
+
 // ==================== GET /public/workflows/ranked ====================
 
 describe("GET /public/workflows/ranked", () => {
   beforeEach(() => {
     mockWorkflowRows.length = 0;
     mockWorkflowRunRows.length = 0;
-    mockFetchRunIdsByWorkflow.mockReset();
     mockFetchRunCostsAuth.mockReset();
-    mockFetchEmailStats.mockReset();
+    mockFetchEmailStatsAuth.mockReset();
     mockFetchRunCostsPublic.mockReset();
     mockFetchEmailStatsPublic.mockReset();
   });
@@ -167,10 +172,9 @@ describe("GET /public/workflows/ranked", () => {
     mockFetchRunCostsPublic.mockResolvedValue([
       { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
     ]);
-    mockFetchEmailStatsPublic.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 10 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    mockFetchEmailStatsPublic.mockResolvedValue([
+      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { replied: 10 } }),
+    ]);
 
     const res = await request
       .get("/public/workflows/ranked")
@@ -191,10 +195,9 @@ describe("GET /public/workflows/ranked", () => {
     mockFetchRunCostsPublic.mockResolvedValue([
       { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 50, runCount: 1 },
     ]);
-    mockFetchEmailStatsPublic.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    mockFetchEmailStatsPublic.mockResolvedValue([
+      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { replied: 5 } }),
+    ]);
 
     const res = await request
       .get("/public/workflows/ranked")
@@ -210,22 +213,18 @@ describe("GET /public/workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-sys", "ext-run-1"));
 
     mockFetchRunCostsPublic.mockResolvedValue([]);
-    mockFetchEmailStatsPublic.mockResolvedValue({
-      transactional: { ...EMPTY_STATS },
-      broadcast: { ...EMPTY_STATS },
-    });
+    mockFetchEmailStatsPublic.mockResolvedValue([]);
 
     await request
       .get("/public/workflows/ranked")
       .query({ category: "sales", channel: "email", audienceType: "cold-outreach" });
 
-    // Verify public functions are called (no identity arg)
+    // Verify public functions are called
     expect(mockFetchRunCostsPublic).toHaveBeenCalled();
     expect(mockFetchEmailStatsPublic).toHaveBeenCalled();
     // Verify auth functions are NOT called
-    expect(mockFetchRunIdsByWorkflow).not.toHaveBeenCalled();
     expect(mockFetchRunCostsAuth).not.toHaveBeenCalled();
-    expect(mockFetchEmailStats).not.toHaveBeenCalled();
+    expect(mockFetchEmailStatsAuth).not.toHaveBeenCalled();
   });
 
   it("supports groupBy=section", async () => {
@@ -236,10 +235,9 @@ describe("GET /public/workflows/ranked", () => {
     mockFetchRunCostsPublic.mockResolvedValue([
       { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
     ]);
-    mockFetchEmailStatsPublic.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 5, sent: 50 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    mockFetchEmailStatsPublic.mockResolvedValue([
+      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { replied: 5, sent: 50 } }),
+    ]);
 
     const res = await request
       .get("/public/workflows/ranked")
@@ -271,10 +269,9 @@ describe("GET /public/workflows/ranked", () => {
     mockFetchRunCostsPublic.mockResolvedValue([
       { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 350, runCount: 2 },
     ]);
-    mockFetchEmailStatsPublic.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    mockFetchEmailStatsPublic.mockResolvedValue([
+      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { replied: 5 } }),
+    ]);
 
     const res = await request
       .get("/public/workflows/ranked")
@@ -296,10 +293,9 @@ describe("GET /public/workflows/ranked", () => {
     mockFetchRunCostsPublic.mockResolvedValue([
       { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
     ]);
-    mockFetchEmailStatsPublic.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, replied: 10 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    mockFetchEmailStatsPublic.mockResolvedValue([
+      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { replied: 10 } }),
+    ]);
 
     const res = await request
       .get("/public/workflows/ranked")
@@ -316,9 +312,8 @@ describe("GET /public/workflows/best", () => {
   beforeEach(() => {
     mockWorkflowRows.length = 0;
     mockWorkflowRunRows.length = 0;
-    mockFetchRunIdsByWorkflow.mockReset();
     mockFetchRunCostsAuth.mockReset();
-    mockFetchEmailStats.mockReset();
+    mockFetchEmailStatsAuth.mockReset();
     mockFetchRunCostsPublic.mockReset();
     mockFetchEmailStatsPublic.mockReset();
   });
@@ -331,10 +326,9 @@ describe("GET /public/workflows/best", () => {
     mockFetchRunCostsPublic.mockResolvedValue([
       { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
     ]);
-    mockFetchEmailStatsPublic.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    mockFetchEmailStatsPublic.mockResolvedValue([
+      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { opened: 10, replied: 5 } }),
+    ]);
 
     const res = await request
       .get("/public/workflows/best");
@@ -356,10 +350,9 @@ describe("GET /public/workflows/best", () => {
     mockFetchRunCostsPublic.mockResolvedValue([
       { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
     ]);
-    mockFetchEmailStatsPublic.mockResolvedValue({
-      transactional: { ...EMPTY_STATS },
-      broadcast: { ...EMPTY_STATS },
-    });
+    mockFetchEmailStatsPublic.mockResolvedValue([
+      makeEmailGroup(DEFAULT_WF_NAME),
+    ]);
 
     const res = await request
       .get("/public/workflows/best");
@@ -382,18 +375,16 @@ describe("GET /public/workflows/best", () => {
     mockWorkflowRunRows.push(makeRun("wf-sys-best", "ext-run-1"));
 
     mockFetchRunCostsPublic.mockResolvedValue([]);
-    mockFetchEmailStatsPublic.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, opened: 10 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    mockFetchEmailStatsPublic.mockResolvedValue([
+      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { opened: 10 } }),
+    ]);
 
     await request.get("/public/workflows/best");
 
     expect(mockFetchRunCostsPublic).toHaveBeenCalled();
     expect(mockFetchEmailStatsPublic).toHaveBeenCalled();
-    expect(mockFetchRunIdsByWorkflow).not.toHaveBeenCalled();
     expect(mockFetchRunCostsAuth).not.toHaveBeenCalled();
-    expect(mockFetchEmailStats).not.toHaveBeenCalled();
+    expect(mockFetchEmailStatsAuth).not.toHaveBeenCalled();
   });
 
   it("supports by=brand (from runs)", async () => {
@@ -407,8 +398,9 @@ describe("GET /public/workflows/best", () => {
     mockFetchRunCostsPublic.mockResolvedValue([
       { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 600, runCount: 2 },
     ]);
-    mockFetchEmailStatsPublic
-      .mockResolvedValueOnce({ transactional: { ...EMPTY_STATS, opened: 20, replied: 10 }, broadcast: { ...EMPTY_STATS } });
+    mockFetchEmailStatsPublic.mockResolvedValue([
+      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { opened: 20, replied: 10 } }),
+    ]);
 
     const res = await request
       .get("/public/workflows/best")
@@ -428,10 +420,9 @@ describe("GET /public/workflows/best", () => {
     mockFetchRunCostsPublic.mockResolvedValue([
       { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
     ]);
-    mockFetchEmailStatsPublic.mockResolvedValue({
-      transactional: { ...EMPTY_STATS, opened: 10, replied: 5 },
-      broadcast: { ...EMPTY_STATS },
-    });
+    mockFetchEmailStatsPublic.mockResolvedValue([
+      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { opened: 10, replied: 5 } }),
+    ]);
 
     const res = await request
       .get("/public/workflows/best")


### PR DESCRIPTION
## Summary
- Replaces N individual `fetchEmailStats(runIds)` calls with **1 single call** using `GET /stats?groupBy=workflowName&workflowNames=...`
- Email stats are now aggregated per workflowName server-side, then summed across dynasty chain names client-side — same pattern as runs-service costs
- Both auth and public modes use the new grouped endpoint
- Includes `workflowNames` filter on cost endpoints (from runs-service PR #44)
- Removes dependency on local `workflow_runs` table for email stat run IDs (still used for brand grouping)

## Test plan
- [x] 436 tests pass
- [x] Auth tests (`best-workflow.test.ts`) use `setupEmailMock` with per-workflowName stats
- [x] Public tests (`public-workflows.test.ts`) verify public email endpoint called, auth not called
- [x] Dynasty chain aggregation tests verify stats sum across all workflow names
- [x] WorkflowNames filter verified on both cost and email endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)