### PR TITLE
fix: default null searchParams to {} in lead-service node

### DIFF
--- a/scripts/nodes/lead-service.ts
+++ b/scripts/nodes/lead-service.ts
@@ -38,7 +38,7 @@ export async function main(
         campaignId: context.campaignId,
         brandId: context.brandId,
         parentRunId: resolvedRunId,
-        searchParams,
+        searchParams: searchParams ?? {},
       }),
     }
   );

--- a/tests/unit/node-identity-headers.test.ts
+++ b/tests/unit/node-identity-headers.test.ts
@@ -265,6 +265,44 @@ describe("node scripts inject identity headers", () => {
       expect(options.headers["x-run-id"]).toBe("run-uuid-1");
     });
 
+    it("sends empty object for searchParams when null (regression: lead-service 400)", async () => {
+      const { main } = await import("../../scripts/nodes/lead-service.js");
+      mockFetch.mockResolvedValueOnce(jsonResponse({ found: true, lead: { email: "a@b.com" } }));
+
+      await main(
+        "apollo",
+        null as any,                                                              // searchParams = null
+        { orgId: "ctx-org", brandId: "b1", campaignId: "c1", runId: "ctx-run" },
+        leadEnvs,
+        "org-uuid-1",
+        "user-uuid-1",
+        "run-uuid-1",
+      );
+
+      const [, options] = mockFetch.mock.calls[0];
+      const body = JSON.parse(options.body);
+      expect(body.searchParams).toEqual({});
+    });
+
+    it("sends empty object for searchParams when undefined", async () => {
+      const { main } = await import("../../scripts/nodes/lead-service.js");
+      mockFetch.mockResolvedValueOnce(jsonResponse({ found: true, lead: { email: "a@b.com" } }));
+
+      await main(
+        "apollo",
+        undefined,
+        { orgId: "ctx-org", brandId: "b1", campaignId: "c1", runId: "ctx-run" },
+        leadEnvs,
+        "org-uuid-1",
+        "user-uuid-1",
+        "run-uuid-1",
+      );
+
+      const [, options] = mockFetch.mock.calls[0];
+      const body = JSON.parse(options.body);
+      expect(body.searchParams).toEqual({});
+    });
+
     it("falls back to context.orgId and context.runId", async () => {
       const { main } = await import("../../scripts/nodes/lead-service.js");
       mockFetch.mockResolvedValueOnce(jsonResponse({ found: true, lead: { email: "a@b.com" } }));


### PR DESCRIPTION
## Summary
- When a campaign has no `searchParams`, Windmill passes `null` to the lead-service node, which forwards it to `POST /buffer/next`. The lead service rejects `null` (expects a record), causing 400 errors and auto-stopping campaigns after 3 consecutive failures.
- Fix: `searchParams ?? {}` in the lead-service node script so `null`/`undefined` become an empty object.

## Test plan
- [x] Added regression test for `searchParams: null`
- [x] Added test for `searchParams: undefined`
- [x] All 457 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)