### PR TITLE
fix: require all 7 tracking headers on execute endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1771,40 +1771,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -1996,40 +1996,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -2113,40 +2113,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -2228,40 +2228,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -2372,40 +2372,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -2487,40 +2487,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -2613,40 +2613,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -2719,40 +2719,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID. Required on execute endpoints — propagated to all downstream http.call nodes."
             },
-            "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "required": true,
+            "description": "Campaign ID. Required on execute endpoints — propagated to all downstream http.call nodes.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID. Required on execute endpoints — propagated to all downstream http.call nodes."
             },
-            "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "required": true,
+            "description": "Brand ID. Required on execute endpoints — propagated to all downstream http.call nodes.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name. Required on execute endpoints — propagated to all downstream http.call nodes."
             },
-            "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "required": true,
+            "description": "Workflow name. Required on execute endpoints — propagated to all downstream http.call nodes.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug. Required on execute endpoints — propagated to all downstream http.call nodes."
             },
-            "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "required": true,
+            "description": "Feature slug. Required on execute endpoints — propagated to all downstream http.call nodes.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -2836,40 +2836,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -2943,40 +2943,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -3093,40 +3093,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -3210,40 +3210,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -3308,40 +3308,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -3426,40 +3426,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -3615,40 +3615,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -3762,40 +3762,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
             "name": "x-feature-slug",
             "in": "header"
           }
@@ -4044,40 +4044,40 @@
           {
             "schema": {
               "type": "string",
-              "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Campaign ID. Required on execute endpoints — propagated to all downstream http.call nodes."
             },
-            "required": false,
-            "description": "Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "required": true,
+            "description": "Campaign ID. Required on execute endpoints — propagated to all downstream http.call nodes.",
             "name": "x-campaign-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Brand ID. Required on execute endpoints — propagated to all downstream http.call nodes."
             },
-            "required": false,
-            "description": "Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "required": true,
+            "description": "Brand ID. Required on execute endpoints — propagated to all downstream http.call nodes.",
             "name": "x-brand-id",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."
+              "description": "Workflow name. Required on execute endpoints — propagated to all downstream http.call nodes."
             },
-            "required": false,
-            "description": "Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls.",
+            "required": true,
+            "description": "Workflow name. Required on execute endpoints — propagated to all downstream http.call nodes.",
             "name": "x-workflow-name",
             "in": "header"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."
+              "description": "Feature slug. Required on execute endpoints — propagated to all downstream http.call nodes."
             },
-            "required": false,
-            "description": "Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats.",
+            "required": true,
+            "description": "Feature slug. Required on execute endpoints — propagated to all downstream http.call nodes.",
             "name": "x-feature-slug",
             "in": "header"
           }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -61,3 +61,30 @@ export function requireBrandId(
   }
   next();
 }
+
+const REQUIRED_EXECUTION_HEADERS = [
+  "x-org-id",
+  "x-user-id",
+  "x-run-id",
+  "x-brand-id",
+  "x-campaign-id",
+  "x-workflow-name",
+  "x-feature-slug",
+] as const;
+
+export function requireExecutionHeaders(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const missing = REQUIRED_EXECUTION_HEADERS.filter(
+    (h) => !req.headers[h],
+  );
+  if (missing.length > 0) {
+    res.status(400).json({
+      error: `Missing required headers for workflow execution: ${missing.join(", ")}`,
+    });
+    return;
+  }
+  next();
+}

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { eq, and } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { workflows, workflowRuns } from "../db/schema.js";
-import { requireApiKey, requireBrandId } from "../middleware/auth.js";
+import { requireApiKey, requireExecutionHeaders } from "../middleware/auth.js";
 import { executeRateLimit } from "../middleware/rate-limit.js";
 import { getWindmillClient } from "../lib/windmill-client.js";
 import { collectServiceEnvs } from "../lib/service-envs.js";
