### PR TITLE
fix: handle array indices in walkSchemaPath validation

### DIFF
--- a/src/lib/openapi-schema-resolver.ts
+++ b/src/lib/openapi-schema-resolver.ts
@@ -107,15 +107,36 @@ export function walkSchemaPath(
   spec: Record<string, unknown>,
 ): WalkResult {
   let current: ResolvedSchema | null = schema;
+  // Track the raw schema alongside the resolved one so we can detect arrays
+  let currentRaw: Record<string, unknown> | null = null;
   const resolvedPath: string[] = [];
 
   for (const segment of path) {
     if (!current) {
+      // current is null — previous property was a primitive or unresolvable.
+      // But if we have a raw schema that is an array and the segment is numeric,
+      // we can traverse into items.
+      if (currentRaw && /^\d+$/.test(segment)) {
+        const arrayItems = resolveArrayItems(currentRaw, spec);
+        if (arrayItems) {
+          resolvedPath.push(segment);
+          if (resolvedPath.length === path.length) {
+            return { valid: true, resolvedPath };
+          }
+          current = arrayItems.resolved;
+          currentRaw = arrayItems.raw;
+          continue;
+        }
+      }
       return { valid: false, resolvedPath, availableAt: [] };
     }
 
     const prop = current.properties[segment];
     if (!prop) {
+      // If the segment is a numeric index and the current schema wraps an
+      // array (e.g. a top-level "results" that is type: array), we should
+      // not reach here because current would be ResolvedSchema (object).
+      // However, check if any property is an array we can descend into.
       return {
         valid: false,
         resolvedPath,
@@ -132,13 +153,42 @@ export function walkSchemaPath(
 
     // Try to descend into the property's schema
     if (typeof prop === "object" && prop !== null) {
-      current = resolveSchema(prop as Record<string, unknown>, spec);
+      const rawProp = resolveRawSchema(prop as Record<string, unknown>, spec);
+      current = resolveSchema(rawProp, spec);
+      currentRaw = rawProp;
     } else {
       current = null;
+      currentRaw = null;
     }
   }
 
   return { valid: true, resolvedPath };
+}
+
+/**
+ * Resolves $ref in a raw schema without requiring properties (unlike resolveSchema).
+ */
+function resolveRawSchema(
+  schema: Record<string, unknown>,
+  spec: Record<string, unknown>,
+): Record<string, unknown> {
+  if (typeof schema.$ref === "string") {
+    const resolved = followRef(schema.$ref, spec);
+    return resolved ?? schema;
+  }
+  return schema;
+}
+
+/**
+ * If the schema is an array type, resolves its items schema.
+ */
+function resolveArrayItems(
+  rawSchema: Record<string, unknown>,
+  spec: Record<string, unknown>,
+): { resolved: ResolvedSchema | null; raw: Record<string, unknown> } | null {
+  if (rawSchema.type !== "array" || !rawSchema.items) return null;
+  const itemsRaw = resolveRawSchema(rawSchema.items as Record<string, unknown>, spec);
+  return { resolved: resolveSchema(itemsRaw, spec), raw: itemsRaw };
 }
 
 export function getRequestBodySchema(

--- a/tests/unit/openapi-schema-resolver.test.ts
+++ b/tests/unit/openapi-schema-resolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   resolveSchema,
+  walkSchemaPath,
   getRequestBodySchema,
   getResponseSchema,
 } from "../../src/lib/openapi-schema-resolver.js";
@@ -108,6 +109,116 @@ describe("resolveSchema", () => {
     const schema = { type: "object", properties: { foo: { type: "string" } } };
     const result = resolveSchema(schema, {});
     expect(result?.required).toEqual([]);
+  });
+});
+
+describe("walkSchemaPath", () => {
+  it("traverses array items when path segment is numeric (regression: results.0.value false positive)", () => {
+    // brand POST /brands/{brandId}/extract-fields returns { results: [{ key, value, ... }] }
+    const schema = resolveSchema(
+      {
+        type: "object",
+        properties: {
+          results: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                key: { type: "string" },
+                value: { type: "string" },
+              },
+              required: ["key", "value"],
+            },
+          },
+        },
+        required: ["results"],
+      },
+      {},
+    )!;
+
+    // results.0.value should be valid — array index 0, then object property "value"
+    const result = walkSchemaPath(schema, ["results", "0", "value"], {});
+    expect(result.valid).toBe(true);
+    expect(result.resolvedPath).toEqual(["results", "0", "value"]);
+  });
+
+  it("rejects non-numeric segment on array schema", () => {
+    const schema = resolveSchema(
+      {
+        type: "object",
+        properties: {
+          results: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: { key: { type: "string" } },
+            },
+          },
+        },
+      },
+      {},
+    )!;
+
+    const result = walkSchemaPath(schema, ["results", "foo"], {});
+    expect(result.valid).toBe(false);
+  });
+
+  it("traverses array items via $ref", () => {
+    const spec = {
+      components: {
+        schemas: {
+          ExtractResult: {
+            type: "object",
+            properties: {
+              key: { type: "string" },
+              value: { type: "string" },
+            },
+          },
+        },
+      },
+    };
+
+    const schema = resolveSchema(
+      {
+        type: "object",
+        properties: {
+          results: {
+            type: "array",
+            items: { $ref: "#/components/schemas/ExtractResult" },
+          },
+        },
+      },
+      spec,
+    )!;
+
+    const result = walkSchemaPath(schema, ["results", "0", "value"], spec);
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects invalid nested field after array index", () => {
+    const schema = resolveSchema(
+      {
+        type: "object",
+        properties: {
+          results: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                key: { type: "string" },
+                value: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+      {},
+    )!;
+
+    const result = walkSchemaPath(schema, ["results", "0", "nonexistent"], {});
+    expect(result.valid).toBe(false);
+    expect(result.availableAt).toContain("key");
+    expect(result.availableAt).toContain("value");
   });
 });
 

