### PR TITLE
fix: coalesce undefined body.variables for content-generation

### DIFF
--- a/src/lib/input-mapping.ts
+++ b/src/lib/input-mapping.ts
@@ -57,6 +57,15 @@ export function buildInputTransforms(
           }
         }
 
+        // Content-generation template variables (body.variables.*) are always
+        // strings.  When an upstream $ref resolves to undefined (e.g. brand
+        // profile missing a field), JSON.stringify strips the key entirely and
+        // content-generation rejects the request with "expected string, received
+        // undefined".  Coalesce to "" so the field is always present.
+        if (key.startsWith("body.variables.")) {
+          expr += ' ?? ""';
+        }
+
         transforms[key] = { type: "javascript", expr };
       } else {
         transforms[key] = { type: "static", value: ref };

--- a/tests/unit/input-mapping.test.ts
+++ b/tests/unit/input-mapping.test.ts
@@ -212,6 +212,36 @@ describe("buildInputTransforms", () => {
     expect(result.body.expr).toContain('?.["0"]');
   });
 
+  it("regression: body.variables.* $ref expressions coalesce to empty string", () => {
+    const result = buildInputTransforms(
+      { body: { type: "cold-email" } },
+      {
+        "body.variables.leadFirstName": "$ref:fetch-lead.output.lead.data.firstName",
+        "body.variables.clientCompanyOverview": "$ref:brand-profile.output.profile.companyOverview",
+        "body.brandId": "$ref:start-run.output.brandId",
+      },
+    );
+
+    expect(result.body).toBeDefined();
+    expect(result.body.type).toBe("javascript");
+
+    // body.variables.* expressions should coalesce undefined to ""
+    expect(result.body.expr).toContain('results.fetch_lead?.lead?.data?.firstName ?? ""');
+    expect(result.body.expr).toContain('results.brand_profile?.profile?.companyOverview ?? ""');
+
+    // Non-variables $ref should NOT coalesce
+    expect(result.body.expr).toMatch(/results\.start_run\?\.brandId(?!\s*\?\?)/);
+
+    // Expression should be valid JavaScript
+    expect(() => new Function("results", "flow_input", `return ${result.body.expr!}`)).not.toThrow();
+
+    // When upstream returns undefined, variables should be "" not undefined
+    const fn = new Function("results", "flow_input", `return ${result.body.expr!}`);
+    const output = fn({}, {});
+    expect(output.variables.leadFirstName).toBe("");
+    expect(output.variables.clientCompanyOverview).toBe("");
+  });
+
   it("leaves non-dot-notation keys untouched", () => {
     const result = buildInputTransforms(
       { service: "stripe", method: "GET" },


### PR DESCRIPTION
## Summary
- When brand-profile returns missing fields (e.g. `companyOverview`), `$ref` expressions resolve to `undefined` via optional chaining
- `JSON.stringify` strips `undefined` values, so content-generation receives a body missing required string fields → 400 error: "expected string, received undefined"
- Added `?? ""` null coalescing to all `body.variables.*` `$ref` expressions in `input-mapping.ts` so template variables are always present as empty strings

## Test plan
- [x] Regression test: `body.variables.*` expressions coalesce to `""` when upstream returns undefined
- [x] Regression test: non-variables `$ref` expressions (e.g. `body.brandId`) are NOT coalesced
- [x] All 479 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)