### PR TITLE
fix: query signatureNames globally to avoid cross-org name collisions

### DIFF
--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -78,7 +78,7 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
     const existingWorkflows = await db
       .select({ signatureName: workflows.signatureName })
       .from(workflows)
-      .where(eq(workflows.orgId, orgId));
+      .where(eq(workflows.status, "active"));
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
 
     const [existing] = await db
@@ -314,7 +314,7 @@ router.post("/workflows", requireApiKey, async (req, res) => {
     const existingWorkflows = await db
       .select({ signatureName: workflows.signatureName })
       .from(workflows)
-      .where(eq(workflows.orgId, orgId));
+      .where(eq(workflows.status, "active"));
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
     const signatureName = pickSignatureName(signature, usedNames);
 
@@ -467,7 +467,7 @@ router.put("/workflows/upgrade", requireApiKey, async (req, res) => {
     const existingWorkflows = await db
       .select({ signatureName: workflows.signatureName })
       .from(workflows)
-      .where(eq(workflows.orgId, orgId));
+      .where(eq(workflows.status, "active"));
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
 
     const results: { id: string; name: string; category: string; channel: string; audienceType: string; tags: string[]; signature: string; signatureName: string; action: "created" | "updated" }[] = [];
@@ -1092,7 +1092,7 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
     const existingWorkflows = await db
       .select({ signatureName: workflows.signatureName })
       .from(workflows)
-      .where(eq(workflows.orgId, orgId));
+      .where(eq(workflows.status, "active"));
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
     const signatureName = pickSignatureName(newSignature, usedNames);
 

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -1157,27 +1157,33 @@ describe("PUT /workflows/:id — fork", () => {
     expect(res.body.signatureName).not.toBe("jasmine");
   });
 
-  it("fork signature conflict check is org-scoped (cross-org same signature allowed)", async () => {
+  it("fork avoids signatureNames used by other orgs (global uniqueness)", async () => {
     const { computeDAGSignature } = await import("../../src/lib/dag-signature.js");
-    const newDagSig = computeDAGSignature(DAG_WITH_TRANSACTIONAL_EMAIL_SEND);
+    const { pickSignatureName } = await import("../../src/lib/signature-words.js");
+
+    const newDag = DAG_WITH_TRANSACTIONAL_EMAIL_SEND;
+    const newSig = computeDAGSignature(newDag);
+
+    // Determine what signatureName pickSignatureName would pick if no names were used
+    const firstPick = pickSignatureName(newSig, new Set());
 
     const originalWorkflow = {
-      id: "wf-cross-org",
+      id: "wf-global-test",
       orgId: "org-1",
       createdForBrandId: null,
       humanId: null,
       campaignId: null,
       subrequestId: null,
       styleName: null,
-      name: "sales-email-cold-outreach-maple",
-      displayName: "Maple Flow",
+      name: "sales-email-cold-outreach-cedar",
+      displayName: "Cedar Flow",
       description: "Original",
       category: "sales",
       channel: "email",
       audienceType: "cold-outreach",
       tags: [],
-      signature: "old-sig-cross",
-      signatureName: "maple",
+      signature: "old-sig-global",
+      signatureName: "cedar",
       dag: VALID_LINEAR_DAG,
       status: "active",
       upgradedTo: null,
@@ -1190,20 +1196,23 @@ describe("PUT /workflows/:id — fork", () => {
       updatedAt: new Date(),
     };
 
+    // Mock: the signatureNames query returns the first-pick name as already used
+    // (simulating another org already having that signatureName globally)
     mockSelectResponses.push(
       [originalWorkflow],  // existing workflow lookup
-      [],                  // no conflicting signature IN SAME ORG (other org has same sig, but mock returns empty = no conflict)
-      [{ signatureName: "maple" }],  // existing signatureNames in org
+      [],                  // no conflicting signature
+      [{ signatureName: "cedar" }, { signatureName: firstPick }],  // globally used signatureNames
     );
 
     const res = await request
-      .put("/workflows/wf-cross-org")
+      .put("/workflows/wf-global-test")
       .set(AUTH)
-      .send({ dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND });
+      .send({ dag: newDag });
 
-    // Should succeed — a different org having the same signature should NOT block this fork
     expect(res.status).toBe(201);
-    expect(res.body.forkedFrom).toBe("wf-cross-org");
+    // Must NOT use the firstPick since it's globally taken
+    expect(res.body.signatureName).not.toBe(firstPick);
+    expect(res.body.signatureName).not.toBe("cedar");
   });
 
   it("rejects invalid DAG on fork", async () => {


### PR DESCRIPTION
## Summary
- The `signatureName` uniqueness constraint is global, but `pickSignatureName` only checked names within the current org. When another org already used a signatureName (e.g. `roman`), the fork would reuse it, causing `duplicate key value violates unique constraint "idx_workflows_signature_name_active"`.
- Fixed all 4 places that query used signatureNames to filter by `status = 'active'` globally instead of `orgId`.
- Added regression test verifying the fork avoids globally-taken signatureNames.

## Test plan
- [x] Regression test: fork avoids signatureNames used by other orgs
- [x] All 437 tests pass
- [x] Build + OpenAPI generation pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)