### PR TITLE
fix: propagate campaign/brand from workflow record into Windmill flow inputs

### DIFF
--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -124,9 +124,9 @@ router.post(
       const userId = res.locals.userId as string;
       const callerRunId = res.locals.runId as string;
 
-      // Extract tracking context: prefer request body inputs, fall back to headers
-      const campaignId = (body.inputs?.campaignId as string | undefined) ?? (res.locals.campaignId as string | undefined);
-      const brandId = (body.inputs?.brandId as string | undefined) ?? (res.locals.brandId as string | undefined);
+      // Extract tracking context: prefer request body inputs, fall back to headers, then workflow record
+      const campaignId = (body.inputs?.campaignId as string | undefined) ?? (res.locals.campaignId as string | undefined) ?? workflow.campaignId ?? undefined;
+      const brandId = (body.inputs?.brandId as string | undefined) ?? (res.locals.brandId as string | undefined) ?? workflow.createdForBrandId ?? undefined;
       const featureSlug = (body.inputs?.featureSlug as string | undefined) ?? (res.locals.featureSlug as string | undefined);
       const headerWorkflowName = res.locals.workflowName as string | undefined;
 
@@ -179,8 +179,8 @@ router.post(
           workflowId: workflow.id,
           orgId,
           userId,
-          campaignId: campaignId ?? workflow.campaignId,
-          brandId: brandId ?? workflow.createdForBrandId,
+          campaignId,
+          brandId,
           featureSlug,
           workflowName: workflow.name,
           subrequestId: (body.inputs?.subrequestId as string | undefined) ?? workflow.subrequestId,
@@ -253,9 +253,9 @@ router.post("/workflows/:id/execute", requireApiKey, executeRateLimit, requireBr
     const executeUserId = res.locals.userId as string;
     const callerRunId = res.locals.runId as string;
 
-    // Extract tracking context: prefer request body inputs, fall back to headers
-    const execCampaignId = (body.inputs?.campaignId as string | undefined) ?? (res.locals.campaignId as string | undefined);
-    const execBrandId = (body.inputs?.brandId as string | undefined) ?? (res.locals.brandId as string | undefined);
+    // Extract tracking context: prefer request body inputs, fall back to headers, then workflow record
+    const execCampaignId = (body.inputs?.campaignId as string | undefined) ?? (res.locals.campaignId as string | undefined) ?? workflow.campaignId ?? undefined;
+    const execBrandId = (body.inputs?.brandId as string | undefined) ?? (res.locals.brandId as string | undefined) ?? workflow.createdForBrandId ?? undefined;
     const execFeatureSlug = (body.inputs?.featureSlug as string | undefined) ?? (res.locals.featureSlug as string | undefined);
 
     // Create a child run in runs-service (links to caller's run via parentRunId)
@@ -304,8 +304,8 @@ router.post("/workflows/:id/execute", requireApiKey, executeRateLimit, requireBr
         workflowId: workflow.id,
         orgId,
         userId: executeUserId,
-        campaignId: execCampaignId ?? workflow.campaignId,
-        brandId: execBrandId ?? workflow.createdForBrandId,
+        campaignId: execCampaignId,
+        brandId: execBrandId,
         featureSlug: execFeatureSlug,
         workflowName: workflow.name,
         subrequestId: (body.inputs?.subrequestId as string | undefined) ?? workflow.subrequestId,

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -297,6 +297,34 @@ describe("POST /workflows/:id/execute", () => {
     expect(res.body.subrequestId).toBe("sub-from-wf");
   });
 
+  it("propagates workflow record campaignId and brandId into Windmill flow inputs", async () => {
+    mockWorkflows.push({
+      id: "wf-1",
+      orgId: "org-1",
+      name: "Test Flow",
+      campaignId: "camp-from-wf",
+      createdForBrandId: "brand-from-wf",
+      subrequestId: null,
+      windmillFlowPath: "f/workflows/org_1/test_flow",
+      windmillWorkspace: "prod",
+      dag: VALID_LINEAR_DAG,
+    });
+
+    // Execute WITHOUT campaignId in inputs or headers — should fall back to workflow record
+    await request
+      .post("/workflows/wf-1/execute")
+      .set(AUTH)
+      .send({ inputs: { email: "test@example.com" } });
+
+    expect(mockRunFlow).toHaveBeenCalledWith(
+      "f/workflows/org_1/test_flow",
+      expect.objectContaining({
+        campaignId: "camp-from-wf",
+        brandId: "brand-1", // from x-brand-id header (takes priority over workflow record)
+      }),
+    );
+  });
+
   it("requires authentication", async () => {
     const res = await request
       .post("/workflows/wf-1/execute")
@@ -563,6 +591,34 @@ describe("POST /workflows/by-name/:name/execute", () => {
     expect(res.status).toBe(410);
     expect(res.body.error).toBe("Workflow has been deprecated");
     expect(res.body.upgradedTo).toBe("wf-missing");
+  });
+
+  it("propagates workflow record campaignId and brandId into Windmill flow inputs (by name)", async () => {
+    mockWorkflows.push({
+      id: "wf-1",
+      orgId: "deployer-org",
+      name: "campaign-flow",
+      campaignId: "camp-on-record",
+      createdForBrandId: "brand-on-record",
+      subrequestId: null,
+      windmillFlowPath: "f/workflows/org_1/campaign_flow",
+      windmillWorkspace: "prod",
+      dag: VALID_LINEAR_DAG,
+    });
+
+    // Execute WITHOUT campaignId in inputs — should fall back to workflow.campaignId
+    await request
+      .post("/workflows/by-name/campaign-flow/execute")
+      .set(AUTH)
+      .send({ inputs: {} });
+
+    expect(mockRunFlow).toHaveBeenCalledWith(
+      "f/workflows/org_1/campaign_flow",
+      expect.objectContaining({
+        campaignId: "camp-on-record",
+        brandId: "brand-1", // from x-brand-id header (takes priority over workflow record)
+      }),
+    );
   });
 
   it("stores campaignId from inputs when following upgrade chain", async () => {


### PR DESCRIPTION
## Summary
- When executing a workflow, `campaignId` and `brandId` now fall back to the workflow record's stored values if not provided in the request inputs or headers
- Previously, only inputs and headers were checked — meaning workflows deployed with a campaign context would silently lose that context at execution time
- This caused http.call nodes to omit the `x-campaign-id` header, breaking downstream services (e.g. journalist-service `/v1/journalists/resolve`) that require it

## Test plan
- [x] Added regression test: workflow record campaignId propagated into Windmill flow inputs (execute by ID)
- [x] Added regression test: workflow record campaignId propagated into Windmill flow inputs (execute by name)
- [x] All 473 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)