### PR TITLE
docs: add OpenAPI examples with condition field and fork response

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -273,7 +273,24 @@
         "required": [
           "id",
           "type"
-        ]
+        ],
+        "example": {
+          "id": "fetch-lead",
+          "type": "http.call",
+          "config": {
+            "service": "lead",
+            "method": "POST",
+            "path": "/buffer/next",
+            "body": {
+              "sourceType": "journalist"
+            }
+          },
+          "inputMapping": {
+            "body.brandId": "$ref:start-run.output.brandId",
+            "body.campaignId": "$ref:flow_input.campaignId"
+          },
+          "retries": 0
+        }
       },
       "DAGEdge": {
         "type": "object",
@@ -296,7 +313,12 @@
         "required": [
           "from",
           "to"
-        ]
+        ],
+        "example": {
+          "from": "check-lead",
+          "to": "brand-profile",
+          "condition": "results['fetch-lead'].found == true"
+        }
       },
       "DAG": {
         "type": "object",
@@ -324,7 +346,76 @@
         "required": [
           "nodes",
           "edges"
-        ]
+        ],
+        "example": {
+          "nodes": [
+            {
+              "id": "fetch-lead",
+              "type": "http.call",
+              "config": {
+                "service": "lead",
+                "method": "POST",
+                "path": "/buffer/next"
+              },
+              "inputMapping": {
+                "body.campaignId": "$ref:flow_input.campaignId"
+              }
+            },
+            {
+              "id": "check-lead",
+              "type": "condition"
+            },
+            {
+              "id": "send-email",
+              "type": "http.call",
+              "config": {
+                "service": "email-gateway",
+                "method": "POST",
+                "path": "/send"
+              },
+              "inputMapping": {
+                "body.to": "$ref:fetch-lead.output.lead.email"
+              },
+              "retries": 0
+            },
+            {
+              "id": "end-run",
+              "type": "http.call",
+              "config": {
+                "service": "campaign",
+                "method": "POST",
+                "path": "/end-run",
+                "body": {
+                  "success": true
+                }
+              },
+              "inputMapping": {
+                "body.campaignId": "$ref:flow_input.campaignId"
+              }
+            }
+          ],
+          "edges": [
+            {
+              "from": "fetch-lead",
+              "to": "check-lead"
+            },
+            {
+              "from": "check-lead",
+              "to": "send-email",
+              "condition": "results['fetch-lead'].found == true"
+            },
+            {
+              "from": "check-lead",
+              "to": "end-run",
+              "condition": "results['fetch-lead'].found == false"
+            },
+            {
+              "from": "send-email",
+              "to": "end-run"
+            }
+          ],
+          "onError": "end-run"
+        }
       },
       "CreateWorkflowRequest": {
         "type": "object",
@@ -477,7 +568,20 @@
               "_action"
             ]
           }
-        ]
+        ],
+        "example": {
+          "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "orgId": "b645207b-d8e9-40b0-9391-072b777cd9a9",
+          "name": "pr-cold-email-outreach-sequoia",
+          "displayName": "pr-cold-email-outreach-sequoia",
+          "featureSlug": "pr-cold-email-outreach",
+          "signature": "abc123...",
+          "signatureName": "sequoia",
+          "status": "active",
+          "forkedFrom": "original-workflow-uuid",
+          "_action": "forked",
+          "_forkedFromName": "pr-cold-email-outreach-ivory"
+        }
       },
       "WorkflowConflictResponse": {
         "type": "object",
@@ -520,6 +624,79 @@
           },
           "dag": {
             "$ref": "#/components/schemas/DAG"
+          }
+        },
+        "example": {
+          "dag": {
+            "nodes": [
+              {
+                "id": "fetch-lead",
+                "type": "http.call",
+                "config": {
+                  "service": "lead",
+                  "method": "POST",
+                  "path": "/buffer/next",
+                  "body": {
+                    "sourceType": "journalist"
+                  }
+                },
+                "inputMapping": {
+                  "body.campaignId": "$ref:flow_input.campaignId"
+                }
+              },
+              {
+                "id": "check-lead",
+                "type": "condition"
+              },
+              {
+                "id": "send-email",
+                "type": "http.call",
+                "config": {
+                  "service": "email-gateway",
+                  "method": "POST",
+                  "path": "/send"
+                },
+                "inputMapping": {
+                  "body.to": "$ref:fetch-lead.output.lead.email"
+                },
+                "retries": 0
+              },
+              {
+                "id": "end-run",
+                "type": "http.call",
+                "config": {
+                  "service": "campaign",
+                  "method": "POST",
+                  "path": "/end-run",
+                  "body": {
+                    "success": true
+                  }
+                },
+                "inputMapping": {
+                  "body.campaignId": "$ref:flow_input.campaignId"
+                }
+              }
+            ],
+            "edges": [
+              {
+                "from": "fetch-lead",
+                "to": "check-lead"
+              },
+              {
+                "from": "check-lead",
+                "to": "send-email",
+                "condition": "results['fetch-lead'].found == true"
+              },
+              {
+                "from": "check-lead",
+                "to": "end-run",
+                "condition": "results['fetch-lead'].found == false"
+              },
+              {
+                "from": "send-email",
+                "to": "end-run"
+              }
+            ]
           }
         }
       },
