### PR TITLE
fix: validate deep $ref output paths at startup

### DIFF
--- a/src/lib/openapi-schema-resolver.ts
+++ b/src/lib/openapi-schema-resolver.ts
@@ -89,6 +89,58 @@ function followRef(
 /**
  * Extracts the requestBody schema for an endpoint from an OpenAPI spec.
  */
+export interface WalkResult {
+  valid: boolean;
+  /** The path segments that were successfully resolved */
+  resolvedPath: string[];
+  /** Available properties at the point of failure (empty if valid) */
+  availableAt?: string[];
+}
+
+/**
+ * Walks a nested path through a JSON Schema, resolving $refs along the way.
+ * Returns whether the full path resolves to an existing field.
+ */
+export function walkSchemaPath(
+  schema: ResolvedSchema,
+  path: string[],
+  spec: Record<string, unknown>,
+): WalkResult {
+  let current: ResolvedSchema | null = schema;
+  const resolvedPath: string[] = [];
+
+  for (const segment of path) {
+    if (!current) {
+      return { valid: false, resolvedPath, availableAt: [] };
+    }
+
+    const prop = current.properties[segment];
+    if (!prop) {
+      return {
+        valid: false,
+        resolvedPath,
+        availableAt: Object.keys(current.properties),
+      };
+    }
+
+    resolvedPath.push(segment);
+
+    // If this is the last segment, we're done — the field exists
+    if (resolvedPath.length === path.length) {
+      return { valid: true, resolvedPath };
+    }
+
+    // Try to descend into the property's schema
+    if (typeof prop === "object" && prop !== null) {
+      current = resolveSchema(prop as Record<string, unknown>, spec);
+    } else {
+      current = null;
+    }
+  }
+
+  return { valid: true, resolvedPath };
+}
+
 export function getRequestBodySchema(
   spec: Record<string, unknown>,
   path: string,

--- a/src/lib/validate-workflow-endpoints.ts
+++ b/src/lib/validate-workflow-endpoints.ts
@@ -1,6 +1,6 @@
 import type { DAG, DAGNode } from "./dag-validator.js";
 import { extractHttpEndpoints } from "./extract-http-endpoints.js";
-import { getRequestBodySchema, getResponseSchema, resolveSchema } from "./openapi-schema-resolver.js";
+import { getRequestBodySchema, getResponseSchema, resolveSchema, walkSchemaPath } from "./openapi-schema-resolver.js";
 
 export interface InvalidEndpoint {
   service: string;
@@ -124,8 +124,8 @@ export function extractBodyFields(node: DAGNode): string[] {
 export function extractOutputRefs(
   dag: DAG,
   sourceNodeId: string,
-): Array<{ downstreamNodeId: string; field: string }> {
-  const refs: Array<{ downstreamNodeId: string; field: string }> = [];
+): Array<{ downstreamNodeId: string; field: string; fullPath: string[] }> {
+  const refs: Array<{ downstreamNodeId: string; field: string; fullPath: string[] }> = [];
   const normalizedId = sourceNodeId.replace(/-/g, "_");
   const hyphenId = sourceNodeId;
 
@@ -141,10 +141,10 @@ export function extractOutputRefs(
       const refNodeId = parts[0];
       if (refNodeId !== hyphenId && refNodeId !== normalizedId) continue;
 
-      // Skip "output" keyword, get the actual field name
+      // Skip "output" keyword, get the actual field path
       const rest = parts.slice(1).filter((p) => p !== "output");
       if (rest.length > 0) {
-        refs.push({ downstreamNodeId: node.id, field: rest[0] });
+        refs.push({ downstreamNodeId: node.id, field: rest[0], fullPath: rest });
       }
       // If rest.length === 0, it's a whole-output reference — skip validation
     }
@@ -226,6 +226,24 @@ function validateFields(
             severity: "warning",
             reason: `Output field "${ref.field}" referenced by "${ref.downstreamNodeId}" not in ${service} ${method} ${path} response schema`,
           });
+          continue;
+        }
+
+        // Deep path validation: check nested fields (e.g. lead.firstName vs lead.data.firstName)
+        if (ref.fullPath.length > 1) {
+          const walkResult = walkSchemaPath(responseSchema, ref.fullPath, spec);
+          if (!walkResult.valid) {
+            const failedAt = walkResult.resolvedPath.join(".");
+            const triedField = ref.fullPath[walkResult.resolvedPath.length];
+            const available = walkResult.availableAt?.join(", ") ?? "none";
+            issues.push({
+              nodeId: node.id,
+              service, method, path,
+              field: ref.fullPath.join("."),
+              severity: "error",
+              reason: `Output path "${ref.fullPath.join(".")}" referenced by "${ref.downstreamNodeId}" is invalid: "${triedField}" does not exist under "${failedAt}" in ${service} ${method} ${path} response (available: ${available})`,
+            });
+          }
         }
       }
     }

--- a/tests/unit/validate-workflow-endpoints.test.ts
+++ b/tests/unit/validate-workflow-endpoints.test.ts
@@ -803,6 +803,126 @@ describe("field validation — nested object detection in additionalProperties",
     expect(nestedErrors).toHaveLength(0);
   });
 
