### PR TITLE
feat: adapt to api-registry progressive disclosure API

### DIFF
--- a/src/lib/api-registry-client.ts
+++ b/src/lib/api-registry-client.ts
@@ -2,23 +2,27 @@ import type { IdentityHeaders } from "./key-service-client.js";
 
 export interface LlmServiceSummary {
   service: string;
-  baseUrl: string;
-  title?: string;
   description?: string;
-  error?: string;
-  endpoints: Array<{
-    method: string;
-    path: string;
-    summary: string;
-    params?: Array<{ name: string; in: string; required: boolean; type?: string }>;
-    bodyFields?: string[];
-  }>;
+  endpointCount: number;
 }
 
 export interface LlmContextResponse {
   _description: string;
   _usage: string;
   services: LlmServiceSummary[];
+}
+
+export interface LlmServiceEndpoint {
+  method: string;
+  path: string;
+  summary: string;
+  responseFields?: string[];
+}
+
+export interface LlmServiceEndpointsResponse {
+  service: string;
+  description?: string;
+  endpoints: LlmServiceEndpoint[];
 }
 
 function getApiRegistryConfig(): { baseUrl: string; apiKey: string } {
@@ -61,6 +65,31 @@ export async function fetchLlmContext(identity?: IdentityHeaders): Promise<LlmCo
   }
 
   return res.json() as Promise<LlmContextResponse>;
