### PR TITLE
feat: store x-feature-slug in workflow runs

### DIFF
--- a/drizzle/0019_add_feature_slug_to_runs.sql
+++ b/drizzle/0019_add_feature_slug_to_runs.sql
@@ -1,0 +1,6 @@
+-- Add feature_slug column to workflow_runs for per-feature analytics.
+-- Propagated via x-feature-slug header from campaign-service / features-service.
+
+ALTER TABLE "workflow_runs" ADD COLUMN "feature_slug" text;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_workflow_runs_feature_slug" ON "workflow_runs" ("feature_slug");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1772621106410,
       "tag": "0018_scope_unique_indexes_by_org",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1772707506410,
+      "tag": "0019_add_feature_slug_to_runs",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -627,6 +627,11 @@
             "type": "string",
             "nullable": true
           },
+          "featureSlug": {
+            "type": "string",
+            "nullable": true,
+            "description": "Feature slug from features-service. Used for per-feature analytics."
+          },
           "workflowName": {
             "type": "string",
             "nullable": true,
@@ -713,6 +718,7 @@
           "orgId",
           "campaignId",
           "brandId",
+          "featureSlug",
           "workflowName",
           "subrequestId",
           "userId",
@@ -1447,6 +1453,16 @@
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -1631,6 +1647,16 @@
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1738,6 +1764,16 @@
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "responses": {
@@ -1842,6 +1878,16 @@
             "required": false,
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],
@@ -1977,6 +2023,16 @@
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "responses": {
@@ -2081,6 +2137,16 @@
             "required": false,
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],
@@ -2198,6 +2264,16 @@
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "responses": {
@@ -2293,6 +2369,16 @@
             "required": false,
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],
@@ -2401,6 +2487,16 @@
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "responses": {
@@ -2498,6 +2594,16 @@
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "responses": {
@@ -2559,6 +2665,16 @@
             },
             "required": false,
             "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter runs by feature slug."
+            },
+            "required": false,
+            "description": "Filter runs by feature slug.",
+            "name": "featureSlug",
             "in": "query"
           },
           {
@@ -2627,6 +2743,16 @@
             "required": false,
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],
@@ -2735,6 +2861,16 @@
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "responses": {
@@ -2822,6 +2958,16 @@
             "required": false,
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],
@@ -2930,6 +3076,16 @@
             "required": false,
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],
@@ -3148,6 +3304,16 @@
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "responses": {
@@ -3284,6 +3450,16 @@
             "required": false,
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],
@@ -3594,6 +3770,16 @@
             "required": false,
             "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -54,6 +54,7 @@ export const workflowRuns = pgTable(
     userId: text("user_id"),
     campaignId: text("campaign_id"),
     brandId: text("brand_id"),
