### PR TITLE
fix: bracket notation for numeric path segments in input transforms

### DIFF
--- a/src/lib/input-mapping.ts
+++ b/src/lib/input-mapping.ts
@@ -48,8 +48,12 @@ export function buildInputTransforms(
           if (rest.length === 0) {
             expr = `results.${nodeId}`;
           } else {
-            // Optional chaining on node result + all intermediate properties
-            expr = `results.${nodeId}?.${rest.join("?.")}`;
+            // Optional chaining on node result + all intermediate properties.
+            // Numeric segments use bracket notation: ?.["0"] instead of ?.0
+            // because ?.0 is invalid JS (parsed as a decimal literal).
+            expr = `results.${nodeId}` + rest.map((seg) =>
+              /^\d+$/.test(seg) ? `?.["${seg}"]` : `?.${seg}`
+            ).join("");
           }
         }
 

--- a/tests/unit/input-mapping.test.ts
+++ b/tests/unit/input-mapping.test.ts
@@ -169,6 +169,49 @@ describe("buildInputTransforms", () => {
     expect(result["path.id"].expr).toContain("results.start_run?.runId");
   });
 
+  it("uses bracket notation for numeric path segments", () => {
+    const result = buildInputTransforms(undefined, {
+      brand: "$ref:brand-profile.output.brands.0",
+    });
+
+    expect(result.brand).toEqual({
+      type: "javascript",
+      expr: 'results.brand_profile?.brands?.["0"]',
+    });
+
+    // Verify the expression is valid JavaScript
+    expect(() => new Function("results", `return ${result.brand.expr!}`)).not.toThrow();
+  });
+
+  it("uses bracket notation for numeric segments in deep paths", () => {
+    const result = buildInputTransforms(undefined, {
+      name: "$ref:brand-profile.output.brands.0.name",
+    });
+
+    expect(result.name).toEqual({
+      type: "javascript",
+      expr: 'results.brand_profile?.brands?.["0"]?.name',
+    });
+
+    expect(() => new Function("results", `return ${result.name.expr!}`)).not.toThrow();
+  });
+
+  it("regression: numeric index in collapsed body expression produces valid JS", () => {
+    const result = buildInputTransforms(
+      { body: { type: "pr-cold-email-v2" } },
+      {
+        "body.variables.brandProfile": "$ref:brand-profile.output.brands.0",
+        "body.variables.companyName": "$ref:brand-profile.output.brands.0.name",
+      },
+    );
+
+    expect(result.body).toBeDefined();
+    expect(result.body.type).toBe("javascript");
+    // The collapsed expression must be valid JavaScript
+    expect(() => new Function("results", "flow_input", `return ${result.body.expr!}`)).not.toThrow();
+    expect(result.body.expr).toContain('?.["0"]');
+  });
+
   it("leaves non-dot-notation keys untouched", () => {
     const result = buildInputTransforms(
       { service: "stripe", method: "GET" },


### PR DESCRIPTION
## Summary
- Numeric path segments in `$ref` expressions (e.g. `$ref:brand-profile.output.brands.0`) were generating invalid JavaScript: `results.brand_profile?.brands?.0` — the `?.0` syntax is parsed as a decimal literal, not a property access
- This caused Windmill to fail evaluating the entire module's `input_transforms`, resulting in **all** parameters (including `service`) being `undefined`
- Root cause of the `TypeError: undefined is not an object (evaluating 'service.toUpperCase')` crash in `email_generate` step of `pr-cold-email-outreach-mast`
- Fix: detect numeric segments and emit bracket notation `?.["0"]` instead of dot notation `?.0`

## Test plan
- [x] 3 new regression tests covering numeric indices in paths, deep numeric paths, and collapsed body expressions
- [x] All 332 unit tests pass
- [x] Verified generated expression is valid JavaScript via `new Function()` assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)