### PR TITLE
feat: add POST /internal/migrate-feature-slug

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1330,6 +1330,66 @@
             "description": "Runtime inputs for the workflow. Accessible in nodes via $ref:flow_input.fieldName."
           }
         }
+      },
+      "MigrateFeatureSlugResponse": {
+        "type": "object",
+        "properties": {
+          "migrated": {
+            "type": "number",
+            "description": "Number of active workflows whose featureSlug was updated."
+          },
+          "workflows": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "oldFeatureSlug": {
+                  "type": "string"
+                },
+                "newFeatureSlug": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "oldFeatureSlug",
+                "newFeatureSlug"
+              ]
+            },
+            "description": "List of workflows that were migrated."
+          }
+        },
+        "required": [
+          "migrated",
+          "workflows"
+        ]
+      },
+      "MigrateFeatureSlugRequest": {
+        "type": "object",
+        "properties": {
+          "oldSlug": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The deprecated feature slug to migrate away from."
+          },
+          "newSlug": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The new active feature slug to migrate to."
+          }
+        },
+        "required": [
+          "oldSlug",
+          "newSlug"
+        ]
       }
     },
     "parameters": {}
@@ -3734,6 +3794,124 @@
           },
           "404": {
             "description": "Workflow not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/internal/migrate-feature-slug": {
+      "post": {
+        "summary": "Migrate workflows from one feature slug to another",
+        "description": "Called by features-service when a feature is upgraded (metadata-only change that deprecates the old slug). Updates featureSlug on all active workflows matching oldSlug → newSlug. Workflow names are unchanged (execution by name is unaffected). Idempotent: re-calling with the same slugs is a no-op if already migrated.",
+        "tags": [
+          "Internal"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+            },
+            "required": false,
+            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "name": "x-feature-slug",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MigrateFeatureSlugRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Migration complete",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MigrateFeatureSlugResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -14,6 +14,7 @@ import {
   GenerateWorkflowSchema,
   RankedWorkflowQuerySchema,
   BestWorkflowQuerySchema,
+  MigrateFeatureSlugSchema,
 } from "../schemas.js";
 import {
   generateWorkflow,
@@ -1244,6 +1245,66 @@ router.post("/workflows/:id/validate", requireApiKey, async (req, res) => {
     res.json(result);
   } catch (err) {
     console.error("[workflow-service] VALIDATE error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// POST /internal/migrate-feature-slug — Update featureSlug on all active workflows
+// Called by features-service when a feature is upgraded (old slug deprecated, new slug active)
+router.post("/internal/migrate-feature-slug", requireApiKey, async (req, res) => {
+  try {
+    const body = MigrateFeatureSlugSchema.parse(req.body);
+
+    if (body.oldSlug === body.newSlug) {
+      res.json({ migrated: 0, workflows: [] });
+      return;
+    }
+
+    // Find all active workflows with the old slug
+    const matching = await db
+      .select()
+      .from(workflows)
+      .where(
+        and(
+          eq(workflows.featureSlug, body.oldSlug),
+          eq(workflows.status, "active"),
+        )
+      );
+
+    if (matching.length === 0) {
+      res.json({ migrated: 0, workflows: [] });
+      return;
+    }
+
+    // Update all matching workflows
+    await db
+      .update(workflows)
+      .set({ featureSlug: body.newSlug, updatedAt: new Date() })
+      .where(
+        and(
+          eq(workflows.featureSlug, body.oldSlug),
+          eq(workflows.status, "active"),
+        )
+      );
+
+    const migrated = matching.map((w) => ({
+      id: w.id,
+      name: w.name,
+      oldFeatureSlug: body.oldSlug,
+      newFeatureSlug: body.newSlug,
+    }));
+
+    console.log(
+      `[workflow-service] migrate-feature-slug: "${body.oldSlug}" -> "${body.newSlug}" (${migrated.length} workflows)`,
+    );
+
+    res.json({ migrated: migrated.length, workflows: migrated });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.name === "ZodError") {
+      res.status(400).json({ error: "Validation error", details: err });
+      return;
+    }
+    console.error("[workflow-service] migrate-feature-slug error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -611,6 +611,29 @@ export const WorkflowConflictResponseSchema = z
   })
   .openapi("WorkflowConflictResponse");
 
+// --- Migrate feature slug (internal) ---
+
+export const MigrateFeatureSlugSchema = z
+  .object({
+    oldSlug: z.string().min(1).describe("The deprecated feature slug to migrate away from."),
+    newSlug: z.string().min(1).describe("The new active feature slug to migrate to."),
+  })
+  .openapi("MigrateFeatureSlugRequest");
+
+export const MigrateFeatureSlugResponseSchema = z
+  .object({
+    migrated: z.number().describe("Number of active workflows whose featureSlug was updated."),
+    workflows: z.array(
+      z.object({
+        id: z.string().uuid(),
+        name: z.string(),
+        oldFeatureSlug: z.string(),
+        newFeatureSlug: z.string(),
+      })
+    ).describe("List of workflows that were migrated."),
+  })
+  .openapi("MigrateFeatureSlugResponse");
+
 // --- Common ---
 
 export const ErrorResponseSchema = z
@@ -1200,6 +1223,38 @@ registry.registerPath({
     },
     404: {
       description: "Workflow not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/internal/migrate-feature-slug",
+  summary: "Migrate workflows from one feature slug to another",
+  description:
+    "Called by features-service when a feature is upgraded (metadata-only change that deprecates the old slug). " +
+    "Updates featureSlug on all active workflows matching oldSlug → newSlug. " +
+    "Workflow names are unchanged (execution by name is unaffected). " +
+    "Idempotent: re-calling with the same slugs is a no-op if already migrated.",
+  tags: ["Internal"],
+  security: [{ apiKey: [] }],
+  request: {
+    headers: IdentityHeaders,
+    body: {
+      required: true,
+      content: { "application/json": { schema: MigrateFeatureSlugSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Migration complete",
+      content: {
+        "application/json": { schema: MigrateFeatureSlugResponseSchema },
+      },
+    },
+    400: {
+      description: "Validation error",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -1434,3 +1434,72 @@ describe("POST /workflows/:id/validate", () => {
     expect(res.body.valid).toBe(true);
   });
 });
+
+describe("POST /internal/migrate-feature-slug", () => {
+  beforeEach(() => {
+    mockDbRows.length = 0;
+    mockSelectResponses.length = 0;
+  });
+
+  it("migrates active workflows from old slug to new slug", async () => {
+    const wf1 = {
+      id: "wf-migrate-1",
+      orgId: "org-1",
+      name: "old-feature-sequoia",
+      featureSlug: "old-feature",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockDbRows.push(wf1);
+
+    // Queue the select response (matching workflows)
+    mockSelectResponses.push([wf1]);
+
+    const res = await request
+      .post("/internal/migrate-feature-slug")
+      .set(AUTH)
+      .send({ oldSlug: "old-feature", newSlug: "new-feature" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.migrated).toBe(1);
+    expect(res.body.workflows).toHaveLength(1);
+    expect(res.body.workflows[0].id).toBe("wf-migrate-1");
+    expect(res.body.workflows[0].oldFeatureSlug).toBe("old-feature");
+    expect(res.body.workflows[0].newFeatureSlug).toBe("new-feature");
+  });
+
+  it("returns empty result when no workflows match the old slug", async () => {
+    // Queue empty select response
+    mockSelectResponses.push([]);
+
+    const res = await request
+      .post("/internal/migrate-feature-slug")
+      .set(AUTH)
+      .send({ oldSlug: "nonexistent-feature", newSlug: "new-feature" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.migrated).toBe(0);
+    expect(res.body.workflows).toEqual([]);
+  });
+
+  it("is a no-op when oldSlug equals newSlug", async () => {
+    const res = await request
+      .post("/internal/migrate-feature-slug")
+      .set(AUTH)
+      .send({ oldSlug: "same-feature", newSlug: "same-feature" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.migrated).toBe(0);
+    expect(res.body.workflows).toEqual([]);
+  });
+
+  it("rejects request with missing slugs", async () => {
+    const res = await request
+      .post("/internal/migrate-feature-slug")
+      .set(AUTH)
+      .send({ oldSlug: "only-old" });
+
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `POST /internal/migrate-feature-slug` endpoint for features-service to call when a feature is **upgraded** (metadata-only change that deprecates the old slug)
- Updates `featureSlug` on all active workflows matching `oldSlug` → `newSlug`
- Workflow `name` is unchanged — execution by name (`/workflows/by-name/{name}/execute`) is unaffected
- Idempotent: re-calling with the same slugs is a no-op

## Context
Features-service now has fork-on-write semantics (PR #24). In the **fork** case (inputs/outputs change), both old and new features stay active — no migration needed. In the **upgrade** case (metadata-only), the old feature slug is deprecated and workflows must point to the new active slug.

## Test plan
- [x] Migrates active workflows from old slug to new slug
- [x] Returns empty result when no workflows match
- [x] No-op when oldSlug equals newSlug
- [x] Rejects request with missing slugs (400)
- [x] All 55 workflow integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)