+    featureSlug: text("feature_slug"),
     workflowName: text("workflow_name"),
     subrequestId: text("subrequest_id"),
     runId: text("run_id"),

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -39,8 +39,10 @@ export function requireIdentity(
 
   const campaignId = req.headers["x-campaign-id"] as string | undefined;
   const workflowName = req.headers["x-workflow-name"] as string | undefined;
+  const featureSlug = req.headers["x-feature-slug"] as string | undefined;
   if (campaignId) res.locals.campaignId = campaignId;
   if (workflowName) res.locals.workflowName = workflowName;
+  if (featureSlug) res.locals.featureSlug = featureSlug;
 
   next();
 }

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -125,6 +125,7 @@ router.post(
       // Extract tracking context: prefer request body inputs, fall back to headers
       const campaignId = (body.inputs?.campaignId as string | undefined) ?? (res.locals.campaignId as string | undefined);
       const brandId = (body.inputs?.brandId as string | undefined) ?? (res.locals.brandId as string | undefined);
+      const featureSlug = (body.inputs?.featureSlug as string | undefined) ?? (res.locals.featureSlug as string | undefined);
       const headerWorkflowName = res.locals.workflowName as string | undefined;
 
       // Create a child run in runs-service (links to caller's run via parentRunId)
@@ -151,7 +152,7 @@ router.post(
       const client = getWindmillClient();
       if (client) {
         try {
-          const flowInputs = { ...body.inputs, orgId, userId, runId: ownRunId, workflowName: workflow.name, campaignId, brandId, serviceEnvs: collectServiceEnvs() };
+          const flowInputs = { ...body.inputs, orgId, userId, runId: ownRunId, workflowName: workflow.name, campaignId, brandId, featureSlug, serviceEnvs: collectServiceEnvs() };
           windmillJobId = await client.runFlow(
             workflow.windmillFlowPath,
             flowInputs
@@ -178,6 +179,7 @@ router.post(
           userId,
           campaignId: campaignId ?? workflow.campaignId,
           brandId: brandId ?? workflow.createdForBrandId,
+          featureSlug,
           workflowName: workflow.name,
           subrequestId: (body.inputs?.subrequestId as string | undefined) ?? workflow.subrequestId,
           runId: ownRunId,
@@ -252,6 +254,7 @@ router.post("/workflows/:id/execute", requireApiKey, requireBrandId, async (req,
     // Extract tracking context: prefer request body inputs, fall back to headers
     const execCampaignId = (body.inputs?.campaignId as string | undefined) ?? (res.locals.campaignId as string | undefined);
     const execBrandId = (body.inputs?.brandId as string | undefined) ?? (res.locals.brandId as string | undefined);
+    const execFeatureSlug = (body.inputs?.featureSlug as string | undefined) ?? (res.locals.featureSlug as string | undefined);
 
     // Create a child run in runs-service (links to caller's run via parentRunId)
     let ownRunId: string | null = null;
@@ -277,7 +280,7 @@ router.post("/workflows/:id/execute", requireApiKey, requireBrandId, async (req,
     const client = getWindmillClient();
     if (client) {
       try {
-        const flowInputs = { ...body.inputs, orgId, userId: executeUserId, runId: ownRunId, workflowName: workflow.name, campaignId: execCampaignId, brandId: execBrandId, serviceEnvs: collectServiceEnvs() };
+        const flowInputs = { ...body.inputs, orgId, userId: executeUserId, runId: ownRunId, workflowName: workflow.name, campaignId: execCampaignId, brandId: execBrandId, featureSlug: execFeatureSlug, serviceEnvs: collectServiceEnvs() };
         windmillJobId = await client.runFlow(
           workflow.windmillFlowPath,
           flowInputs
@@ -301,6 +304,7 @@ router.post("/workflows/:id/execute", requireApiKey, requireBrandId, async (req,
         userId: executeUserId,
         campaignId: execCampaignId ?? workflow.campaignId,
         brandId: execBrandId ?? workflow.createdForBrandId,
+        featureSlug: execFeatureSlug,
         workflowName: workflow.name,
         subrequestId: (body.inputs?.subrequestId as string | undefined) ?? workflow.subrequestId,
         runId: ownRunId,
@@ -391,7 +395,7 @@ router.get("/workflow-runs/:id", requireApiKey, async (req, res) => {
 // GET /workflow-runs — List runs
 router.get("/workflow-runs", requireApiKey, async (req, res) => {
   try {
-    const { workflowId, orgId, campaignId, status } = req.query;
+    const { workflowId, orgId, campaignId, featureSlug, status } = req.query;
 
     const conditions = [];
 
@@ -403,6 +407,9 @@ router.get("/workflow-runs", requireApiKey, async (req, res) => {
     }
     if (campaignId && typeof campaignId === "string") {
       conditions.push(eq(workflowRuns.campaignId, campaignId));
+    }
+    if (featureSlug && typeof featureSlug === "string") {
+      conditions.push(eq(workflowRuns.featureSlug, featureSlug));
     }
     if (status && typeof status === "string") {
       conditions.push(eq(workflowRuns.status, status));

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -215,6 +215,7 @@ export const WorkflowRunResponseSchema = z
     orgId: z.string(),
     campaignId: z.string().nullable(),
     brandId: z.string().nullable(),
+    featureSlug: z.string().nullable().describe("Feature slug from features-service. Used for per-feature analytics."),
     workflowName: z.string().nullable().describe("Name of the workflow that was executed."),
     subrequestId: z.string().nullable(),
     userId: z.string().nullable().describe("User ID from the execution context."),
@@ -646,6 +647,7 @@ const IdentityHeaders = z.object({
   "x-campaign-id": z.string().optional().describe("Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."),
   "x-brand-id": z.string().optional().describe("Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."),
   "x-workflow-name": z.string().optional().describe("Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."),
+  "x-feature-slug": z.string().optional().describe("Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."),
 });
 
 // --- Register Paths ---
@@ -951,6 +953,7 @@ registry.registerPath({
       workflowId: z.string().uuid().optional(),
       orgId: z.string().optional(),
       campaignId: z.string().optional(),
+      featureSlug: z.string().optional().describe("Filter runs by feature slug."),
       status: z.string().optional(),
     }),
   },

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -792,3 +792,89 @@ describe("POST /workflow-runs/:id/cancel", () => {
     expect(mockCancelJob).toHaveBeenCalled();
   });
 });
+
+describe("x-feature-slug tracking", () => {
+  beforeEach(() => {
+    mockWorkflows.length = 0;
+    mockRuns.length = 0;
+    mockSelectResponses.length = 0;
+    mockRunFlow.mockClear();
+    mockCreateRun.mockClear();
+    mockCreateRun.mockResolvedValue({ runId: "run-feat-1" });
+  });
+
+  const WORKFLOW_FIXTURE = {
+    id: "wf-feat",
+    orgId: "org-1",
+    name: "sales-email-cold-outreach-sequoia",
+    campaignId: null,
+    subrequestId: null,
+    createdForBrandId: null,
+    windmillFlowPath: "f/workflows/org_1/sales_email",
+    windmillWorkspace: "prod",
+    dag: VALID_LINEAR_DAG,
+  };
+
+  it("stores featureSlug from x-feature-slug header in the run (execute by name)", async () => {
+    mockWorkflows.push(WORKFLOW_FIXTURE);
+
+    const res = await request
+      .post("/workflows/by-name/sales-email-cold-outreach-sequoia/execute")
+      .set({ ...AUTH, "x-feature-slug": "sales-email-cold-outreach" })
+      .send({ inputs: {} });
+
+    expect(res.status).toBe(201);
+    expect(res.body.featureSlug).toBe("sales-email-cold-outreach");
+  });
+
+  it("stores featureSlug from x-feature-slug header in the run (execute by id)", async () => {
+    mockWorkflows.push(WORKFLOW_FIXTURE);
+
+    const res = await request
+      .post("/workflows/wf-feat/execute")
+      .set({ ...AUTH, "x-feature-slug": "sales-email-cold-outreach" })
+      .send({ inputs: {} });
+
+    expect(res.status).toBe(201);
+    expect(res.body.featureSlug).toBe("sales-email-cold-outreach");
+  });
+
+  it("prefers featureSlug from inputs over header", async () => {
+    mockWorkflows.push(WORKFLOW_FIXTURE);
+
+    const res = await request
+      .post("/workflows/by-name/sales-email-cold-outreach-sequoia/execute")
+      .set({ ...AUTH, "x-feature-slug": "from-header" })
+      .send({ inputs: { featureSlug: "from-inputs" } });
+
+    expect(res.status).toBe(201);
+    expect(res.body.featureSlug).toBe("from-inputs");
+  });
+
+  it("forwards featureSlug into Windmill flow inputs", async () => {
+    mockWorkflows.push(WORKFLOW_FIXTURE);
+
+    await request
+      .post("/workflows/by-name/sales-email-cold-outreach-sequoia/execute")
+      .set({ ...AUTH, "x-feature-slug": "sales-email-cold-outreach" })
+      .send({ inputs: { email: "test@example.com" } });
+
+    expect(mockRunFlow).toHaveBeenCalledWith(
+      "f/workflows/org_1/sales_email",
+      expect.objectContaining({ featureSlug: "sales-email-cold-outreach", email: "test@example.com" }),
+    );
+  });
+
+  it("featureSlug is undefined when header is not sent", async () => {
+    mockWorkflows.push(WORKFLOW_FIXTURE);
+
+    const res = await request
+      .post("/workflows/by-name/sales-email-cold-outreach-sequoia/execute")
+      .set(AUTH)
+      .send({ inputs: {} });
+
+    expect(res.status).toBe(201);
+    // featureSlug should not be set (undefined → null in JSON or absent)
+    expect(res.body.featureSlug).toBeFalsy();
+  });
+});

--- a/tests/unit/tracking-headers.test.ts
+++ b/tests/unit/tracking-headers.test.ts
@@ -10,7 +10,7 @@ function mockReqRes(headers: Record<string, string>, body?: Record<string, unkno
 }
 
 describe("requireIdentity – tracking headers", () => {
-  it("extracts x-brand-id and optional x-campaign-id, x-workflow-name into res.locals", () => {
+  it("extracts x-brand-id and optional x-campaign-id, x-workflow-name, x-feature-slug into res.locals", () => {
     const { req, res, locals } = mockReqRes({
       "x-org-id": "org-1",
       "x-user-id": "user-1",
@@ -18,6 +18,7 @@ describe("requireIdentity – tracking headers", () => {
       "x-brand-id": "brand-xyz",
       "x-campaign-id": "camp-abc",
       "x-workflow-name": "sales-email-cold-outreach",
+      "x-feature-slug": "sales-email-cold-outreach",
     });
 
     let called = false;
@@ -29,6 +30,7 @@ describe("requireIdentity – tracking headers", () => {
     expect(locals.brandId).toBe("brand-xyz");
     expect(locals.campaignId).toBe("camp-abc");
     expect(locals.workflowName).toBe("sales-email-cold-outreach");
+    expect(locals.featureSlug).toBe("sales-email-cold-outreach");
   });
 
   it("passes without x-brand-id (now optional on identity middleware)", () => {
@@ -47,6 +49,7 @@ describe("requireIdentity – tracking headers", () => {
     expect(locals).not.toHaveProperty("brandId");
     expect(locals).not.toHaveProperty("campaignId");
     expect(locals).not.toHaveProperty("workflowName");
+    expect(locals).not.toHaveProperty("featureSlug");
   });
 
   it("sets brandId in locals when x-brand-id header is present", () => {


### PR DESCRIPTION
## Summary
- Accept optional `x-feature-slug` header on execute endpoints, store it in `workflow_runs.feature_slug`
- Pass `featureSlug` into Windmill flow inputs so downstream nodes can access it
- Add `featureSlug` filter on `GET /workflow-runs` for per-feature queries
- DB migration adds nullable `feature_slug` column with index

## Test plan
- [x] Unit test: `x-feature-slug` extracted into `res.locals.featureSlug` by auth middleware
- [x] Integration: featureSlug stored from header (by-name and by-id execute)
- [x] Integration: inputs.featureSlug takes precedence over header
- [x] Integration: featureSlug forwarded to Windmill flow inputs
- [x] Integration: absent header → featureSlug is falsy
- [x] All 455 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)