+}
+
+/** GET /llm-context/:service — endpoints for a specific service (method, path, summary) */
+export async function fetchServiceEndpoints(
+  serviceName: string,
+  identity?: IdentityHeaders,
+): Promise<LlmServiceEndpointsResponse> {
+  const { baseUrl, apiKey } = getApiRegistryConfig();
+
+  const res = await fetch(
+    `${baseUrl}/llm-context/${encodeURIComponent(serviceName)}`,
+    {
+      method: "GET",
+      headers: buildHeaders(apiKey, identity),
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `api-registry error: GET /llm-context/${serviceName} -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  return res.json() as Promise<LlmServiceEndpointsResponse>;
 }
 
 /** GET /services — list all registered services (used for health check + enumeration) */

--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -80,14 +80,32 @@ export const LIST_SERVICES_TOOL = {
   },
 };
 
+/** Tool for listing endpoints of a specific service */
+export const LIST_SERVICE_ENDPOINTS_TOOL = {
+  name: "list_service_endpoints" as const,
+  description:
+    "List all endpoints for a specific service with method, path, and summary. " +
+    "Call this after list_services to see what endpoints a service offers before diving into full details.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      service: {
+        type: "string" as const,
+        description: "The service name (e.g. 'lead', 'campaign', 'brand')",
+      },
+    },
+    required: ["service"],
+  },
+};
+
 /** Tool for getting detailed OpenAPI spec for a specific service */
 export const GET_SERVICE_ENDPOINTS_TOOL = {
   name: "get_service_endpoints" as const,
   description:
     "Get the full OpenAPI specification for a specific service, including all endpoints, " +
     "request/response schemas, required fields, and parameter details. " +
-    "Call this for EACH service you plan to use in the workflow to understand exact endpoint paths, " +
-    "required body fields, and response shapes. Do NOT guess — always verify.",
+    "Use this when you need exact request body schemas and response shapes for specific endpoints. " +
+    "Do NOT guess — always verify.",
   input_schema: {
     type: "object" as const,
     properties: {
@@ -103,6 +121,7 @@ export const GET_SERVICE_ENDPOINTS_TOOL = {
 /** All tools for agentic workflow generation */
 export const AGENTIC_TOOLS = [
   LIST_SERVICES_TOOL,
+  LIST_SERVICE_ENDPOINTS_TOOL,
   GET_SERVICE_ENDPOINTS_TOOL,
   DAG_GENERATION_TOOL,
 ];
@@ -124,9 +143,10 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const serviceSection = `## Service Discovery (MANDATORY)
 
 You have access to a live API registry via tools. Before generating the workflow, you MUST:
-1. Call list_services to see all available microservices and their endpoints
-2. Call get_service_endpoints for EACH service you plan to use in the workflow — this gives you exact endpoint paths, required request body fields, and response schemas
-3. Only then call create_workflow with an informed DAG based on verified endpoint specs
+1. Call list_services to see all available microservices (names, descriptions, endpoint counts)
+2. Call list_service_endpoints for services you're interested in — this shows method, path, and summary for each endpoint
+3. Call get_service_endpoints for EACH service you plan to use in the workflow — this gives you exact request body fields, response schemas, and parameter details
+4. Only then call create_workflow with an informed DAG based on verified endpoint specs
 
 Do NOT guess endpoint paths or request body fields. ALWAYS verify with get_service_endpoints first.
 If a service or endpoint you need does not exist, do NOT invent it — adjust the workflow to use only real endpoints.`;

--- a/src/lib/workflow-generator.ts
+++ b/src/lib/workflow-generator.ts
@@ -7,6 +7,7 @@ import {
 } from "./prompt-templates.js";
 import {
   fetchLlmContext,
+  fetchServiceEndpoints,
   fetchServiceSpec,
   fetchSpecsForServices,
 } from "./api-registry-client.js";
@@ -58,11 +59,15 @@ async function resolveToolCall(
       const context = await fetchLlmContext(identity);
       const summary = context.services.map((s) => ({
         name: s.service,
-        description: s.description ?? s.title ?? "",
-        endpointCount: s.endpoints.length,
-        endpoints: s.endpoints.map((e) => `${e.method} ${e.path}`),
+        description: s.description ?? "",
+        endpointCount: s.endpointCount,
       }));
       return { content: JSON.stringify(summary, null, 2) };
+    }
+    case "list_service_endpoints": {
+      const serviceName = toolInput.service as string;
+      const endpoints = await fetchServiceEndpoints(serviceName, identity);
+      return { content: JSON.stringify(endpoints, null, 2) };
     }
     case "get_service_endpoints": {
       const serviceName = toolInput.service as string;

--- a/src/lib/workflow-upgrader.ts
+++ b/src/lib/workflow-upgrader.ts
@@ -7,6 +7,7 @@ import {
 } from "./prompt-templates.js";
 import {
   fetchLlmContext,
+  fetchServiceEndpoints,
   fetchServiceSpec,
 } from "./api-registry-client.js";
 import type { IdentityHeaders } from "./key-service-client.js";
@@ -33,11 +34,15 @@ async function resolveToolCall(
       const context = await fetchLlmContext(identity);
       const summary = context.services.map((s) => ({
         name: s.service,
-        description: s.description ?? s.title ?? "",
-        endpointCount: s.endpoints.length,
-        endpoints: s.endpoints.map((e) => `${e.method} ${e.path}`),
+        description: s.description ?? "",
+        endpointCount: s.endpointCount,
       }));
       return { content: JSON.stringify(summary, null, 2) };
+    }
+    case "list_service_endpoints": {
+      const serviceName = toolInput.service as string;
+      const endpoints = await fetchServiceEndpoints(serviceName, identity);
+      return { content: JSON.stringify(endpoints, null, 2) };
     }
     case "get_service_endpoints": {
       const serviceName = toolInput.service as string;

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -8,6 +8,7 @@ vi.mock("../../src/lib/api-registry-client.js", () => ({
   fetchServiceList: (...args: unknown[]) => mockFetchServiceList(...args),
   fetchSpecsForServices: (...args: unknown[]) => mockFetchSpecsForServices(...args),
   fetchLlmContext: vi.fn().mockResolvedValue({ services: [] }),
+  fetchServiceEndpoints: vi.fn().mockResolvedValue({ service: "", endpoints: [] }),
   fetchServiceSpec: vi.fn().mockResolvedValue({}),
 }));
 

--- a/tests/unit/workflow-generator.test.ts
+++ b/tests/unit/workflow-generator.test.ts
@@ -13,10 +13,12 @@ import { VALID_LINEAR_DAG } from "../helpers/fixtures.js";
 
 // Mock api-registry-client
 const mockFetchLlmContext = vi.fn();
+const mockFetchServiceEndpoints = vi.fn();
 const mockFetchServiceSpec = vi.fn();
 
 vi.mock("../../src/lib/api-registry-client.js", () => ({
   fetchLlmContext: (...args: unknown[]) => mockFetchLlmContext(...args),
+  fetchServiceEndpoints: (...args: unknown[]) => mockFetchServiceEndpoints(...args),
   fetchServiceSpec: (...args: unknown[]) => mockFetchServiceSpec(...args),
 }));
 
@@ -43,6 +45,7 @@ describe("buildSystemPrompt", () => {
     const prompt = buildSystemPrompt();
     expect(prompt).toContain("Service Discovery (MANDATORY)");
     expect(prompt).toContain("list_services");
+    expect(prompt).toContain("list_service_endpoints");
     expect(prompt).toContain("get_service_endpoints");
     expect(prompt).not.toContain("Available Services");
   });
@@ -159,23 +162,23 @@ const MOCK_LLM_CONTEXT = {
   services: [
     {
       service: "lead",
-      baseUrl: "https://lead.example.com",
-      title: "Lead Service",
       description: "Lead buffer management",
-      endpoints: [
-        { method: "POST", path: "/buffer/next", summary: "Get next lead" },
-        { method: "POST", path: "/buffer/push", summary: "Push lead" },
-      ],
+      endpointCount: 2,
     },
     {
       service: "campaign",
-      baseUrl: "https://campaign.example.com",
-      title: "Campaign Service",
       description: "Campaign lifecycle",
-      endpoints: [
-        { method: "POST", path: "/gate-check", summary: "Gate check" },
-      ],
+      endpointCount: 1,
     },
+  ],
+};
+
+const MOCK_SERVICE_ENDPOINTS = {
+  service: "lead",
+  description: "Lead buffer management",
+  endpoints: [
+    { method: "POST", path: "/buffer/next", summary: "Get next lead" },
+    { method: "POST", path: "/buffer/push", summary: "Push lead" },
   ],
 };
 
@@ -205,8 +208,10 @@ describe("generateWorkflow", () => {
     process.env.API_REGISTRY_SERVICE_URL = "http://fake-registry";
     process.env.API_REGISTRY_SERVICE_API_KEY = "test-key";
     mockFetchLlmContext.mockReset();
+    mockFetchServiceEndpoints.mockReset();
     mockFetchServiceSpec.mockReset();
     mockFetchLlmContext.mockResolvedValue(MOCK_LLM_CONTEXT);
+    mockFetchServiceEndpoints.mockResolvedValue(MOCK_SERVICE_ENDPOINTS);
     mockFetchServiceSpec.mockResolvedValue(MOCK_SERVICE_SPEC);
   });
 
@@ -340,15 +345,16 @@ describe("generateWorkflow", () => {
     expect(call.tool_choice).toEqual({ type: "auto" });
   });
 
-  it("provides all three tools", async () => {
+  it("provides all four tools", async () => {
     mockCreate.mockResolvedValueOnce(createMockToolResponse(VALID_LINEAR_DAG));
 
     await generateWorkflow({ description: "test workflow" }, TEST_API_KEY, TEST_IDENTITY);
 
     const call = mockCreate.mock.calls[0][0];
-    expect(call.tools).toHaveLength(3);
+    expect(call.tools).toHaveLength(4);
     const toolNames = call.tools.map((t: { name: string }) => t.name);
     expect(toolNames).toContain("list_services");
+    expect(toolNames).toContain("list_service_endpoints");
     expect(toolNames).toContain("get_service_endpoints");
     expect(toolNames).toContain("create_workflow");
   });

--- a/tests/unit/workflow-upgrader.test.ts
+++ b/tests/unit/workflow-upgrader.test.ts
@@ -8,12 +8,17 @@ vi.mock("../../src/lib/api-registry-client.js", () => ({
       {
         service: "campaign",
         description: "Campaign service",
-        endpoints: [
-          { method: "POST", path: "/gate-check", summary: "Gate check" },
-          { method: "POST", path: "/start-run", summary: "Start run" },
-          { method: "POST", path: "/end-run", summary: "End run" },
-        ],
+        endpointCount: 3,
       },
+    ],
+  }),
+  fetchServiceEndpoints: vi.fn().mockResolvedValue({
+    service: "campaign",
+    description: "Campaign service",
+    endpoints: [
+      { method: "POST", path: "/gate-check", summary: "Gate check" },
+      { method: "POST", path: "/start-run", summary: "Start run" },
+      { method: "POST", path: "/end-run", summary: "End run" },
     ],
   }),
   fetchServiceSpec: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary
- **Breaking change in api-registry**: `GET /llm-context` now returns service summaries (name, description, endpointCount) instead of full endpoint arrays
- Added `fetchServiceEndpoints()` client for the new `GET /llm-context/:service` endpoint (returns method, path, summary per endpoint)
- Added `list_service_endpoints` LLM tool for progressive disclosure: `list_services` → `list_service_endpoints` → `get_service_endpoints` → `create_workflow`
- Updated `resolveToolCall` in both workflow-generator and workflow-upgrader
- All 324 unit tests pass

## Test plan
- [x] All existing unit tests updated and passing
- [x] TypeScript compiles cleanly
- [ ] Verify against deployed api-registry with new progressive disclosure endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)