### PR TITLE
fix: return 502 when key-service unreachable on required-providers

### DIFF
--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -964,6 +964,13 @@ router.get("/workflows/:id/required-providers", requireApiKey, async (req, res) 
       res.status(502).json({ error: err.message });
       return;
     }
+    if (err instanceof TypeError && err.message === "fetch failed") {
+      const cause = (err as unknown as { cause?: { code?: string } }).cause;
+      const detail = cause?.code ? ` (${cause.code})` : "";
+      console.error(`[workflow-service] required-providers: key-service unreachable${detail}`, err);
+      res.status(502).json({ error: `key-service unreachable${detail}` });
+      return;
+    }
     console.error("[workflow-service] required-providers error:", err);
     res.status(500).json({ error: "Internal server error" });
   }

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -921,6 +921,30 @@ describe("GET /workflows/:id/required-providers", () => {
     expect(res.status).toBe(502);
   });
 
+  it("returns 502 when key-service is unreachable (network error)", async () => {
+    mockDbRows.push({
+      id: "wf-http",
+      orgId: "org-1",
+      name: "HTTP Flow",
+      dag: DAG_WITH_HTTP_CALL,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const err = new TypeError("fetch failed");
+    (err as unknown as { cause: { code: string } }).cause = {
+      code: "UND_ERR_CONNECT_TIMEOUT",
+    };
+    mockFetchProviderRequirements.mockRejectedValue(err);
+
+    const res = await request
+      .get("/workflows/wf-http/required-providers")
+      .set(AUTH);
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe("key-service unreachable (UND_ERR_CONNECT_TIMEOUT)");
+  });
+
   it("requires authentication", async () => {
     const res = await request
       .get("/workflows/wf-1/required-providers")


### PR DESCRIPTION
## Summary
- `GET /workflows/:id/required-providers` was returning 500 when key-service was unreachable (network timeout), because `TypeError("fetch failed")` didn't match existing error checks
- Now catches network errors and returns 502 with the cause code (e.g. `UND_ERR_CONNECT_TIMEOUT`) for better diagnostics
- Added regression test

## Test plan
- [x] New test: "returns 502 when key-service is unreachable (network error)" — simulates `TypeError("fetch failed")` with `ConnectTimeoutError` cause
- [x] All 476 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)