### PR TITLE
fix: validate http.call required config fields at deploy time

### DIFF
--- a/scripts/nodes/http-call.ts
+++ b/scripts/nodes/http-call.ts
@@ -23,6 +23,13 @@ export async function main(
   workflowName?: string,
   featureSlug?: string,
 ) {
+  if (!service) {
+    throw new Error(
+      "http.call node is missing required config field \"service\". " +
+      "Re-deploy the workflow with service, method, and path in the node config."
+    );
+  }
+
   // Convert service name to env var prefix: "transactional-email" → "TRANSACTIONAL_EMAIL"
   const envPrefix = service.toUpperCase().replace(/-/g, "_");
   const urlKey = `${envPrefix}_SERVICE_URL`;

--- a/src/lib/dag-validator.ts
+++ b/src/lib/dag-validator.ts
@@ -36,6 +36,9 @@ export interface ValidationResult {
  */
 const BANNED_HTTP_CALL_SERVICES = new Set(["api"]);
 
+/** Fields that every http.call node must have in its config. */
+const HTTP_CALL_REQUIRED_FIELDS = ["service", "method", "path"] as const;
+
 export function validateDAG(dag: DAG): ValidationResult {
   const errors: ValidationError[] = [];
   const nodeIds = dag.nodes.map((n) => n.id);
@@ -111,9 +114,21 @@ export function validateDAG(dag: DAG): ValidationResult {
     });
   }
 
-  // 7. Banned service names in http.call nodes
+  // 7. Validate http.call nodes: required fields + banned services
   for (const node of dag.nodes) {
     if (node.type !== "http.call") continue;
+
+    // Required config fields
+    for (const field of HTTP_CALL_REQUIRED_FIELDS) {
+      if (typeof node.config?.[field] !== "string" || !(node.config[field] as string).trim()) {
+        errors.push({
+          field: `nodes[${node.id}].config.${field}`,
+          message: `http.call node "${node.id}" is missing required config field "${field}"`,
+        });
+      }
+    }
+
+    // Banned service names
     const service = node.config?.service;
     if (typeof service === "string" && BANNED_HTTP_CALL_SERVICES.has(service)) {
       errors.push({

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -279,6 +279,39 @@ export const DAG_WITH_BANNED_API_SERVICE: DAG = {
   edges: [],
 };
 
+export const DAG_WITH_HTTP_CALL_MISSING_SERVICE: DAG = {
+  nodes: [
+    {
+      id: "fetch-data",
+      type: "http.call",
+      config: { method: "GET", path: "/data" },
+    },
+  ],
+  edges: [],
+};
+
+export const DAG_WITH_HTTP_CALL_MISSING_METHOD: DAG = {
+  nodes: [
+    {
+      id: "fetch-data",
+      type: "http.call",
+      config: { service: "brand", path: "/data" },
+    },
+  ],
+  edges: [],
+};
+
+export const DAG_WITH_HTTP_CALL_MISSING_PATH: DAG = {
+  nodes: [
+    {
+      id: "fetch-data",
+      type: "http.call",
+      config: { service: "brand", method: "GET" },
+    },
+  ],
+  edges: [],
+};
+
 export const DAG_WITH_CUSTOM_RETRIES: DAG = {
   nodes: [
     {

--- a/tests/unit/dag-validator.test.ts
+++ b/tests/unit/dag-validator.test.ts
@@ -22,6 +22,9 @@ import {
   DAG_WITH_BAD_ON_ERROR,
   DAG_WITH_RETRIES_ZERO,
   DAG_WITH_BANNED_API_SERVICE,
+  DAG_WITH_HTTP_CALL_MISSING_SERVICE,
+  DAG_WITH_HTTP_CALL_MISSING_METHOD,
+  DAG_WITH_HTTP_CALL_MISSING_PATH,
 } from "../helpers/fixtures.js";
 
 describe("validateDAG", () => {
@@ -151,6 +154,30 @@ describe("validateDAG", () => {
     const result = validateDAG(DAG_WITH_RETRIES_ZERO);
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
+  });
+
+  it("rejects http.call node missing 'service' config", () => {
+    const result = validateDAG(DAG_WITH_HTTP_CALL_MISSING_SERVICE);
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.message.includes('missing required config field "service"'))
+    ).toBe(true);
+  });
+
+  it("rejects http.call node missing 'method' config", () => {
+    const result = validateDAG(DAG_WITH_HTTP_CALL_MISSING_METHOD);
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.message.includes('missing required config field "method"'))
+    ).toBe(true);
+  });
+
+  it("rejects http.call node missing 'path' config", () => {
+    const result = validateDAG(DAG_WITH_HTTP_CALL_MISSING_PATH);
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.message.includes('missing required config field "path"'))
+    ).toBe(true);
   });
 
   it("rejects a DAG with http.call using banned service 'api'", () => {


### PR DESCRIPTION
## Summary
- Adds deploy-time validation that `http.call` nodes must have `service`, `method`, and `path` in their config
- Adds runtime guard in `http-call.ts` with a clear error message when `service` is missing (instead of a raw `TypeError: undefined is not an object`)
- Adds regression tests for all three required fields

## Context
Production Windmill jobs were crashing with `TypeError: undefined is not an object (evaluating 'service.toUpperCase')` at the `email_generate` step. The root cause was an `http.call` node deployed without the `service` config field — previously this passed validation silently and only failed at runtime.

## Test plan
- [x] Unit tests for missing `service`, `method`, `path` validation (3 new tests)
- [x] All 332 existing unit tests pass
- [x] Existing `http.call` fixtures with valid config still accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)