@@ -780,6 +957,15 @@
             },
             "description": "Runtime inputs for the workflow. Accessible in nodes via $ref:flow_input.fieldName."
           }
+        },
+        "example": {
+          "inputs": {
+            "orgId": "b645207b-d8e9-40b0-9391-072b777cd9a9",
+            "campaignId": "camp-123",
+            "prAngle": "AI-powered PR automation",
+            "newsHook": "Company raises Series A",
+            "currentDate": "2026-03-26"
+          }
         }
       },
       "WorkflowRunDebugResponse": {
@@ -927,7 +1113,92 @@
         },
         "required": [
           "workflows"
-        ]
+        ],
+        "example": {
+          "workflows": [
+            {
+              "featureSlug": "pr-cold-email-outreach",
+              "description": "Cold outreach sequence for PR campaigns",
+              "category": "pr",
+              "channel": "email",
+              "audienceType": "cold-outreach",
+              "tags": [
+                "email"
+              ],
+              "dag": {
+                "nodes": [
+                  {
+                    "id": "fetch-lead",
+                    "type": "http.call",
+                    "config": {
+                      "service": "lead",
+                      "method": "POST",
+                      "path": "/buffer/next",
+                      "body": {
+                        "sourceType": "journalist"
+                      }
+                    },
+                    "inputMapping": {
+                      "body.campaignId": "$ref:flow_input.campaignId"
+                    }
+                  },
+                  {
+                    "id": "check-lead",
+                    "type": "condition"
+                  },
+                  {
+                    "id": "send-email",
+                    "type": "http.call",
+                    "config": {
+                      "service": "email-gateway",
+                      "method": "POST",
+                      "path": "/send"
+                    },
+                    "inputMapping": {
+                      "body.to": "$ref:fetch-lead.output.lead.email"
+                    },
+                    "retries": 0
+                  },
+                  {
+                    "id": "end-run",
+                    "type": "http.call",
+                    "config": {
+                      "service": "campaign",
+                      "method": "POST",
+                      "path": "/end-run",
+                      "body": {
+                        "success": true
+                      }
+                    },
+                    "inputMapping": {
+                      "body.campaignId": "$ref:flow_input.campaignId"
+                    }
+                  }
+                ],
+                "edges": [
+                  {
+                    "from": "fetch-lead",
+                    "to": "check-lead"
+                  },
+                  {
+                    "from": "check-lead",
+                    "to": "send-email",
+                    "condition": "results['fetch-lead'].found == true"
+                  },
+                  {
+                    "from": "check-lead",
+                    "to": "end-run",
+                    "condition": "results['fetch-lead'].found == false"
+                  },
+                  {
+                    "from": "send-email",
+                    "to": "end-run"
+                  }
+                ]
+              }
+            }
+          ]
+        }
       },
       "GenerateWorkflowResponse": {
         "type": "object",
@@ -1355,6 +1626,16 @@
               "nullable": true
             },
             "description": "Runtime inputs for the workflow. Accessible in nodes via $ref:flow_input.fieldName."
+          }
+        },
+        "example": {
+          "inputs": {
+            "orgId": "b645207b-d8e9-40b0-9391-072b777cd9a9",
+            "campaignId": "camp-123",
+            "prAngle": "AI-powered PR automation",
+            "newsHook": "Company raises Series A",
+            "spokesperson": "Jane Doe, CEO",
+            "currentDate": "2026-03-26"
           }
         }
       }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -55,7 +55,23 @@ export const DAGNodeSchema = z
       "Set to 0 for non-idempotent operations (e.g., sending emails, consuming queue items) to prevent duplicates."
     ),
   })
