### PR TITLE
fix: return 200 with empty results instead of 404

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3171,16 +3171,6 @@
               }
             }
           },
-          "404": {
-            "description": "No workflows found matching the criteria",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "502": {
             "description": "External service (runs-service or email-gateway-service) unavailable",
             "content": {
@@ -3304,16 +3294,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BestWorkflowResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No active workflows found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3460,16 +3440,6 @@
               }
             }
           },
-          "404": {
-            "description": "No workflows found matching the criteria",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "502": {
             "description": "External service unavailable",
             "content": {
@@ -3528,16 +3498,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BestWorkflowResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No active workflows found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/src/routes/public-workflows.ts
+++ b/src/routes/public-workflows.ts
@@ -41,7 +41,7 @@ router.get("/public/workflows/ranked", async (req, res) => {
     const deprecatedWorkflows = allMatchingWorkflows.filter((w) => w.status === "deprecated");
 
     if (activeWorkflows.length === 0) {
-      res.status(404).json({ error: "No workflows found matching the criteria" });
+      res.json({ results: [] });
       return;
     }
 
@@ -150,7 +150,7 @@ router.get("/public/workflows/best", async (req, res) => {
     const deprecatedWorkflows = allMatchingWorkflows.filter((w) => w.status === "deprecated");
 
     if (activeWorkflows.length === 0) {
-      res.status(404).json({ error: "No active workflows found" });
+      res.json({ bestCostPerOpen: null, bestCostPerReply: null });
       return;
     }
 

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -646,7 +646,7 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
     const deprecatedWorkflows = allMatchingWorkflows.filter((w) => w.status === "deprecated");
 
     if (activeWorkflows.length === 0) {
-      res.status(404).json({ error: "No workflows found matching the criteria" });
+      res.json({ results: [] });
       return;
     }
 
@@ -762,7 +762,7 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
     const deprecatedWorkflows = allMatchingWorkflows.filter((w) => w.status === "deprecated");
 
     if (activeWorkflows.length === 0) {
-      res.status(404).json({ error: "No active workflows found" });
+      res.json({ bestCostPerOpen: null, bestCostPerReply: null });
       return;
     }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1076,10 +1076,6 @@ registry.registerPath({
         "application/json": { schema: RankedWorkflowResponseSchema },
       },
     },
-    404: {
-      description: "No workflows found matching the criteria",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
     400: {
       description: "Missing or invalid query parameters",
       content: { "application/json": { schema: ErrorResponseSchema } },
@@ -1113,10 +1109,6 @@ registry.registerPath({
         "application/json": { schema: BestWorkflowResponseSchema },
       },
     },
-    404: {
-      description: "No active workflows found",
-      content: { "application/json": { schema: ErrorResponseSchema } },
-    },
     502: {
       description: "External service unavailable",
       content: { "application/json": { schema: ErrorResponseSchema } },
@@ -1146,10 +1138,6 @@ registry.registerPath({
       content: {
         "application/json": { schema: PublicRankedWorkflowResponseSchema },
       },
-    },
-    404: {
-      description: "No workflows found matching the criteria",
-      content: { "application/json": { schema: ErrorResponseSchema } },
     },
     400: {
       description: "Missing or invalid query parameters",
@@ -1182,10 +1170,6 @@ registry.registerPath({
       content: {
         "application/json": { schema: BestWorkflowResponseSchema },
       },
-    },
-    404: {
-      description: "No active workflows found",
-      content: { "application/json": { schema: ErrorResponseSchema } },
     },
     502: {
       description: "External service unavailable",

--- a/tests/integration/best-workflow.test.ts
+++ b/tests/integration/best-workflow.test.ts
@@ -300,10 +300,10 @@ describe("GET /workflows/ranked", () => {
     expect(res.body.results[0].stats.costPerOutcome).toBe(10);
   });
 
-  it("returns 404 when no workflows match", async () => {
+  it("returns 200 with empty results when no workflows match", async () => {
     const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
-    expect(res.status).toBe(404);
-    expect(res.body.error).toMatch(/No workflows found/);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ results: [] });
   });
 
   it("returns 502 when email-gateway-service fails", async () => {
@@ -556,12 +556,13 @@ describe("GET /workflows/best (hero records)", () => {
     expect(res.body.bestCostPerReply).toBeNull();
   });
 
-  it("returns 404 when no active workflows exist", async () => {
+  it("returns 200 with null records when no active workflows exist", async () => {
     const res = await request
       .get("/workflows/best")
       .set(AUTH);
 
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ bestCostPerOpen: null, bestCostPerReply: null });
   });
 
   it("requires authentication", async () => {

--- a/tests/integration/public-workflows.test.ts
+++ b/tests/integration/public-workflows.test.ts
@@ -250,12 +250,13 @@ describe("GET /public/workflows/ranked", () => {
     expect(res.body.sections[0].workflows[0]).not.toHaveProperty("dag");
   });
 
-  it("returns 404 when no workflows match", async () => {
+  it("returns 200 with empty results when no workflows match", async () => {
     const res = await request
       .get("/public/workflows/ranked")
       .query({ category: "sales", channel: "email", audienceType: "cold-outreach" });
 
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ results: [] });
   });
 
   it("supports groupBy=brand (from runs)", async () => {
@@ -362,11 +363,12 @@ describe("GET /public/workflows/best", () => {
     expect(res.body.bestCostPerReply).toBeNull();
   });
 
-  it("returns 404 when no active workflows exist", async () => {
+  it("returns 200 with null records when no active workflows exist", async () => {
     const res = await request
       .get("/public/workflows/best");
 
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ bestCostPerOpen: null, bestCostPerReply: null });
   });
 
   it("calls public fetch functions without identity", async () => {


### PR DESCRIPTION
## Summary
- `/workflows/ranked`, `/public/workflows/ranked` now return `200 { results: [] }` instead of `404` when no workflows match the filter criteria
- `/workflows/best`, `/public/workflows/best` now return `200 { bestCostPerOpen: null, bestCostPerReply: null }` instead of `404`
- Removed 404 response definitions from OpenAPI spec for these endpoints
- Updated 4 regression tests to verify the new behavior

## Why
Listing/search endpoints returning 404 on empty results is semantically wrong — the resource (the list) exists, it's just empty. Callers (api-service, Windmill scripts) were treating this as a crash instead of a valid empty state.

## Test plan
- [x] All 449 tests pass
- [x] 4 existing tests updated to verify 200 + empty body instead of 404
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)