### PR TITLE
feat: clean error summaries for failed workflow runs

### DIFF
--- a/src/lib/error-parser.ts
+++ b/src/lib/error-parser.ts
@@ -1,0 +1,126 @@
+/**
+ * Parses raw Windmill error results into clean, frontend-friendly error info.
+ *
+ * Windmill errors come as JSON like:
+ *   {"error":{"message":"POST lead/buffer/next failed (500): {\"error\":\"Internal server error\"}","name":"Error","stack":"...","step_id":"fetch_lead"}}
+ *
+ * Service errors are often deeply nested:
+ *   "runs-service POST /v1/runs/.../costs failed: 502 - {\"error\":\"billing-service unavailable: billing-service returned 400\"}"
+ */
+
+export interface ParsedError {
+  /** Which workflow step failed (e.g. "fetch_lead", "send_email") */
+  failedStep: string | null;
+  /** Clean, human-readable error message (no stack traces) */
+  message: string;
+  /** The innermost root cause extracted from nested service error chains */
+  rootCause: string;
+}
+
+/**
+ * Extract the innermost error message from nested service error chains.
+ *
+ * Handles patterns like:
+ *   "runs-service POST /v1/runs/.../costs failed: 502 - {\"error\":\"billing-service unavailable: billing-service returned 400\"}"
+ *   → "billing-service unavailable: billing-service returned 400"
+ */
+export function extractRootCause(message: string): string {
+  let current = message;
+  const maxDepth = 10;
+
+  for (let i = 0; i < maxDepth; i++) {
+    // Try to find a "failed: STATUS - {...}" pattern and extract the JSON
+    const failedMatch = current.match(/failed:\s*\d+\s*-\s*(\{.+\})\s*$/);
+    if (failedMatch) {
+      try {
+        const parsed = JSON.parse(failedMatch[1]);
+        if (typeof parsed.error === "string") {
+          current = parsed.error;
+          continue;
+        }
+      } catch {
+        // Might be escaped JSON — try unescaping once
+        try {
+          const unescaped = failedMatch[1].replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+          const parsed = JSON.parse(unescaped);
+          if (typeof parsed.error === "string") {
+            current = parsed.error;
+            continue;
+          }
+        } catch {
+          // Not valid JSON even after unescaping
+        }
+      }
+    }
+
+    // Try to find an embedded JSON object with an "error" field
+    const jsonMatch = current.match(/\{[^{}]*"error"\s*:\s*"([^"]+)"[^{}]*\}/);
+    if (jsonMatch) {
+      current = jsonMatch[1];
+      continue;
+    }
+
+    break;
+  }
+
+  return current;
+}
+
+/**
+ * Strip stack traces from an error message.
+ * Removes lines starting with "at " or "    at ".
+ */
+function stripStackTrace(message: string): string {
+  return message
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("at "))
+    .join("\n")
+    .trim();
+}
+
+/**
+ * Parse a raw Windmill error result into a clean, structured error.
+ */
+export function parseWindmillError(raw: string | null | undefined): ParsedError {
+  if (!raw) {
+    return { failedStep: null, message: "Unknown error", rootCause: "Unknown error" };
+  }
+
+  // Try to parse as JSON (Windmill's typical format)
+  try {
+    const parsed = JSON.parse(raw);
+
+    // Format: {"error": {"message": "...", "step_id": "...", "stack": "..."}}
+    if (parsed?.error && typeof parsed.error === "object") {
+      const errorObj = parsed.error;
+      const stepId = errorObj.step_id ?? null;
+      const rawMessage = typeof errorObj.message === "string" ? errorObj.message : JSON.stringify(errorObj.message ?? "Unknown error");
+      const message = stripStackTrace(rawMessage);
+      const rootCause = extractRootCause(message);
+
+      return { failedStep: stepId, message, rootCause };
+    }
+
+    // Format: {"error": "some string"}
+    if (typeof parsed?.error === "string") {
+      const message = stripStackTrace(parsed.error);
+      return { failedStep: null, message, rootCause: extractRootCause(message) };
+    }
+
+    // Format: {"message": "...", "step_id": "..."}
+    if (typeof parsed?.message === "string") {
+      const message = stripStackTrace(parsed.message);
+      return {
+        failedStep: parsed.step_id ?? null,
+        message,
+        rootCause: extractRootCause(message),
+      };
+    }
+  } catch {
+    // Not JSON — treat as plain string
+  }
+
+  // Plain string error
+  const message = stripStackTrace(raw);
+  return { failedStep: null, message, rootCause: extractRootCause(message) };
+}

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -7,16 +7,31 @@ import { getWindmillClient } from "../lib/windmill-client.js";
 import { collectServiceEnvs } from "../lib/service-envs.js";
 import { createRun } from "../lib/runs-client.js";
 import { ExecuteWorkflowSchema, ExecuteByNameSchema } from "../schemas.js";
