### PR TITLE
fix: ban http.call service "api" at deploy time

### DIFF
--- a/src/lib/dag-validator.ts
+++ b/src/lib/dag-validator.ts
@@ -30,6 +30,12 @@ export interface ValidationResult {
   errors: ValidationError[];
 }
 
+/**
+ * Service names that are banned in http.call nodes.
+ * api-service is a proxy — workflows must call the underlying services directly.
+ */
+const BANNED_HTTP_CALL_SERVICES = new Set(["api"]);
+
 export function validateDAG(dag: DAG): ValidationResult {
   const errors: ValidationError[] = [];
   const nodeIds = dag.nodes.map((n) => n.id);
@@ -105,7 +111,21 @@ export function validateDAG(dag: DAG): ValidationResult {
     });
   }
 
-  // 7. onError references an existing node
+  // 7. Banned service names in http.call nodes
+  for (const node of dag.nodes) {
+    if (node.type !== "http.call") continue;
+    const service = node.config?.service;
+    if (typeof service === "string" && BANNED_HTTP_CALL_SERVICES.has(service)) {
+      errors.push({
+        field: `nodes[${node.id}].config.service`,
+        message: `Banned service "${service}" in http.call node "${node.id}". ` +
+          `api-service is a proxy — call the underlying service directly ` +
+          `(e.g. "brand", "lead", "client").`,
+      });
+    }
+  }
+
+  // 8. onError references an existing node
   if (dag.onError && !nodeIdSet.has(dag.onError)) {
     errors.push({
       field: "onError",

--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -143,7 +143,7 @@ A workflow DAG has:
 ## Recommended Node Type: http.call
 
 Use "http.call" for all service calls. Config:
-- service (string): service name, maps to {SERVICE}_SERVICE_URL env var
+- service (string): service name, maps to {SERVICE}_SERVICE_URL env var. NEVER use "api" — api-service is a proxy. Call the underlying service directly (e.g. "brand", "lead", "client").
 - method (string): HTTP verb (GET, POST, PUT, DELETE)
 - path (string): endpoint path
 - body (object, optional): static request body parts

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -268,6 +268,17 @@ export const DAG_WITH_RETRIES_ZERO: DAG = {
   edges: [],
 };
 
+export const DAG_WITH_BANNED_API_SERVICE: DAG = {
+  nodes: [
+    {
+      id: "brand-profile",
+      type: "http.call",
+      config: { service: "api", method: "GET", path: "/brands/123/profile" },
+    },
+  ],
+  edges: [],
+};
+
 export const DAG_WITH_CUSTOM_RETRIES: DAG = {
   nodes: [
     {

--- a/tests/unit/dag-validator.test.ts
+++ b/tests/unit/dag-validator.test.ts
@@ -21,6 +21,7 @@ import {
   DAG_WITH_ON_ERROR,
   DAG_WITH_BAD_ON_ERROR,
   DAG_WITH_RETRIES_ZERO,
+  DAG_WITH_BANNED_API_SERVICE,
 } from "../helpers/fixtures.js";
 
 describe("validateDAG", () => {
@@ -150,5 +151,16 @@ describe("validateDAG", () => {
     const result = validateDAG(DAG_WITH_RETRIES_ZERO);
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
+  });
+
+  it("rejects a DAG with http.call using banned service 'api'", () => {
+    const result = validateDAG(DAG_WITH_BANNED_API_SERVICE);
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.message.includes('Banned service "api"'))
+    ).toBe(true);
+    expect(
+      result.errors.some((e) => e.message.includes("call the underlying service directly"))
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Adds deploy-time validation in `dag-validator.ts` that rejects `http.call` nodes using `service: "api"` with a clear error message directing callers to use the underlying service directly (e.g. "brand", "lead", "client")
- Updates the prompt template to explicitly document that "api" is banned as a service name
- Adds regression test reproducing the exact failure from the `sales-email-cold-outreach-pyre` workflow

## Context
The Pyre workflow `sales-email-cold-outreach-pyre` deployed a `brand_profile` step with `http.call` using `service: "api"`, which resolves to `API_SERVICE_URL` — an env var that doesn't exist because api-service is a proxy and should never be called directly. This caused an infinite fail/retry loop until auto-stopped after 3 consecutive failures.

## Test plan
- [x] New unit test: rejects DAG with `service: "api"` in `http.call` node
- [x] All 322 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)