### PR TITLE
feat: rate limit execute endpoints (60/min/org)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "drizzle-orm": "^0.36.0",
         "express": "^4.21.0",
+        "express-rate-limit": "^8.3.1",
         "postgres": "^3.4.0",
         "zod": "^3.24.0"
       },
@@ -2311,6 +2312,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2600,6 +2619,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cors": "^2.8.5",
     "drizzle-orm": "^0.36.0",
     "express": "^4.21.0",
+    "express-rate-limit": "^8.3.1",
     "postgres": "^3.4.0",
     "zod": "^3.24.0"
   },

--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -1,0 +1,23 @@
+import rateLimit from "express-rate-limit";
+import type { Request } from "express";
+
+/**
+ * Rate limit for workflow execution endpoints.
+ * 60 requests per minute per orgId — generous for normal use,
+ * prevents abuse (e.g. spamming free-node workflows).
+ */
+export const executeRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 60,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  keyGenerator: (req: Request) => {
+    // Rate limit per org — orgId is always set by requireIdentity middleware
+    // which runs before this middleware (applied at app.use level in index.ts).
+    // The fallback to "unknown" is defensive only.
+    return (req.res?.locals.orgId as string) ?? "unknown";
+  },
+  message: {
+    error: "Too many workflow executions — limit is 60 per minute per organization",
+  },
+});

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -3,6 +3,7 @@ import { eq, and } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { workflows, workflowRuns } from "../db/schema.js";
 import { requireApiKey, requireBrandId } from "../middleware/auth.js";
+import { executeRateLimit } from "../middleware/rate-limit.js";
 import { getWindmillClient } from "../lib/windmill-client.js";
 import { collectServiceEnvs } from "../lib/service-envs.js";
 import { createRun } from "../lib/runs-client.js";
