### PR TITLE
feat: add outlets/journalists discovery workflow enums

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -44,21 +44,25 @@
         "type": "string",
         "enum": [
           "sales",
-          "pr"
+          "pr",
+          "outlets",
+          "journalists"
         ],
         "description": "Workflow category."
       },
       "WorkflowChannel": {
         "type": "string",
         "enum": [
-          "email"
+          "email",
+          "database"
         ],
         "description": "Workflow distribution channel."
       },
       "WorkflowAudienceType": {
         "type": "string",
         "enum": [
-          "cold-outreach"
+          "cold-outreach",
+          "discovery"
         ],
         "description": "Workflow audience type."
       },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -90,17 +90,17 @@ export const DAGSchema = z
 // --- Workflow enums ---
 
 export const WorkflowCategorySchema = z
-  .enum(["sales", "pr"])
+  .enum(["sales", "pr", "outlets", "journalists"])
   .describe("Workflow category.")
   .openapi("WorkflowCategory");
 
 export const WorkflowChannelSchema = z
-  .enum(["email"])
+  .enum(["email", "database"])
   .describe("Workflow distribution channel.")
   .openapi("WorkflowChannel");
 
 export const WorkflowAudienceTypeSchema = z
-  .enum(["cold-outreach"])
+  .enum(["cold-outreach", "discovery"])
   .describe("Workflow audience type.")
   .openapi("WorkflowAudienceType");
 

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -326,6 +326,54 @@ describe("PUT /workflows/upgrade", () => {
     expect(wf.name).toBe(`sales-email-cold-outreach-${wf.signatureName}`);
   });
 
+  it("creates outlets-database-discovery workflow with correct name", async () => {
+    const res = await request
+      .put("/workflows/upgrade")
+      .set(AUTH)
+      .send({
+        workflows: [
+          {
+            category: "outlets" as const,
+            channel: "database" as const,
+            audienceType: "discovery" as const,
+            description: "outlets database discovery",
+            dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    const wf = res.body.workflows[0];
+    expect(wf.category).toBe("outlets");
+    expect(wf.channel).toBe("database");
+    expect(wf.audienceType).toBe("discovery");
+    expect(wf.name).toBe(`outlets-database-discovery-${wf.signatureName}`);
+  });
+
+  it("creates journalists-database-discovery workflow with correct name", async () => {
+    const res = await request
+      .put("/workflows/upgrade")
+      .set(AUTH)
+      .send({
+        workflows: [
+          {
+            category: "journalists" as const,
+            channel: "database" as const,
+            audienceType: "discovery" as const,
+            description: "journalists database discovery",
+            dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    const wf = res.body.workflows[0];
+    expect(wf.category).toBe("journalists");
+    expect(wf.channel).toBe("database");
+    expect(wf.audienceType).toBe("discovery");
+    expect(wf.name).toBe(`journalists-database-discovery-${wf.signatureName}`);
+  });
+
   it("stores orgId from x-org-id header in DB", async () => {
     const res = await request
       .put("/workflows/upgrade")


### PR DESCRIPTION
## Summary
- Adds `"outlets"` and `"journalists"` to `WorkflowCategorySchema`
- Adds `"database"` to `WorkflowChannelSchema`
- Adds `"discovery"` to `WorkflowAudienceTypeSchema`
- Regenerated `openapi.json`

This enables workflow names matching the pattern expected by api-service and campaign-service:
- `outlets-database-discovery-{signatureName}`
- `journalists-database-discovery-{signatureName}`

## Test plan
- [x] 2 new integration tests verify correct name generation for both categories
- [x] All 448 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)