-  .openapi("DAGNode");
+  .openapi("DAGNode", {
+    example: {
+      id: "fetch-lead",
+      type: "http.call",
+      config: {
+        service: "lead",
+        method: "POST",
+        path: "/buffer/next",
+        body: { sourceType: "journalist" },
+      },
+      inputMapping: {
+        "body.brandId": "$ref:start-run.output.brandId",
+        "body.campaignId": "$ref:flow_input.campaignId",
+      },
+      retries: 0,
+    },
+  });
 
 export const DAGEdgeSchema = z
   .object({
@@ -69,7 +85,13 @@ export const DAGEdgeSchema = z
       "Example: \"results.fetch_lead.found == true\""
     ),
   })
-  .openapi("DAGEdge");
+  .openapi("DAGEdge", {
+    example: {
+      from: "check-lead",
+      to: "brand-profile",
+      condition: "results['fetch-lead'].found == true",
+    },
+  });
 
 export const DAGSchema = z
   .object({
@@ -85,7 +107,23 @@ export const DAGSchema = z
       "Tip: check errorMessage to distinguish expected stops (e.g. 'validation failed: expected found=true') from real errors."
     ),
   })
-  .openapi("DAG");
+  .openapi("DAG", {
+    example: {
+      nodes: [
+        { id: "fetch-lead", type: "http.call", config: { service: "lead", method: "POST", path: "/buffer/next" }, inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" } },
+        { id: "check-lead", type: "condition" },
+        { id: "send-email", type: "http.call", config: { service: "email-gateway", method: "POST", path: "/send" }, inputMapping: { "body.to": "$ref:fetch-lead.output.lead.email" }, retries: 0 },
+        { id: "end-run", type: "http.call", config: { service: "campaign", method: "POST", path: "/end-run", body: { success: true } }, inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" } },
+      ],
+      edges: [
+        { from: "fetch-lead", to: "check-lead" },
+        { from: "check-lead", to: "send-email", condition: "results['fetch-lead'].found == true" },
+        { from: "check-lead", to: "end-run", condition: "results['fetch-lead'].found == false" },
+        { from: "send-email", to: "end-run" },
+      ],
+      onError: "end-run",
+    },
+  });
 
 // --- Workflow enums ---
 
@@ -131,7 +169,24 @@ export const UpdateWorkflowSchema = z
     tags: z.array(z.string()).optional().describe("Updated tags for filtering/grouping."),
     dag: DAGSchema.optional(),
   })
