### PR TITLE
fix: add _action and _forkedFromName to PUT fork response

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -452,6 +452,33 @@
           "providers"
         ]
       },
+      "WorkflowMutationResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/WorkflowResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "_action": {
+                "type": "string",
+                "enum": [
+                  "updated",
+                  "forked"
+                ],
+                "description": "What happened: 'updated' means the existing workflow was modified in-place, 'forked' means a new workflow was created (check the new name and id)."
+              },
+              "_forkedFromName": {
+                "type": "string",
+                "description": "Only present when _action is 'forked'. The name of the original workflow that was forked."
+              }
+            },
+            "required": [
+              "_action"
+            ]
+          }
+        ]
+      },
       "WorkflowConflictResponse": {
         "type": "object",
         "properties": {
@@ -1907,21 +1934,21 @@
         },
         "responses": {
           "200": {
-            "description": "Workflow updated in-place (metadata only, no DAG change)",
+            "description": "Workflow updated in-place (metadata only or same DAG signature). _action='updated'.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowResponse"
+                  "$ref": "#/components/schemas/WorkflowMutationResponse"
                 }
               }
             }
           },
           "201": {
-            "description": "Workflow forked (new workflow created with modified DAG)",
+            "description": "Workflow forked (new workflow created with modified DAG). Check _action='forked' and the new name.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowResponse"
+                  "$ref": "#/components/schemas/WorkflowMutationResponse"
                 }
               }
             }

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -998,7 +998,7 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
         .where(eq(workflows.id, req.params.id))
         .returning();
 
-      res.json(formatWorkflow(updated));
+      res.json({ ...formatWorkflow(updated), _action: "updated" as const });
       return;
     }
 
@@ -1042,7 +1042,7 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
         .where(eq(workflows.id, req.params.id))
         .returning();
 
-      res.json(formatWorkflow(updated));
+      res.json({ ...formatWorkflow(updated), _action: "updated" as const });
       return;
     }
 
@@ -1156,7 +1156,11 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
       `[workflow-service] fork: "${existing.name}" (${existing.id}) -> "${newName}" (${forked.id})`,
     );
 
-    res.status(201).json(formatWorkflow(forked));
+    res.status(201).json({
+      ...formatWorkflow(forked),
+      _action: "forked" as const,
+      _forkedFromName: existing.name,
+    });
   } catch (err: unknown) {
     if (err instanceof Error && err.name === "ZodError") {
       res.status(400).json({ error: "Validation error", details: err });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -165,6 +165,16 @@ export const WorkflowResponseSchema = z
   })
   .openapi("WorkflowResponse");
 
+export const WorkflowMutationResponseSchema = WorkflowResponseSchema.extend({
+  _action: z.enum(["updated", "forked"]).describe(
+    "What happened: 'updated' means the existing workflow was modified in-place, " +
+    "'forked' means a new workflow was created (check the new name and id)."
+  ),
+  _forkedFromName: z.string().optional().describe(
+    "Only present when _action is 'forked'. The name of the original workflow that was forked."
+  ),
+}).openapi("WorkflowMutationResponse");
+
 export const TemplateContractIssueSchema = z
   .object({
     nodeId: z.string().describe("DAG node ID that calls content-generation."),
@@ -789,12 +799,12 @@ registry.registerPath({
   },
   responses: {
     201: {
-      description: "Workflow forked (new workflow created with modified DAG)",
-      content: { "application/json": { schema: WorkflowResponseSchema } },
+      description: "Workflow forked (new workflow created with modified DAG). Check _action='forked' and the new name.",
+      content: { "application/json": { schema: WorkflowMutationResponseSchema } },
     },
     200: {
-      description: "Workflow updated in-place (metadata only, no DAG change)",
-      content: { "application/json": { schema: WorkflowResponseSchema } },
+      description: "Workflow updated in-place (metadata only or same DAG signature). _action='updated'.",
+      content: { "application/json": { schema: WorkflowMutationResponseSchema } },
     },
     404: {
       description: "Not found",

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -983,6 +983,9 @@ describe("PUT /workflows/:id — fork", () => {
     expect(res.status).toBe(201);
     expect(res.body.id).not.toBe("wf-original");
     expect(res.body.forkedFrom).toBe("wf-original");
+    expect(res.body._action).toBe("forked");
+    expect(res.body._forkedFromName).toBe("sales-email-cold-outreach-jasmine");
+    expect(res.body.name).not.toBe("sales-email-cold-outreach-jasmine");
     expect(res.body.category).toBe("sales");
     expect(res.body.channel).toBe("email");
     expect(res.body.audienceType).toBe("cold-outreach");
@@ -1014,6 +1017,8 @@ describe("PUT /workflows/:id — fork", () => {
       });
 
     expect(res.status).toBe(200);
+    expect(res.body._action).toBe("updated");
+    expect(res.body._forkedFromName).toBeUndefined();
     expect(res.body.description).toBe("Updated description");
     expect(res.body.tags).toEqual(["updated"]);
     // No forkedFrom — it's the same workflow
@@ -1044,6 +1049,8 @@ describe("PUT /workflows/:id — fork", () => {
       });
 
     expect(res.status).toBe(200);
+    expect(res.body._action).toBe("updated");
+    expect(res.body._forkedFromName).toBeUndefined();
     expect(res.body.description).toBe("Same DAG, new desc");
   });
 


### PR DESCRIPTION
## Summary
- When `PUT /workflows/:id` triggers a fork (DAG signature changed), the response now includes `_action: "forked"` and `_forkedFromName` (the original workflow's name)
- In-place updates return `_action: "updated"` with no `_forkedFromName`
- Updated OpenAPI spec with `WorkflowMutationResponse` schema for the PUT endpoint

## Context
MCP agents calling PUT to modify a workflow didn't realize a fork happened because the response body format was identical for forks (201) and in-place updates (200). They continued using the old workflow ID/name, missing the new one.

## Test plan
- [x] Existing fork test verifies `_action: "forked"` and `_forkedFromName` match the original name
- [x] Metadata-only update test verifies `_action: "updated"` and no `_forkedFromName`
- [x] Same-signature DAG update test verifies `_action: "updated"`
- [x] All 471 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)