@@ -38,6 +39,7 @@ function formatRun(r: typeof workflowRuns.$inferSelect) {
 router.post(
   "/workflows/by-name/:name/execute",
   requireApiKey,
+  executeRateLimit,
   requireBrandId,
   async (req, res) => {
     try {
@@ -207,7 +209,7 @@ router.post(
 );
 
 // POST /workflows/:id/execute — Execute a workflow
-router.post("/workflows/:id/execute", requireApiKey, requireBrandId, async (req, res) => {
+router.post("/workflows/:id/execute", requireApiKey, executeRateLimit, requireBrandId, async (req, res) => {
   try {
     const body = ExecuteWorkflowSchema.parse(req.body ?? {});
     const orgId = res.locals.orgId as string;

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock DB, Windmill, and runs-client (required by app import)
+const mockWorkflows: Record<string, unknown>[] = [];
+const mockRuns: Record<string, unknown>[] = [];
+
+function mockQueryResult(data: Record<string, unknown>[]) {
+  const obj = {
+    then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) =>
+      Promise.resolve(data).then(resolve, reject),
+    limit: () => obj,
+  };
+  return obj;
+}
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    insert: () => ({
+      values: (row: Record<string, unknown>) => {
+        const newRow = {
+          id: "run-" + Math.random().toString(36).slice(2, 10),
+          ...row,
+          windmillWorkspace: row.windmillWorkspace ?? "prod",
+          createdAt: new Date(),
+          startedAt: null,
+          completedAt: null,
+        };
+        mockRuns.push(newRow);
+        return { returning: () => Promise.resolve([newRow]) };
+      },
+    }),
+    select: () => ({
+      from: () => ({
+        where: () => {
+          if (mockWorkflows.length > 0) return mockQueryResult([mockWorkflows[0]]);
+          return mockQueryResult([]);
+        },
+      }),
+    }),
+    update: () => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => ({
+          returning: () => Promise.resolve([{ ...mockRuns[0], ...values }]),
+        }),
+      }),
+    }),
+  },
+  sql: { end: () => Promise.resolve() },
+}));
+
+vi.mock("../../src/lib/windmill-client.js", () => ({
+  getWindmillClient: () => ({
+    createFlow: vi.fn(),
+    updateFlow: vi.fn(),
+    deleteFlow: vi.fn(),
+    runFlow: vi.fn().mockResolvedValue("job-uuid-123"),
+    getJob: vi.fn(),
+    cancelJob: vi.fn(),
+    healthCheck: vi.fn(),
+  }),
+  WindmillClient: vi.fn(),
+  resetWindmillClient: vi.fn(),
+}));
+
+vi.mock("../../src/lib/runs-client.js", () => ({
+  createRun: vi.fn().mockResolvedValue({ runId: "run-own-123" }),
+}));
+
+import supertest from "supertest";
+import app from "../../src/index.js";
+
+const request = supertest(app);
+const AUTH = {
+  "x-api-key": "test-api-key",
+  "x-org-id": "org-rate-test",
+  "x-user-id": "user-1",
+  "x-run-id": "run-1",
+  "x-brand-id": "brand-1",
+};
+
+describe("Execute endpoint rate limiting", () => {
+  beforeEach(() => {
+    mockWorkflows.length = 0;
+    mockRuns.length = 0;
+    mockWorkflows.push({
+      id: "wf-1",
+      name: "Rate Test Flow",
+      status: "active",
+      windmillFlowPath: "f/workflows/test/flow",
+      windmillWorkspace: "prod",
+      dag: { nodes: [], edges: [] },
+    });
+  });
+
+  it("returns 429 after exceeding 60 requests per minute for the same org", async () => {
+    // Send 61 requests — the 61st should be rate limited
+    const promises = [];
+    for (let i = 0; i < 61; i++) {
+      promises.push(
+        request
+          .post("/workflows/wf-1/execute")
+          .set(AUTH)
+          .send({ inputs: {} })
+      );
+    }
+
+    const results = await Promise.all(promises);
+    const statuses = results.map((r) => r.status);
+
+    // At least one should be 429
+    expect(statuses).toContain(429);
+
+    // Most should succeed (201)
+    const successCount = statuses.filter((s) => s === 201).length;
+    expect(successCount).toBe(60);
+  });
+
+  it("does not rate limit a different org", async () => {
+    // Exhaust org-rate-test's limit
+    const exhaustPromises = [];
+    for (let i = 0; i < 60; i++) {
+      exhaustPromises.push(
+        request
+          .post("/workflows/wf-1/execute")
+          .set(AUTH)
+          .send({ inputs: {} })
+      );
+    }
+    await Promise.all(exhaustPromises);
+
+    // Different org should still work
+    const res = await request
+      .post("/workflows/wf-1/execute")
+      .set({ ...AUTH, "x-org-id": "org-other" })
+      .send({ inputs: {} });
+
+    expect(res.status).toBe(201);
+  });
+
+  it("rate limits by-name execute endpoint too", async () => {
+    // Send 61 requests to the by-name endpoint
+    const promises = [];
+    for (let i = 0; i < 61; i++) {
+      promises.push(
+        request
+          .post("/workflows/by-name/Rate Test Flow/execute")
+          .set(AUTH)
+          .send({ inputs: {} })
+      );
+    }
+
+    const results = await Promise.all(promises);
+    const statuses = results.map((r) => r.status);
+    expect(statuses).toContain(429);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `express-rate-limit` middleware on both execute endpoints (`POST /workflows/:id/execute` and `POST /workflows/by-name/:name/execute`)
- Rate limit: 60 requests per minute per `orgId` (in-memory store)
- Returns 429 with clear error message when exceeded
- Does not affect other endpoints (CRUD, status, cancel, etc.)

## Context
Flagged by api-service team: execute endpoints had no rate limiting, meaning a valid token could spam executions and overload Windmill/DB even with free-node workflows. The 60/min/org limit is generous for normal use while preventing systematic abuse.

## Test plan
- [x] Unit test: 61st request from same org returns 429
- [x] Unit test: different org is not affected by another org's limit
- [x] Unit test: by-name execute endpoint is also rate limited
- [x] All 463 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)