+import { parseWindmillError } from "../lib/error-parser.js";
 
 const router = Router();
 
 function formatRun(r: typeof workflowRuns.$inferSelect) {
-  return {
+  const base = {
     ...r,
     startedAt: r.startedAt?.toISOString() ?? null,
     completedAt: r.completedAt?.toISOString() ?? null,
     createdAt: r.createdAt?.toISOString() ?? null,
   };
+
+  if (r.status === "failed" && r.error) {
+    const parsed = parseWindmillError(r.error);
+    return {
+      ...base,
+      errorSummary: {
+        failedStep: parsed.failedStep,
+        message: parsed.message,
+        rootCause: parsed.rootCause,
+      },
+    };
+  }
+
+  return base;
 }
 
 // POST /workflows/by-name/:name/execute — Execute a workflow by name

--- a/tests/unit/error-parser.test.ts
+++ b/tests/unit/error-parser.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { parseWindmillError, extractRootCause } from "../../src/lib/error-parser.js";
+
+describe("extractRootCause", () => {
+  it("extracts innermost error from nested service chain", () => {
+    const msg =
+      'runs-service POST /v1/runs/abc/costs failed: 502 - {"error":"billing-service unavailable: billing-service returned 400"}';
+    expect(extractRootCause(msg)).toBe(
+      "billing-service unavailable: billing-service returned 400"
+    );
+  });
+
+  it("returns the message as-is when no nesting", () => {
+    expect(extractRootCause("Something went wrong")).toBe("Something went wrong");
+  });
+
+  it("handles double-nested service errors", () => {
+    const msg =
+      'apollo-service POST /search failed: 500 - {"error":"runs-service POST /v1/runs/xyz/costs failed: 502 - {\\"error\\":\\"billing-service unavailable\\"}"}';
+    expect(extractRootCause(msg)).toBe("billing-service unavailable");
+  });
+});
+
+describe("parseWindmillError", () => {
+  it("parses standard Windmill error format with step_id", () => {
+    const raw = JSON.stringify({
+      error: {
+        message: 'POST lead/buffer/next failed (500): {"error":"Internal server error"}',
+        name: "Error",
+        stack: 'Error: POST lead/buffer/next failed\n    at main (/tmp/windmill/cache/bun/abc:43:16)\n    at async run (/tmp/windmill/wk.mjs:30:21)',
+        step_id: "fetch_lead",
+      },
+    });
+
+    const result = parseWindmillError(raw);
+    expect(result.failedStep).toBe("fetch_lead");
+    expect(result.message).not.toContain("at main");
+    expect(result.message).not.toContain("at async run");
+    expect(result.rootCause).toBe("Internal server error");
+  });
+
+  it("parses billing-service cascade error", () => {
+    const raw = JSON.stringify({
+      error: {
+        message:
+          'Apollo service call failed: 500 - {"error":"runs-service POST /v1/runs/abc/costs failed: 502 - {\\"error\\":\\"billing-service unavailable: billing-service returned 400\\"}"}',
+        name: "Error",
+        stack: "Error: Apollo service call failed\n    at callApolloService (file:///app/dist/lib/apollo-client.js:16:15)",
+        step_id: "search_leads",
+      },
+    });
+
+    const result = parseWindmillError(raw);
+    expect(result.failedStep).toBe("search_leads");
+    expect(result.rootCause).toBe("billing-service unavailable: billing-service returned 400");
+  });
+
+  it("handles null/undefined input", () => {
+    expect(parseWindmillError(null)).toEqual({
+      failedStep: null,
+      message: "Unknown error",
+      rootCause: "Unknown error",
+    });
+    expect(parseWindmillError(undefined)).toEqual({
+      failedStep: null,
+      message: "Unknown error",
+      rootCause: "Unknown error",
+    });
+  });
+
+  it("handles plain string error", () => {
+    const result = parseWindmillError("Something broke");
+    expect(result).toEqual({
+      failedStep: null,
+      message: "Something broke",
+      rootCause: "Something broke",
+    });
+  });
+
+  it("handles {error: string} format", () => {
+    const raw = JSON.stringify({ error: "timeout after 30s" });
+    const result = parseWindmillError(raw);
+    expect(result.message).toBe("timeout after 30s");
+    expect(result.rootCause).toBe("timeout after 30s");
+  });
+
+  it("strips stack traces from message", () => {
+    const raw = JSON.stringify({
+      error: {
+        message: "Request failed\n    at doRequest (file:///app/dist/client.js:10:5)\n    at async main (file:///app/dist/index.js:20:3)",
+        name: "Error",
+        step_id: "api_call",
+      },
+    });
+
+    const result = parseWindmillError(raw);
+    expect(result.message).toBe("Request failed");
+    expect(result.failedStep).toBe("api_call");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/lib/error-parser.ts` that extracts clean error info from raw Windmill error results
- Parses nested service error chains (e.g. billing → runs → apollo) to find the root cause
- Strips stack traces and returns `failedStep`, `message`, and `rootCause`
- `formatRun` now includes an `errorSummary` field on failed runs — frontend gets clean messages instead of raw JSON blobs
- Raw `error` field preserved in DB for debugging

## Test plan
- [x] 9 unit tests covering: nested errors, double-nested escaped JSON, null input, plain strings, stack trace stripping
- [x] All 321 existing unit tests still pass
- [x] TypeScript builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)