+  it("detects wrong nested output path lead.firstName instead of lead.data.firstName (regression: recipientFirstName missing)", () => {
+    const EMAIL_GATEWAY_SPEC: Record<string, unknown> = {
+      paths: {
+        "/send": {
+          post: {
+            summary: "Send email",
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      type: { type: "string" },
+                      to: { type: "string" },
+                      subject: { type: "string" },
+                      sequence: { type: "array" },
+                      recipientFirstName: { type: "string" },
+                      recipientLastName: { type: "string" },
+                      recipientCompany: { type: "string" },
+                      leadId: { type: "string" },
+                      brandId: { type: "string" },
+                      campaignId: { type: "string" },
+                    },
+                    required: ["type", "to", "subject", "recipientFirstName", "recipientLastName", "recipientCompany"],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "fetch-lead",
+          type: "http.call",
+          config: { service: "lead", method: "POST", path: "/buffer/next" },
+          inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" },
+        },
+        {
+          id: "email-send",
+          type: "http.call",
+          config: {
+            service: "email-gateway",
+            method: "POST",
+            path: "/send",
+            body: { type: "broadcast" },
+          },
+          inputMapping: {
+            "body.to": "$ref:fetch-lead.output.lead.email",
+            "body.subject": "$ref:email-gen.output.subject",
+            "body.recipientFirstName": "$ref:fetch-lead.output.lead.firstName",
+            "body.recipientLastName": "$ref:fetch-lead.output.lead.lastName",
+            "body.recipientCompany": "$ref:fetch-lead.output.lead.publicationName",
+            "body.leadId": "$ref:fetch-lead.output.lead.leadId",
+            "body.campaignId": "$ref:flow_input.campaignId",
+          },
+        },
+      ],
+      edges: [{ from: "fetch-lead", to: "email-send" }],
+    };
+
+    const specs = new Map([
+      ["lead", LEAD_SPEC_WITH_SCHEMAS],
+      ["email-gateway", EMAIL_GATEWAY_SPEC],
+    ]);
+
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    // lead.firstName doesn't exist — correct path is lead.data.firstName
+    const deepErrors = result.fieldIssues.filter(
+      (i) => i.severity === "error" && i.reason.includes("does not exist under"),
+    );
+    expect(deepErrors.length).toBeGreaterThanOrEqual(2);
+
+    const fieldPaths = deepErrors.map((e) => e.field);
+    expect(fieldPaths).toContain("lead.firstName");
+    expect(fieldPaths).toContain("lead.lastName");
+
+    expect(result.valid).toBe(false);
+  });
+
+  it("passes deep path validation for correct path lead.data.firstName", () => {
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "fetch-lead",
+          type: "http.call",
+          config: { service: "lead", method: "POST", path: "/buffer/next" },
+          inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" },
+        },
+        {
+          id: "email-generate",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "cold-email",
+            "body.variables.leadFirstName": "$ref:fetch-lead.output.lead.data.firstName",
+            "body.variables.leadLastName": "$ref:fetch-lead.output.lead.data.lastName",
+          },
+        },
+      ],
+      edges: [{ from: "fetch-lead", to: "email-generate" }],
+    };
+
+    const specs = new Map([
+      ["lead", LEAD_SPEC_WITH_SCHEMAS],
+      ["content-generation", CONTENT_GEN_SPEC],
+    ]);
+
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    const deepErrors = result.fieldIssues.filter(
+      (i) => i.severity === "error" && i.reason.includes("does not exist under"),
+    );
+    expect(deepErrors).toHaveLength(0);
+  });
+
   it("skips nested object check when upstream spec is unavailable", () => {
     const dag: DAG = {
       nodes: [


### PR DESCRIPTION
## Summary
- The startup validator only checked top-level output fields in $ref paths (e.g. `lead` exists → OK). It didn't walk nested paths, so `$ref:fetch-lead.output.lead.firstName` passed even though `firstName` lives under `lead.data.firstName` per the lead service schema.
- This caused the `pr-email-cold-outreach-herald` workflow to send null for `recipientFirstName`/`recipientLastName`/`recipientCompany` to email-gateway, which rejects them as required fields.
- Added `walkSchemaPath` to traverse response schemas and validate full nested paths. Invalid paths are flagged as errors, triggering the existing LLM-powered auto-upgrade on next restart.

## Test plan
- [x] Regression test: detects `lead.firstName` vs `lead.data.firstName` mismatch
- [x] Positive test: correct path `lead.data.firstName` passes validation
- [x] All 478 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)