### PR TITLE
fix: prevent signatureName recycling from deprecated workflows

### DIFF
--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -78,7 +78,7 @@ router.post("/workflows/generate", requireApiKey, async (req, res) => {
     const existingWorkflows = await db
       .select({ signatureName: workflows.signatureName })
       .from(workflows)
-      .where(eq(workflows.status, "active"));
+      .where(sql`true`);
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
 
     const [existing] = await db
@@ -463,11 +463,11 @@ router.put("/workflows/upgrade", requireApiKey, async (req, res) => {
       // Don't block deploy if content-generation is unreachable
     }
 
-    // Fetch all existing signatureNames for this orgId to avoid collisions
+    // Fetch all existing signatureNames to avoid collisions (include deprecated)
     const existingWorkflows = await db
       .select({ signatureName: workflows.signatureName })
       .from(workflows)
-      .where(eq(workflows.status, "active"));
+      .where(sql`true`);
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
 
     const results: { id: string; name: string; category: string; channel: string; audienceType: string; tags: string[]; signature: string; signatureName: string; action: "created" | "updated" }[] = [];
@@ -1088,11 +1088,11 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
       return;
     }
 
-    // Generate new signatureName
+    // Generate new signatureName (include deprecated to avoid recycling names)
     const existingWorkflows = await db
       .select({ signatureName: workflows.signatureName })
       .from(workflows)
-      .where(eq(workflows.status, "active"));
+      .where(sql`true`);
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
     const signatureName = pickSignatureName(newSignature, usedNames);
 

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -1263,6 +1263,64 @@ describe("PUT /workflows/:id — fork", () => {
     expect(res.body.signatureName).not.toBe("cedar");
   });
 
+  it("fork avoids signatureNames used by deprecated workflows", async () => {
+    const { computeDAGSignature } = await import("../../src/lib/dag-signature.js");
+    const { pickSignatureName } = await import("../../src/lib/signature-words.js");
+
+    const newDag = DAG_WITH_TRANSACTIONAL_EMAIL_SEND;
+    const newSig = computeDAGSignature(newDag);
+
+    // Determine what signatureName pickSignatureName would pick if no names were used
+    const firstPick = pickSignatureName(newSig, new Set());
+
+    const originalWorkflow = {
+      id: "wf-deprecated-test",
+      orgId: "org-1",
+      createdForBrandId: null,
+      humanId: null,
+      campaignId: null,
+      subrequestId: null,
+      styleName: null,
+      name: `sales-email-cold-outreach-aldebaran`,
+      displayName: `sales-email-cold-outreach-${firstPick}`,
+      description: "Original",
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      tags: [],
+      signature: "old-sig-deprecated",
+      signatureName: "aldebaran",
+      dag: VALID_LINEAR_DAG,
+      status: "active",
+      upgradedTo: null,
+      forkedFrom: null,
+      windmillFlowPath: "f/workflows/org-1/flow",
+      windmillWorkspace: "prod",
+      createdByUserId: "user-1",
+      createdByRunId: "run-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    // Mock: the signatureNames query includes a DEPRECATED workflow using the firstPick name
+    // This simulates the bug where a deprecated workflow's signatureName was recycled
+    mockSelectResponses.push(
+      [originalWorkflow],  // existing workflow lookup
+      [],                  // no conflicting signature
+      [{ signatureName: "aldebaran" }, { signatureName: firstPick }],  // firstPick is taken (by deprecated wf)
+    );
+
+    const res = await request
+      .put("/workflows/wf-deprecated-test")
+      .set(AUTH)
+      .send({ dag: newDag });
+
+    expect(res.status).toBe(201);
+    // Must NOT reuse the firstPick even though the workflow using it is deprecated
+    expect(res.body.signatureName).not.toBe(firstPick);
+    expect(res.body.signatureName).not.toBe("aldebaran");
+  });
+
   it("rejects invalid DAG on fork", async () => {
     mockDbRows.push({
       id: "wf-bad",


### PR DESCRIPTION
## Summary
- **Bug**: `pickSignatureName` only queried active workflows for used names, allowing deprecated workflow signatureNames to be recycled
- **Impact**: Fork of workflow "aldebaran" (dynasty "viking") got signatureName "viking" because the original deprecated "viking" workflow wasn't in the exclusion set — the hash landed on "roman" (taken), walk-forward hit "viking" (appeared free)
- **Fix**: Changed all 3 call sites in `workflows.ts` to query ALL workflows (not just active) when building the used names set, matching what `startup-validator.ts` already does correctly

## Test plan
- [x] Regression test: `fork avoids signatureNames used by deprecated workflows`
- [x] All 455 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)