### PR TITLE
fix: update stale upgrade endpoint description

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2894,7 +2894,7 @@
     "/workflows/upgrade": {
       "put": {
         "summary": "Upgrade (upsert) workflows by DAG signature",
-        "description": "Idempotent: creates new workflows or updates existing ones matched by (orgId + DAG signature). The workflow name is auto-generated as {category}-{channel}-{audienceType}-{signatureName}. signatureName is a human-readable word auto-assigned to each unique DAG. After deploying, execute workflows via POST /workflows/by-name/{name}/execute.",
+        "description": "Idempotent: creates new workflows or updates existing ones matched by (orgId + DAG signature). The workflow name is auto-generated as {featureSlug}-{signatureName}. signatureName is a human-readable word auto-assigned to each unique DAG. After deploying, execute workflows via POST /workflows/by-name/{name}/execute.",
         "tags": [
           "Workflows"
         ],

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -989,7 +989,7 @@ registry.registerPath({
   summary: "Upgrade (upsert) workflows by DAG signature",
   description:
     "Idempotent: creates new workflows or updates existing ones matched by (orgId + DAG signature). " +
-    "The workflow name is auto-generated as {category}-{channel}-{audienceType}-{signatureName}. " +
+    "The workflow name is auto-generated as {featureSlug}-{signatureName}. " +
     "signatureName is a human-readable word auto-assigned to each unique DAG. " +
     "After deploying, execute workflows via POST /workflows/by-name/{name}/execute.",
   tags: ["Workflows"],


### PR DESCRIPTION
## Summary
- The `PUT /workflows/upgrade` OpenAPI description still referenced the old `{category}-{channel}-{audienceType}-{signatureName}` naming format
- Updated to `{featureSlug}-{signatureName}` to match the actual code (changed in PR #162)
- Regenerated `openapi.json`

## Context
Spotted while reviewing features-service's fork-on-write alignment message — their team referenced our naming format and the published spec was stale.

## Test plan
- [x] All 460 tests pass
- [x] No remaining references to old naming format in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)