### PR TITLE
feat: add featureSlug to workflows table

### DIFF
--- a/drizzle/0020_add_feature_slug_to_workflows.sql
+++ b/drizzle/0020_add_feature_slug_to_workflows.sql
@@ -1,0 +1,6 @@
+-- Add feature_slug column to workflows so each workflow can be directly linked to a feature.
+-- The dashboard uses this to list workflows for a given feature instead of filtering by category.
+
+ALTER TABLE "workflows" ADD COLUMN "feature_slug" text;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_workflows_feature_slug" ON "workflows" ("feature_slug");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1772707506410,
       "tag": "0019_add_feature_slug_to_runs",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1772793906410,
+      "tag": "0020_add_feature_slug_to_workflows",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -78,6 +78,11 @@
             "type": "string",
             "description": "Organization ID."
           },
+          "featureSlug": {
+            "type": "string",
+            "nullable": true,
+            "description": "Feature slug from features-service. Links this workflow to a specific feature."
+          },
           "createdForBrandId": {
             "type": "string",
             "nullable": true
@@ -190,6 +195,7 @@
         "required": [
           "id",
           "orgId",
+          "featureSlug",
           "createdForBrandId",
           "humanId",
           "campaignId",
@@ -341,6 +347,10 @@
           "description": {
             "type": "string",
             "description": "Human-readable description of what this workflow does."
+          },
+          "featureSlug": {
+            "type": "string",
+            "description": "Feature slug from features-service. Links this workflow to a specific feature for dashboard display."
           },
           "category": {
             "$ref": "#/components/schemas/WorkflowCategory"
@@ -847,6 +857,10 @@
           "createdForBrandId": {
             "type": "string",
             "description": "Optional brand ID — records which brand context created this workflow."
+          },
+          "featureSlug": {
+            "type": "string",
+            "description": "Feature slug from features-service. Links this workflow to a specific feature for dashboard display."
           },
           "description": {
             "type": "string",
@@ -1539,6 +1553,16 @@
             },
             "required": false,
             "name": "campaignId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter workflows by feature slug."
+            },
+            "required": false,
+            "description": "Filter workflows by feature slug.",
+            "name": "featureSlug",
             "in": "query"
           },
           {
@@ -3168,6 +3192,16 @@
           },
           {
             "schema": {
+              "type": "string",
+              "description": "Filter workflows by feature slug."
+            },
+            "required": false,
+            "description": "Filter workflows by feature slug.",
+            "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
               "allOf": [
                 {
                   "$ref": "#/components/schemas/WorkflowCategory"
@@ -3513,6 +3547,16 @@
             "required": false,
             "description": "Filter workflows by brand ID.",
             "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter workflows by feature slug."
+            },
+            "required": false,
+            "description": "Filter workflows by feature slug.",
+            "name": "featureSlug",
             "in": "query"
           },
           {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -21,6 +21,7 @@ export const workflows = pgTable(
     name: text("name").notNull(),
     displayName: text("display_name"),
     description: text("description"),
+    featureSlug: text("feature_slug"),
     category: text("category").notNull(),
     channel: text("channel").notNull(),
     audienceType: text("audience_type").notNull(),

--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -305,6 +305,7 @@ async function attemptUpgrade(
       .values({
         orgId: wf.orgId,
         createdForBrandId: wf.createdForBrandId,
+        featureSlug: wf.featureSlug,
         humanId: wf.humanId,
         campaignId: wf.campaignId,
         subrequestId: wf.subrequestId,

--- a/src/routes/public-workflows.ts
+++ b/src/routes/public-workflows.ts
@@ -25,10 +25,11 @@ router.get("/public/workflows/ranked", async (req, res) => {
       res.status(400).json({ error: "Validation error", details: query.error });
       return;
     }
-    const { orgId, brandId, category, channel, audienceType, objective, limit, groupBy } = query.data;
+    const { orgId, brandId, featureSlug, category, channel, audienceType, objective, limit, groupBy } = query.data;
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
+    if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
     if (category) conditions.push(eq(workflows.category, category));
     if (channel) conditions.push(eq(workflows.channel, channel));
     if (audienceType) conditions.push(eq(workflows.audienceType, audienceType));

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -324,6 +324,7 @@ router.post("/workflows", requireApiKey, async (req, res) => {
       .values({
         orgId,
         createdForBrandId: body.createdForBrandId,
+        featureSlug: body.featureSlug,
         campaignId: body.campaignId,
         subrequestId: body.subrequestId,
         name: body.name,
@@ -515,6 +516,7 @@ router.put("/workflows/upgrade", requireApiKey, async (req, res) => {
           .set({
             orgId,
             createdForBrandId: wf.createdForBrandId,
+            featureSlug: wf.featureSlug ?? existing.featureSlug,
             description: wf.description ?? existing.description,
             category: wf.category,
             channel: wf.channel,
@@ -570,6 +572,7 @@ router.put("/workflows/upgrade", requireApiKey, async (req, res) => {
           .values({
             orgId,
             createdForBrandId: wf.createdForBrandId,
+            featureSlug: wf.featureSlug,
             name,
             displayName: name,
             description: wf.description,
@@ -625,7 +628,7 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
       res.status(400).json({ error: "Validation error", details: query.error });
       return;
     }
-    const { orgId, brandId, category, channel, audienceType, objective, limit, groupBy } = query.data;
+    const { orgId, brandId, featureSlug, category, channel, audienceType, objective, limit, groupBy } = query.data;
     const identity = {
       orgId: res.locals.orgId as string,
       userId: res.locals.userId as string,
@@ -634,6 +637,7 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
+    if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
     if (category) conditions.push(eq(workflows.category, category));
     if (channel) conditions.push(eq(workflows.channel, channel));
     if (audienceType) conditions.push(eq(workflows.audienceType, audienceType));
@@ -875,7 +879,7 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
 // GET /workflows — List workflows (defaults to active only; ?status=all for all)
 router.get("/workflows", requireApiKey, async (req, res) => {
   try {
-    const { orgId, brandId, humanId, campaignId, category, channel, audienceType, tag, status } = req.query;
+    const { orgId, brandId, humanId, campaignId, featureSlug, category, channel, audienceType, tag, status } = req.query;
 
     const conditions: ReturnType<typeof eq>[] = [];
 
@@ -895,6 +899,9 @@ router.get("/workflows", requireApiKey, async (req, res) => {
     }
     if (campaignId && typeof campaignId === "string") {
       conditions.push(eq(workflows.campaignId, campaignId));
+    }
+    if (featureSlug && typeof featureSlug === "string") {
+      conditions.push(eq(workflows.featureSlug, featureSlug));
     }
     if (category && typeof category === "string") {
       conditions.push(eq(workflows.category, category));
@@ -1138,6 +1145,7 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
         .values({
           orgId: existing.orgId,
           createdForBrandId: existing.createdForBrandId,
+          featureSlug: existing.featureSlug,
           humanId: existing.humanId,
           campaignId: existing.campaignId,
           subrequestId: existing.subrequestId,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -113,6 +113,7 @@ export const CreateWorkflowSchema = z
     subrequestId: z.string().optional().describe("Optional subrequest ID for cost tracking."),
     name: z.string().min(1).describe("Workflow name. Must be unique within the orgId. Used to execute by name later."),
     description: z.string().optional().describe("Human-readable description of what this workflow does."),
+    featureSlug: z.string().optional().describe("Feature slug from features-service. Links this workflow to a specific feature for dashboard display."),
     category: WorkflowCategorySchema.describe("Workflow category."),
     channel: WorkflowChannelSchema.describe("Workflow distribution channel."),
     audienceType: WorkflowAudienceTypeSchema.describe("Workflow audience type."),
@@ -136,6 +137,7 @@ export const WorkflowResponseSchema = z
   .object({
     id: z.string().uuid().describe("Workflow UUID."),
     orgId: z.string().describe("Organization ID."),
+    featureSlug: z.string().nullable().describe("Feature slug from features-service. Links this workflow to a specific feature."),
     createdForBrandId: z.string().nullable(),
     humanId: z.string().nullable().describe("Human ID if this workflow was generated in a human expert's style."),
     campaignId: z.string().nullable(),
@@ -242,6 +244,7 @@ export const WorkflowRunResponseSchema = z
 export const DeployWorkflowItemSchema = z
   .object({
     createdForBrandId: z.string().optional().describe("Optional brand ID — records which brand context created this workflow."),
+    featureSlug: z.string().optional().describe("Feature slug from features-service. Links this workflow to a specific feature for dashboard display."),
     description: z.string().optional().describe("Human-readable description."),
     category: WorkflowCategorySchema.describe("Workflow category. Required — used to build the workflow name."),
     channel: WorkflowChannelSchema.describe("Workflow distribution channel. Required — used to build the workflow name."),
@@ -444,6 +447,7 @@ export const RankedWorkflowQuerySchema = z
   .object({
     orgId: z.string().optional().describe("Organization ID. When omitted, searches across all orgs."),
     brandId: z.string().optional().describe("Filter workflows by brand ID."),
+    featureSlug: z.string().optional().describe("Filter workflows by feature slug."),
     category: WorkflowCategorySchema.optional().describe("Filter workflows by category."),
     channel: WorkflowChannelSchema.optional().describe("Filter workflows by channel."),
     audienceType: WorkflowAudienceTypeSchema.optional().describe("Filter workflows by audience type."),
@@ -703,6 +707,7 @@ registry.registerPath({
       brandId: z.string().optional(),
       humanId: z.string().optional(),
       campaignId: z.string().optional(),
+      featureSlug: z.string().optional().describe("Filter workflows by feature slug."),
       category: WorkflowCategorySchema.optional(),
       channel: WorkflowChannelSchema.optional(),
       audienceType: WorkflowAudienceTypeSchema.optional(),

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -222,6 +222,49 @@ describe("GET /workflows", () => {
     expect(res.body.workflows).toBeDefined();
   });
 
+  it("creates a workflow with featureSlug and returns it in response", async () => {
+    const res = await request
+      .post("/workflows")
+      .set(AUTH)
+      .send({
+        name: "Feature Flow",
+        createdForBrandId: "brand-test-001",
+        featureSlug: "outlet-database-discovery",
+        category: "outlets",
+        channel: "database",
+        audienceType: "discovery",
+        dag: VALID_LINEAR_DAG,
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.featureSlug).toBe("outlet-database-discovery");
+  });
+
+  it("filters workflows by featureSlug", async () => {
+    mockDbRows.push({
+      id: "wf-feature",
+      orgId: "org-1",
+      name: "outlets-database-discovery-sequoia",
+      featureSlug: "outlet-database-discovery",
+      category: "outlets",
+      channel: "database",
+      audienceType: "discovery",
+      status: "active",
+      dag: VALID_LINEAR_DAG,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const res = await request
+      .get("/workflows")
+      .query({ featureSlug: "outlet-database-discovery" })
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.workflows).toBeDefined();
+    expect(res.body.workflows[0].featureSlug).toBe("outlet-database-discovery");
+  });
+
   it("returns dimensions in response", async () => {
     mockDbRows.push({
       id: "wf-1",
@@ -262,6 +305,25 @@ describe("PUT /workflows/upgrade", () => {
     mockSelectResponses.length = 0;
     mockFetchPromptTemplates.mockReset();
     mockFetchPromptTemplates.mockResolvedValue(new Map());
+  });
+
+  it("deploys a workflow with featureSlug", async () => {
+    const res = await request
+      .put("/workflows/upgrade")
+      .set(AUTH)
+      .send({
+        workflows: [
+          {
+            ...DEPLOY_ITEM,
+            featureSlug: "outlet-database-discovery",
+            dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    // featureSlug is stored in DB but deploy result only returns standard fields
+    expect(res.body.workflows).toHaveLength(1);
   });
 
   it("deploys a workflow with tags", async () => {


### PR DESCRIPTION
## Summary
- Adds `feature_slug` column to the `workflows` table so workflows can be directly linked to features
- Adds `featureSlug` filter to `GET /workflows`, `GET /workflows/ranked`, and `GET /public/workflows/ranked` endpoints
- Wires `featureSlug` through create, deploy, fork, and startup-upgrade code paths
- Includes DB migration `0020_add_feature_slug_to_workflows.sql`

## Why
The dashboard page for a feature was filtering workflows by `category`, which broke when the feature's category didn't match the workflow's category (e.g. feature had `pr` but workflows had `outlets`). Direct feature-slug linking eliminates this fragile coupling.

## Test plan
- [x] New integration tests: create workflow with featureSlug, filter by featureSlug, deploy with featureSlug
- [x] All 460 tests pass
- [x] Build + OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)