@@ -39,8 +39,8 @@ function formatRun(r: typeof workflowRuns.$inferSelect) {
 router.post(
   "/workflows/by-name/:name/execute",
   requireApiKey,
+  requireExecutionHeaders,
   executeRateLimit,
-  requireBrandId,
   async (req, res) => {
     try {
       const body = ExecuteByNameSchema.parse(req.body);
@@ -123,12 +123,10 @@ router.post(
 
       const userId = res.locals.userId as string;
       const callerRunId = res.locals.runId as string;
-
-      // Extract tracking context: prefer request body inputs, fall back to headers, then workflow record
-      const campaignId = (body.inputs?.campaignId as string | undefined) ?? (res.locals.campaignId as string | undefined) ?? workflow.campaignId ?? undefined;
-      const brandId = (body.inputs?.brandId as string | undefined) ?? (res.locals.brandId as string | undefined) ?? workflow.createdForBrandId ?? undefined;
-      const featureSlug = (body.inputs?.featureSlug as string | undefined) ?? (res.locals.featureSlug as string | undefined);
-      const headerWorkflowName = res.locals.workflowName as string | undefined;
+      const brandId = res.locals.brandId as string;
+      const campaignId = res.locals.campaignId as string;
+      const workflowNameHeader = res.locals.workflowName as string;
+      const featureSlug = res.locals.featureSlug as string;
 
       // Create a child run in runs-service (links to caller's run via parentRunId)
       let ownRunId: string | null = null;
@@ -149,7 +147,7 @@ router.post(
         return;
       }
 
-      // Run in Windmill — inject orgId, userId, runId, and tracking context so nodes can access them
+      // Run in Windmill — inject identity + tracking headers so every node receives them
       let windmillJobId: string | null = null;
       const client = getWindmillClient();
       if (client) {
@@ -172,7 +170,6 @@ router.post(
       }
 
       // Create workflow run in DB
-      // Prefer resolved campaignId/brandId (from inputs or headers) over workflow record
       const [run] = await db
         .insert(workflowRuns)
         .values({
@@ -209,7 +206,7 @@ router.post(
 );
 
 // POST /workflows/:id/execute — Execute a workflow
-router.post("/workflows/:id/execute", requireApiKey, executeRateLimit, requireBrandId, async (req, res) => {
+router.post("/workflows/:id/execute", requireApiKey, requireExecutionHeaders, executeRateLimit, async (req, res) => {
   try {
     const body = ExecuteWorkflowSchema.parse(req.body ?? {});
     const orgId = res.locals.orgId as string;
@@ -252,11 +249,10 @@ router.post("/workflows/:id/execute", requireApiKey, executeRateLimit, requireBr
 
     const executeUserId = res.locals.userId as string;
     const callerRunId = res.locals.runId as string;
-
-    // Extract tracking context: prefer request body inputs, fall back to headers, then workflow record
-    const execCampaignId = (body.inputs?.campaignId as string | undefined) ?? (res.locals.campaignId as string | undefined) ?? workflow.campaignId ?? undefined;
-    const execBrandId = (body.inputs?.brandId as string | undefined) ?? (res.locals.brandId as string | undefined) ?? workflow.createdForBrandId ?? undefined;
-    const execFeatureSlug = (body.inputs?.featureSlug as string | undefined) ?? (res.locals.featureSlug as string | undefined);
+    const execBrandId = res.locals.brandId as string;
+    const execCampaignId = res.locals.campaignId as string;
+    const execWorkflowName = res.locals.workflowName as string;
+    const execFeatureSlug = res.locals.featureSlug as string;
 
     // Create a child run in runs-service (links to caller's run via parentRunId)
     let ownRunId: string | null = null;
@@ -277,7 +273,7 @@ router.post("/workflows/:id/execute", requireApiKey, executeRateLimit, requireBr
       return;
     }
 
-    // Run in Windmill — inject orgId, userId, runId, and tracking context so nodes can access them
+    // Run in Windmill — inject identity + tracking headers so every node receives them
     let windmillJobId: string | null = null;
     const client = getWindmillClient();
     if (client) {
@@ -297,7 +293,6 @@ router.post("/workflows/:id/execute", requireApiKey, executeRateLimit, requireBr
     }
 
     // Create workflow run in DB
-    // Prefer resolved campaignId/brandId (from inputs or headers) over workflow record
     const [run] = await db
       .insert(workflowRuns)
       .values({

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -790,10 +790,21 @@ const IdentityHeaders = z.object({
   "x-org-id": z.string().describe("Internal org UUID (from client-service). Required."),
   "x-user-id": z.string().describe("Internal user UUID (from client-service). Required."),
   "x-run-id": z.string().describe("Run ID for tracing across services. Required."),
-  "x-campaign-id": z.string().optional().describe("Campaign ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."),
-  "x-brand-id": z.string().optional().describe("Brand ID for tracking. Optional — auto-injected by workflow-service on all downstream calls."),
-  "x-workflow-name": z.string().optional().describe("Workflow name for tracking. Optional — auto-injected by workflow-service on all downstream calls."),
-  "x-feature-slug": z.string().optional().describe("Feature slug from features-service. Optional — propagated by campaign-service for per-feature stats."),
+  "x-campaign-id": z.string().optional().describe("Campaign ID for tracking. Optional on non-execute endpoints."),
+  "x-brand-id": z.string().optional().describe("Brand ID for tracking. Optional on non-execute endpoints."),
+  "x-workflow-name": z.string().optional().describe("Workflow name for tracking. Optional on non-execute endpoints."),
+  "x-feature-slug": z.string().optional().describe("Feature slug from features-service. Optional on non-execute endpoints."),
+});
+
+/** All 7 headers are required on execute endpoints — no fallbacks, no defaults. */
+const ExecutionHeaders = z.object({
+  "x-org-id": z.string().describe("Internal org UUID (from client-service). Required."),
+  "x-user-id": z.string().describe("Internal user UUID (from client-service). Required."),
+  "x-run-id": z.string().describe("Run ID for tracing across services. Required."),
+  "x-campaign-id": z.string().describe("Campaign ID. Required on execute endpoints — propagated to all downstream http.call nodes."),
+  "x-brand-id": z.string().describe("Brand ID. Required on execute endpoints — propagated to all downstream http.call nodes."),
+  "x-workflow-name": z.string().describe("Workflow name. Required on execute endpoints — propagated to all downstream http.call nodes."),
+  "x-feature-slug": z.string().describe("Feature slug. Required on execute endpoints — propagated to all downstream http.call nodes."),
 });
 
 // --- Register Paths ---
@@ -1009,7 +1020,7 @@ registry.registerPath({
   tags: ["Workflow Runs"],
   security: [{ apiKey: [] }],
   request: {
-    headers: IdentityHeaders,
+    headers: ExecutionHeaders,
     params: z.object({ id: z.string().uuid() }),
     body: {
       required: false,
@@ -1339,7 +1350,7 @@ registry.registerPath({
   tags: ["Workflow Runs"],
   security: [{ apiKey: [] }],
   request: {
-    headers: IdentityHeaders,
+    headers: ExecutionHeaders,
     params: z.object({ name: z.string() }),
     body: {
       required: true,

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -100,7 +100,15 @@ import supertest from "supertest";
 import app from "../../src/index.js";
 
 const request = supertest(app);
-const IDENTITY = { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-caller-1", "x-brand-id": "brand-1" };
+const IDENTITY = {
+  "x-org-id": "org-1",
+  "x-user-id": "user-1",
+  "x-run-id": "run-caller-1",
+  "x-brand-id": "brand-1",
+  "x-campaign-id": "camp-1",
+  "x-workflow-name": "test-workflow",
+  "x-feature-slug": "test-feature",
+};
 const AUTH = { "x-api-key": "test-api-key", ...IDENTITY };
 
 describe("POST /workflows/:id/execute", () => {
@@ -156,6 +164,7 @@ describe("POST /workflows/:id/execute", () => {
       userId: "user-1",
       taskName: "execute-workflow",
       workflowName: "Test Flow",
+      campaignId: "camp-1",
       brandId: "brand-1",
     });
   });
@@ -206,6 +215,7 @@ describe("POST /workflows/:id/execute", () => {
       userId: "user-1",
       taskName: "execute-workflow",
       workflowName: "Test Flow",
+      campaignId: "camp-1",
       brandId: "brand-1",
     });
   });
@@ -253,12 +263,12 @@ describe("POST /workflows/:id/execute", () => {
     expect(res.body.upgradedTo).toBe("wf-new-id");
   });
 
-  it("stores campaignId from inputs, not from workflow record", async () => {
+  it("uses campaignId from header, not from workflow record or inputs", async () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "org-1",
       name: "Test Flow",
-      campaignId: null,
+      campaignId: "camp-from-wf",
       subrequestId: null,
       windmillFlowPath: "f/workflows/org_1/test_flow",
       windmillWorkspace: "prod",
@@ -267,62 +277,23 @@ describe("POST /workflows/:id/execute", () => {
 
     const res = await request
       .post("/workflows/wf-1/execute")
-      .set(AUTH)
-      .send({ inputs: { campaignId: "camp-from-input", subrequestId: "sub-from-input" } });
+      .set(AUTH) // x-campaign-id: "camp-1"
+      .send({ inputs: { campaignId: "camp-from-input" } });
 
     expect(res.status).toBe(201);
-    expect(res.body.campaignId).toBe("camp-from-input");
-    expect(res.body.subrequestId).toBe("sub-from-input");
+    expect(res.body.campaignId).toBe("camp-1"); // from header, not input or workflow record
   });
 
-  it("falls back to workflow record campaignId when not in inputs", async () => {
-    mockWorkflows.push({
-      id: "wf-1",
-      orgId: "org-1",
-      name: "Test Flow",
-      campaignId: "camp-from-wf",
-      subrequestId: "sub-from-wf",
-      windmillFlowPath: "f/workflows/org_1/test_flow",
-      windmillWorkspace: "prod",
-      dag: VALID_LINEAR_DAG,
-    });
-
+  it("returns 400 when required execution headers are missing", async () => {
     const res = await request
       .post("/workflows/wf-1/execute")
-      .set(AUTH)
-      .send({ inputs: { email: "test@example.com" } });
+      .set({ "x-api-key": "test-api-key", "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-1" })
+      .send({ inputs: {} });
 
-    expect(res.status).toBe(201);
-    expect(res.body.campaignId).toBe("camp-from-wf");
-    expect(res.body.subrequestId).toBe("sub-from-wf");
-  });
-
-  it("propagates workflow record campaignId and brandId into Windmill flow inputs", async () => {
-    mockWorkflows.push({
-      id: "wf-1",
-      orgId: "org-1",
-      name: "Test Flow",
-      campaignId: "camp-from-wf",
-      createdForBrandId: "brand-from-wf",
-      subrequestId: null,
-      windmillFlowPath: "f/workflows/org_1/test_flow",
-      windmillWorkspace: "prod",
-      dag: VALID_LINEAR_DAG,
-    });
-
-    // Execute WITHOUT campaignId in inputs or headers — should fall back to workflow record
-    await request
-      .post("/workflows/wf-1/execute")
-      .set(AUTH)
-      .send({ inputs: { email: "test@example.com" } });
-
-    expect(mockRunFlow).toHaveBeenCalledWith(
-      "f/workflows/org_1/test_flow",
-      expect.objectContaining({
-        campaignId: "camp-from-wf",
-        brandId: "brand-1", // from x-brand-id header (takes priority over workflow record)
-      }),
-    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Missing required headers");
+    expect(res.body.error).toContain("x-campaign-id");
+    expect(res.body.error).toContain("x-brand-id");
   });
 
   it("requires authentication", async () => {
@@ -389,6 +360,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
       userId: "user-1",
       taskName: "execute-workflow",
       workflowName: "create-user-flow",
+      campaignId: "camp-1",
       brandId: "brand-1",
     });
   });
@@ -432,12 +404,15 @@ describe("POST /workflows/by-name/:name/execute", () => {
       "x-user-id": "user-b",
       "x-run-id": "run-caller-b",
       "x-brand-id": "brand-b",
+      "x-campaign-id": "camp-b",
+      "x-workflow-name": "sales-outreach",
+      "x-feature-slug": "cold-outreach",
     };
 
     const res = await request
       .post("/workflows/by-name/sales-email-cold-outreach-pharaoh/execute")
       .set(CROSS_ORG_AUTH)
-      .send({ inputs: { campaignId: "camp-1" } });
+      .send({ inputs: {} });
 
     expect(res.status).toBe(201);
     expect(res.body.status).toBe("queued");
@@ -593,7 +568,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
     expect(res.body.upgradedTo).toBe("wf-missing");
   });
 
-  it("propagates workflow record campaignId and brandId into Windmill flow inputs (by name)", async () => {
+  it("uses campaignId from header into Windmill flow inputs (by name)", async () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "deployer-org",
@@ -606,25 +581,35 @@ describe("POST /workflows/by-name/:name/execute", () => {
       dag: VALID_LINEAR_DAG,
     });
 
-    // Execute WITHOUT campaignId in inputs — should fall back to workflow.campaignId
     await request
       .post("/workflows/by-name/campaign-flow/execute")
-      .set(AUTH)
+      .set(AUTH) // x-campaign-id: "camp-1", x-brand-id: "brand-1"
       .send({ inputs: {} });
 
     expect(mockRunFlow).toHaveBeenCalledWith(
       "f/workflows/org_1/campaign_flow",
       expect.objectContaining({
-        campaignId: "camp-on-record",
-        brandId: "brand-1", // from x-brand-id header (takes priority over workflow record)
+        campaignId: "camp-1",
+        brandId: "brand-1",
       }),
     );
   });
 
-  it("stores campaignId from inputs when following upgrade chain", async () => {
+  it("returns 400 when required execution headers are missing (by name)", async () => {
+    const res = await request
+      .post("/workflows/by-name/some-flow/execute")
+      .set({ "x-api-key": "test-api-key", "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-1" })
+      .send({ inputs: {} });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Missing required headers");
+    expect(res.body.error).toContain("x-campaign-id");
+  });
+
+  it("stores campaignId from header when following upgrade chain", async () => {
     mockSelectResponses.push(
       [],  // 1. active-only lookup → not found
-      [{   // 2. any-status lookup → deprecated workflow (campaignId is null)
+      [{   // 2. any-status lookup → deprecated workflow
         id: "wf-old",
         name: "old-flow",
         status: "deprecated",
@@ -632,7 +617,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
         subrequestId: null,
         upgradedTo: "wf-new",
       }],
-      [{   // 3. chain follow: replacement is active (campaignId also null)
+      [{   // 3. chain follow: replacement is active
         id: "wf-new",
         name: "new-flow",
         status: "active",
@@ -646,11 +631,11 @@ describe("POST /workflows/by-name/:name/execute", () => {
 
     const res = await request
       .post("/workflows/by-name/old-flow/execute")
-      .set(AUTH)
-      .send({ inputs: { campaignId: "camp-runtime", subrequestId: "sub-runtime" } });
+      .set(AUTH) // x-campaign-id: "camp-1"
+      .send({ inputs: { subrequestId: "sub-runtime" } });
 
     expect(res.status).toBe(201);
-    expect(res.body.campaignId).toBe("camp-runtime");
+    expect(res.body.campaignId).toBe("camp-1");
     expect(res.body.subrequestId).toBe("sub-runtime");
   });
 
@@ -895,7 +880,7 @@ describe("x-feature-slug tracking", () => {
     expect(res.body.featureSlug).toBe("sales-email-cold-outreach");
   });
 
-  it("prefers featureSlug from inputs over header", async () => {
+  it("uses featureSlug from header (inputs do not override)", async () => {
     mockWorkflows.push(WORKFLOW_FIXTURE);
 
     const res = await request
@@ -904,7 +889,7 @@ describe("x-feature-slug tracking", () => {
       .send({ inputs: { featureSlug: "from-inputs" } });
 
     expect(res.status).toBe(201);
-    expect(res.body.featureSlug).toBe("from-inputs");
+    expect(res.body.featureSlug).toBe("from-header");
   });
 
   it("forwards featureSlug into Windmill flow inputs", async () => {
@@ -921,16 +906,4 @@ describe("x-feature-slug tracking", () => {
     );
   });
 
-  it("featureSlug is undefined when header is not sent", async () => {
-    mockWorkflows.push(WORKFLOW_FIXTURE);
-
-    const res = await request
-      .post("/workflows/by-name/sales-email-cold-outreach-sequoia/execute")
-      .set(AUTH)
-      .send({ inputs: {} });
-
-    expect(res.status).toBe(201);
-    // featureSlug should not be set (undefined → null in JSON or absent)
-    expect(res.body.featureSlug).toBeFalsy();
-  });
 });

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -105,6 +105,9 @@ const AUTH = {
   "x-user-id": "user-1",
   "x-run-id": "run-1",
   "x-brand-id": "brand-1",
+  "x-campaign-id": "camp-1",
+  "x-workflow-name": "test-workflow",
+  "x-feature-slug": "test-feature",
 };
 
 describe("Execute endpoint rate limiting", () => {

--- a/tests/unit/tracking-headers.test.ts
+++ b/tests/unit/tracking-headers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { Request, Response, NextFunction } from "express";
-import { requireIdentity, requireBrandId } from "../../src/middleware/auth.js";
+import { requireIdentity, requireBrandId, requireExecutionHeaders } from "../../src/middleware/auth.js";
 
 function mockReqRes(headers: Record<string, string>, body?: Record<string, unknown>) {
   const req = { headers, body: body ?? {} } as unknown as Request;
@@ -135,5 +135,82 @@ describe("requireBrandId – execution endpoints", () => {
     expect(errorBody).toEqual({
       error: "x-brand-id header or inputs.brandId is required for execution endpoints",
     });
+  });
+});
+
+describe("requireExecutionHeaders – all 7 headers required", () => {
+  it("passes when all 7 headers are present", () => {
+    const { req, res } = mockReqRes({
+      "x-org-id": "org-1",
+      "x-user-id": "user-1",
+      "x-run-id": "run-1",
+      "x-brand-id": "brand-1",
+      "x-campaign-id": "camp-1",
+      "x-workflow-name": "my-workflow",
+      "x-feature-slug": "my-feature",
+    });
+
+    let called = false;
+    const next: NextFunction = () => { called = true; };
+
+    requireExecutionHeaders(req, res, next);
+
+    expect(called).toBe(true);
+  });
+
+  it("rejects when tracking headers are missing", () => {
+    const req = { headers: { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-1" } } as unknown as Request;
+    let statusCode = 0;
+    let errorBody: Record<string, unknown> = {};
+    const res = {
+      locals: {},
+      status: (code: number) => {
+        statusCode = code;
+        return { json: (b: Record<string, unknown>) => { errorBody = b; } };
+      },
+    } as unknown as Response;
+
+    let called = false;
+    const next: NextFunction = () => { called = true; };
+
+    requireExecutionHeaders(req, res, next);
+
+    expect(called).toBe(false);
+    expect(statusCode).toBe(400);
+    expect(errorBody.error).toContain("x-brand-id");
+    expect(errorBody.error).toContain("x-campaign-id");
+    expect(errorBody.error).toContain("x-workflow-name");
+    expect(errorBody.error).toContain("x-feature-slug");
+  });
+
+  it("rejects when a single header is missing", () => {
+    const req = { headers: {
+      "x-org-id": "org-1",
+      "x-user-id": "user-1",
+      "x-run-id": "run-1",
+      "x-brand-id": "brand-1",
+      // x-campaign-id missing
+      "x-workflow-name": "my-workflow",
+      "x-feature-slug": "my-feature",
+    } } as unknown as Request;
+    let statusCode = 0;
+    let errorBody: Record<string, unknown> = {};
+    const res = {
+      locals: {},
+      status: (code: number) => {
+        statusCode = code;
+        return { json: (b: Record<string, unknown>) => { errorBody = b; } };
+      },
+    } as unknown as Response;
+
+    let called = false;
+    const next: NextFunction = () => { called = true; };
+
+    requireExecutionHeaders(req, res, next);
+
+    expect(called).toBe(false);
+    expect(statusCode).toBe(400);
+    expect(errorBody.error).toContain("x-campaign-id");
+    expect(errorBody.error).not.toContain("x-brand-id");
   });
 });


### PR DESCRIPTION
## Summary
- All 7 tracking headers (`x-org-id`, `x-user-id`, `x-run-id`, `x-brand-id`, `x-campaign-id`, `x-workflow-name`, `x-feature-slug`) are now **required** on execute endpoints
- Returns 400 with a clear error listing missing headers if any are absent
- Replaces the fallback approach from PR #173 — callers must provide the full context, no silent defaults
- Execute handlers now read strictly from `res.locals` (headers), no input/record fallbacks
- OpenAPI spec updated: execute endpoints document all 7 headers as required

## Test plan
- [x] Unit tests for `requireExecutionHeaders` middleware (passes all 7, missing some, missing one)
- [x] Integration tests for missing headers → 400 on both execute endpoints
- [x] Integration tests verify campaignId/brandId come from headers, not inputs or workflow record
- [x] Rate-limit tests updated with all required headers
- [x] All 475 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)