--- a/tests/unit/validate-workflow-endpoints.test.ts
+++ b/tests/unit/validate-workflow-endpoints.test.ts
@@ -923,6 +923,94 @@ describe("field validation — nested object detection in additionalProperties",
     expect(deepErrors).toHaveLength(0);
   });
 
+  it("accepts array-indexed output paths like results.0.value (regression: regulus false positive)", () => {
+    const BRAND_EXTRACT_SPEC: Record<string, unknown> = {
+      paths: {
+        "/brands/{brandId}/extract-fields": {
+          post: {
+            summary: "Extract fields from brand",
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      fields: { type: "array" },
+                    },
+                    required: ["fields"],
+                  },
+                },
+              },
+            },
+            responses: {
+              "200": {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        results: {
+                          type: "array",
+                          items: {
+                            type: "object",
+                            properties: {
+                              key: { type: "string" },
+                              value: { type: "string" },
+                            },
+                            required: ["key", "value"],
+                          },
+                        },
+                      },
+                      required: ["results"],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const dag: DAG = {
+      nodes: [
+        {
+          id: "brand-extract",
+          type: "http.call",
+          config: { service: "brand", method: "POST", path: "/brands/{brandId}/extract-fields" },
+          inputMapping: {
+            "body.fields": "$ref:flow_input.fields",
+          },
+        },
+        {
+          id: "email-generate",
+          type: "http.call",
+          config: { service: "content-generation", method: "POST", path: "/generate" },
+          inputMapping: {
+            "body.type": "cold-email",
+            "body.variables.industry": "$ref:brand-extract.output.results.0.value",
+            "body.variables.geography": "$ref:brand-extract.output.results.1.value",
+            "body.variables.audience": "$ref:brand-extract.output.results.2.value",
+          },
+        },
+      ],
+      edges: [{ from: "brand-extract", to: "email-generate" }],
+    };
+
+    const specs = new Map([
+      ["brand", BRAND_EXTRACT_SPEC],
+      ["content-generation", CONTENT_GEN_SPEC],
+    ]);
+
+    const result = validateWorkflowEndpoints(dag, specs);
+
+    // These should NOT be flagged as errors — array index paths are valid
+    const deepErrors = result.fieldIssues.filter(
+      (i) => i.severity === "error" && i.reason.includes("does not exist under"),
+    );
+    expect(deepErrors).toHaveLength(0);
+  });
+
   it("skips nested object check when upstream spec is unavailable", () => {
     const dag: DAG = {
       nodes: [


### PR DESCRIPTION
## Summary
- `walkSchemaPath` didn't handle array-type schemas — paths like `results.0.value` caused false positive validation errors because `"0"` was looked up as a named property instead of an array index
- The runtime input-mapping (`input-mapping.ts`) already handled this correctly via `?.["0"]` bracket notation — only the validation was wrong
- Now `walkSchemaPath` detects `type: "array"` schemas and traverses into `items` when the path segment is numeric

## Test plan
- [x] Added `walkSchemaPath` unit tests: numeric index on array, non-numeric rejected, $ref items, invalid nested field after index
- [x] Added integration regression test: exact `results.0.value` / `results.1.value` / `results.2.value` pattern from regulus workflow
- [x] All 346 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)