-  .openapi("UpdateWorkflowRequest");
+  .openapi("UpdateWorkflowRequest", {
+    example: {
+      dag: {
+        nodes: [
+          { id: "fetch-lead", type: "http.call", config: { service: "lead", method: "POST", path: "/buffer/next", body: { sourceType: "journalist" } }, inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" } },
+          { id: "check-lead", type: "condition" },
+          { id: "send-email", type: "http.call", config: { service: "email-gateway", method: "POST", path: "/send" }, inputMapping: { "body.to": "$ref:fetch-lead.output.lead.email" }, retries: 0 },
+          { id: "end-run", type: "http.call", config: { service: "campaign", method: "POST", path: "/end-run", body: { success: true } }, inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" } },
+        ],
+        edges: [
+          { from: "fetch-lead", to: "check-lead" },
+          { from: "check-lead", to: "send-email", condition: "results['fetch-lead'].found == true" },
+          { from: "check-lead", to: "end-run", condition: "results['fetch-lead'].found == false" },
+          { from: "send-email", to: "end-run" },
+        ],
+      },
+    },
+  });
 
 export const WorkflowResponseSchema = z
   .object({
@@ -173,7 +228,21 @@ export const WorkflowMutationResponseSchema = WorkflowResponseSchema.extend({
   _forkedFromName: z.string().optional().describe(
     "Only present when _action is 'forked'. The name of the original workflow that was forked."
   ),
-}).openapi("WorkflowMutationResponse");
+}).openapi("WorkflowMutationResponse", {
+  example: {
+    id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    orgId: "b645207b-d8e9-40b0-9391-072b777cd9a9",
+    name: "pr-cold-email-outreach-sequoia",
+    displayName: "pr-cold-email-outreach-sequoia",
+    featureSlug: "pr-cold-email-outreach",
+    signature: "abc123...",
+    signatureName: "sequoia",
+    status: "active",
+    forkedFrom: "original-workflow-uuid",
+    _action: "forked",
+    _forkedFromName: "pr-cold-email-outreach-ivory",
+  },
+});
 
 export const TemplateContractIssueSchema = z
   .object({
@@ -218,7 +287,17 @@ export const ExecuteWorkflowSchema = z
       "Runtime inputs for the workflow. Accessible in nodes via $ref:flow_input.fieldName."
     ),
   })
-  .openapi("ExecuteWorkflowRequest");
+  .openapi("ExecuteWorkflowRequest", {
+    example: {
+      inputs: {
+        orgId: "b645207b-d8e9-40b0-9391-072b777cd9a9",
+        campaignId: "camp-123",
+        prAngle: "AI-powered PR automation",
+        newsHook: "Company raises Series A",
+        currentDate: "2026-03-26",
+      },
+    },
+  });
 
 export const WorkflowRunResponseSchema = z
   .object({
@@ -268,7 +347,34 @@ export const DeployWorkflowsSchema = z
   .object({
     workflows: z.array(DeployWorkflowItemSchema).min(1).describe("The workflows to deploy."),
   })
-  .openapi("DeployWorkflowsRequest");
+  .openapi("DeployWorkflowsRequest", {
+    example: {
+      workflows: [
+        {
+          featureSlug: "pr-cold-email-outreach",
+          description: "Cold outreach sequence for PR campaigns",
+          category: "pr",
+          channel: "email",
+          audienceType: "cold-outreach",
+          tags: ["email"],
+          dag: {
+            nodes: [
+              { id: "fetch-lead", type: "http.call", config: { service: "lead", method: "POST", path: "/buffer/next", body: { sourceType: "journalist" } }, inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" } },
+              { id: "check-lead", type: "condition" },
+              { id: "send-email", type: "http.call", config: { service: "email-gateway", method: "POST", path: "/send" }, inputMapping: { "body.to": "$ref:fetch-lead.output.lead.email" }, retries: 0 },
+              { id: "end-run", type: "http.call", config: { service: "campaign", method: "POST", path: "/end-run", body: { success: true } }, inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" } },
+            ],
+            edges: [
+              { from: "fetch-lead", to: "check-lead" },
+              { from: "check-lead", to: "send-email", condition: "results['fetch-lead'].found == true" },
+              { from: "check-lead", to: "end-run", condition: "results['fetch-lead'].found == false" },
+              { from: "send-email", to: "end-run" },
+            ],
+          },
+        },
+      ],
+    },
+  });
 
 export const DeployWorkflowResultSchema = z
   .object({
@@ -310,7 +416,18 @@ export const ExecuteByNameSchema = z
       "Runtime inputs for the workflow. Accessible in nodes via $ref:flow_input.fieldName."
     ),
   })
-  .openapi("ExecuteByNameRequest");
+  .openapi("ExecuteByNameRequest", {
+    example: {
+      inputs: {
+        orgId: "b645207b-d8e9-40b0-9391-072b777cd9a9",
+        campaignId: "camp-123",
+        prAngle: "AI-powered PR automation",
+        newsHook: "Company raises Series A",
+        spokesperson: "Jane Doe, CEO",
+        currentDate: "2026-03-26",
+      },
+    },
+  });
 
 // --- Style schema ---
 


### PR DESCRIPTION
## Summary
- Added examples to all DAG-related schemas (DAGNode, DAGEdge, DAG) explicitly showing the `condition` field on edges
- Added examples to request schemas: UpdateWorkflowRequest, DeployWorkflowsRequest, ExecuteWorkflowRequest, ExecuteByNameRequest
- Added example to WorkflowMutationResponse showing the `_action: "forked"` and `_forkedFromName` fields

## Context
MCP Factory agents were constructing workflow update requests without the `condition` field on edges — likely because the OpenAPI spec had no examples showing that field. The schema described it but without an example, LLM-based tools didn't know to include it when serializing edge objects.

## Test plan
- [x] All 471 tests pass
- [x] OpenAPI spec regenerated and verified — examples appear in component schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)