### PR TITLE
fix: use key field from email-gateway groupBy response

### DIFF
--- a/src/lib/stats-client.ts
+++ b/src/lib/stats-client.ts
@@ -235,14 +235,14 @@ export async function fetchEmailStatsPublic(
 function parseEmailStatsGroups(body: unknown): EmailStatsGroup[] {
   const { groups } = body as {
     groups: Array<{
-      workflowName: string;
+      key: string;
       transactional?: Record<string, unknown>;
       broadcast?: Record<string, unknown>;
     }>;
   };
 
   return (groups ?? []).map((g) => ({
-    workflowName: g.workflowName,
+    workflowName: g.key,
     transactional: mapGatewayStats(g.transactional ?? {}),
     broadcast: mapGatewayStats(g.broadcast ?? {}),
   }));


### PR DESCRIPTION
## Summary
- email-gateway's `GET /stats?groupBy=workflowName` returns `{ groups: [{ key, transactional?, broadcast? }] }` — the dimension value is in the `key` field, not `workflowName`
- Our `parseEmailStatsGroups` was reading `g.workflowName` (always undefined), causing empty email stats and triggering 502 errors on `/workflows/ranked`
- Fix: read `g.key` instead

## Test plan
- [x] All 436 tests pass
- [ ] Verify `/workflows/ranked` returns 200 with correct email stats in production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)