### PR TITLE
docs: add errorSummary to OpenAPI schema

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -665,7 +665,31 @@
           "error": {
             "type": "string",
             "nullable": true,
-            "description": "Error message (available when status is failed)."
+            "description": "Error message (available when status is failed). Raw Windmill error — use errorSummary for a clean version."
+          },
+          "errorSummary": {
+            "type": "object",
+            "properties": {
+              "failedStep": {
+                "type": "string",
+                "nullable": true,
+                "description": "Which workflow step failed (e.g. 'fetch_lead', 'send_email')."
+              },
+              "message": {
+                "type": "string",
+                "description": "Clean error message with stack traces stripped."
+              },
+              "rootCause": {
+                "type": "string",
+                "description": "Innermost root cause extracted from nested service error chains."
+              }
+            },
+            "required": [
+              "failedStep",
+              "message",
+              "rootCause"
+            ],
+            "description": "Parsed error summary (present only when status is 'failed'). Use rootCause for user-facing messages."
           },
           "startedAt": {
             "type": "string",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -224,7 +224,12 @@ export const WorkflowRunResponseSchema = z
     status: z.string().describe("Run status: queued, running, completed, failed, or cancelled."),
     inputs: z.unknown().nullable().describe("The inputs that were passed at execution time."),
     result: z.unknown().nullable().describe("Workflow result (available when status is completed). Contains the output of the last node."),
-    error: z.string().nullable().describe("Error message (available when status is failed)."),
+    error: z.string().nullable().describe("Error message (available when status is failed). Raw Windmill error — use errorSummary for a clean version."),
+    errorSummary: z.object({
+      failedStep: z.string().nullable().describe("Which workflow step failed (e.g. 'fetch_lead', 'send_email')."),
+      message: z.string().describe("Clean error message with stack traces stripped."),
+      rootCause: z.string().describe("Innermost root cause extracted from nested service error chains."),
+    }).optional().describe("Parsed error summary (present only when status is 'failed'). Use rootCause for user-facing messages."),
     startedAt: z.string().nullable(),
     completedAt: z.string().nullable(),
     createdAt: z.string(),


### PR DESCRIPTION
## Summary
- Adds `errorSummary` (optional) to `WorkflowRunResponse` OpenAPI schema
- Documents `failedStep`, `message`, and `rootCause` fields
- Regenerated `openapi.json`

Follows up on #149 which added the runtime implementation.

## Test plan
- [x] All 321 unit tests pass
- [x] TypeScript builds cleanly
- [x] openapi.json regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)