### PR TITLE
feat: propagate x-feature-slug in http.call nodes

### DIFF
--- a/scripts/nodes/http-call.ts
+++ b/scripts/nodes/http-call.ts
@@ -21,6 +21,7 @@ export async function main(
   campaignId?: string,
   brandId?: string,
   workflowName?: string,
+  featureSlug?: string,
 ) {
   // Convert service name to env var prefix: "transactional-email" → "TRANSACTIONAL_EMAIL"
   const envPrefix = service.toUpperCase().replace(/-/g, "_");
@@ -66,6 +67,7 @@ export async function main(
   if (campaignId) reqHeaders["x-campaign-id"] = campaignId;
   if (brandId) reqHeaders["x-brand-id"] = brandId;
   if (workflowName) reqHeaders["x-workflow-name"] = workflowName;
+  if (featureSlug) reqHeaders["x-feature-slug"] = featureSlug;
   // Caller-supplied headers can override identity headers
   if (headers) Object.assign(reqHeaders, headers);
   // Resolved x-api-key always takes precedence

--- a/src/lib/dag-to-openflow.ts
+++ b/src/lib/dag-to-openflow.ts
@@ -75,6 +75,7 @@ export function dagToOpenFlow(dag: DAG, name: string): OpenFlow {
     campaignId: { type: "string", description: "Campaign identifier (auto-injected)" },
     brandId: { type: "string", description: "Brand identifier (auto-injected)" },
     workflowName: { type: "string", description: "Workflow name (auto-injected)" },
+    featureSlug: { type: "string", description: "Feature slug from features-service (auto-injected)" },
   };
   for (const node of dag.nodes) {
     if (!node.inputMapping) continue;
@@ -405,6 +406,7 @@ function nodeToModule(node: DAGNode, dag: DAG): FlowModule | null {
     campaignId: "flow_input.campaignId",
     brandId: "flow_input.brandId",
     workflowName: "flow_input.workflowName",
+    featureSlug: "flow_input.featureSlug",
   };
   for (const [key, expr] of Object.entries(autoInjects)) {
     if (!inputTransforms[key]) {
@@ -451,6 +453,7 @@ function buildFailureModule(node: DAGNode): FlowModule | null {
     campaignId: "flow_input.campaignId",
     brandId: "flow_input.brandId",
     workflowName: "flow_input.workflowName",
+    featureSlug: "flow_input.featureSlug",
   };
   for (const [key, expr] of Object.entries(failureAutoInjects)) {
     if (!inputTransforms[key]) {

--- a/tests/unit/http-call.test.ts
+++ b/tests/unit/http-call.test.ts
@@ -60,7 +60,7 @@ describe("http-call script", () => {
     expect(options.headers["x-run-id"]).toBe("run-uuid-3");
   });
 
-  it("auto-injects tracking headers (x-campaign-id, x-brand-id, x-workflow-name) when provided", async () => {
+  it("auto-injects tracking headers (x-campaign-id, x-brand-id, x-workflow-name, x-feature-slug) when provided", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
 
     await main(
@@ -77,12 +77,14 @@ describe("http-call script", () => {
       "camp-123",
       "brand-456",
       "sales-email-cold-outreach",
+      "sales-email-cold-outreach",
     );
 
     const [, options] = mockFetch.mock.calls[0];
     expect(options.headers["x-campaign-id"]).toBe("camp-123");
     expect(options.headers["x-brand-id"]).toBe("brand-456");
     expect(options.headers["x-workflow-name"]).toBe("sales-email-cold-outreach");
+    expect(options.headers["x-feature-slug"]).toBe("sales-email-cold-outreach");
   });
 
   it("merges custom headers with defaults", async () => {


### PR DESCRIPTION
## Summary
- `http-call.ts` node now accepts `featureSlug` param and forwards it as `x-feature-slug` header on all downstream service-to-service calls
- `dag-to-openflow.ts` auto-injects `featureSlug` from `flow_input` into every node (same pattern as `campaignId`/`brandId`/`workflowName`)
- Covers both normal modules and onError failure modules

Follows PR #157 which added `x-feature-slug` acceptance and storage at the workflow-service level. This PR completes the chain: the header now flows from campaign-service → workflow-service → every node → every downstream service.

## Test plan
- [x] Unit test: http-call sends `x-feature-slug` header when `featureSlug` param is provided
- [x] All 455 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)