### PR TITLE
refactor: dynasty naming model for workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,3 +34,93 @@ Workflow orchestration service powered by Windmill. Translates internal DAG form
 - Commit `openapi.json` alongside schema changes in `src/schemas.ts`
 - When adding a node type: update `node-type-registry.ts` + create script in `scripts/nodes/`
 - Every bug fix must include a regression test
+
+## Workflow naming and versioning
+
+Workflows follow a dynasty model: each workflow belongs to a lineage (dynasty) that tracks its evolution through upgrades. Names and slugs are derived from the feature dynasty name (from features-service) and a poetic signature name generated once per dynasty.
+
+### Database columns
+
+| Column | Type | Unique? | Description |
+|---|---|---|---|
+| `slug` | text | Yes (globally) | Technical identifier, immutable once created. Used as API key for execution (`POST /execute/:slug`). |
+| `name` | text | Yes (globally) | Human-readable display name. |
+| `signature_name` | text | Unique among active workflows within the same `feature_slug` | Poetic word generated deterministically from the DAG hash. Set once at dynasty creation, never changes within the dynasty. |
+| `dynasty_name` | text | No | Stable name for the lineage. Constant across all versions of a dynasty. |
+| `signature` | text | Unique per `(feature_slug, status='active')` | Hash of the DAG structure. Used for deduplication on upgrade. |
+| `version` | integer | No | Version number within the dynasty. Starts at 1. |
+| `feature_slug` | text | No | Reference to the feature in features-service. Passed by clients. |
+
+### Name composition
+
+All workflow names are derived from two sources:
+- **`feature_dynasty_name`** and **`feature_dynasty_slug`**: fetched from features-service using the `feature_slug`. These are the stable (unversioned) names of the feature. Never use `feature_name` or `feature_slug` directly, as those may contain version suffixes (e.g. "Sales Cold Outreach v2").
+- **`signature_name`**: the poetic word generated once at dynasty creation (e.g. "obsidian").
+
+```
+dynasty_name = feature_dynasty_name + " " + signature_name
+slug         = feature_dynasty_slug + "-" + signature_name [+ "-v{N}" if N >= 2]
+name         = dynasty_name [+ " v{N}" if N >= 2]
+```
+
+Example with `feature_dynasty_name = "Sales Cold Outreach"`, `signature_name = "obsidian"`, version 3:
+```
+dynasty_name:  "Sales Cold Outreach Obsidian"
+slug:          "sales-cold-outreach-obsidian-v3"
+name:          "Sales Cold Outreach Obsidian v3"
+```
+
+No `-v1` or `v1` suffix for version 1 — the first version has no version suffix in slug or name.
+
+### Operations and behavior
+
+**Creation (new workflow, new dynasty):**
+- Generate a new `signature_name` (poetic word, unique among active workflows for this `feature_slug`).
+- Fetch `feature_dynasty_name` and `feature_dynasty_slug` from features-service.
+- Set `version = 1`. No version suffix in slug or name.
+- Compose `dynasty_name`, `slug`, `name` per the formulas above.
+
+**Upgrade (DAG changed) — via `PUT /workflows/upgrade`:**
+- Match existing active workflow by `feature_slug` (one active workflow per feature_slug).
+- If `signature` unchanged → update metadata in-place, no new record.
+- If `signature` changed:
+  - Deprecate the old workflow (`status = "deprecated"`, `upgraded_to = new.id`).
+  - Create new workflow with same `signature_name` and `dynasty_name`.
+  - Increment `version`. Add version suffix to `slug` and `name` (e.g. `-v2`, `v2`).
+
+**Fork (new style):**
+- Creates a new dynasty — new `signature_name`, new `dynasty_name`.
+- `version = 1`, no version suffix.
+- `forked_from` points to the source workflow (for lineage tracking only).
+
+**PATCH (individual workflow):**
+- Metadata-only: can update `description`, `display_name`, `tags`, `category`, etc.
+- DAG changes are forbidden via PATCH. Structural changes go through `PUT /workflows/upgrade`.
+
+### Lineage convergence
+
+When two dynasties evolve independently and eventually produce the same DAG for the same `feature_slug`:
+- The upgrade that arrives second finds an active workflow with the same `(feature_slug, signature)`.
+- It does NOT create a new workflow. Instead, it deprecates its own predecessor and sets `upgraded_to` pointing to the already-existing active workflow.
+- The two lineages now converge on a single active workflow.
+- Ancestors from both branches retain their original `dynasty_name`.
+
+### Stats aggregation across lineages
+
+Stats (costs, email metrics, completed runs) are aggregated across the entire upgrade chain using `getUpgradeChainIds()` in `workflow-scoring.ts`.
+
+- The function builds a `predecessorMap` (`Map<string, string[]>`) from all deprecated workflows' `upgraded_to` pointers.
+- BFS traversal from the active workflow collects ALL ancestors, including multiple branches when lineages have converged.
+- A `visited` set prevents double-counting.
+- Stats are aggregated by `slug` (formerly `name`) across the entire chain, then summed.
+
+This means: if dynasty A and dynasty B converge, the active workflow's stats include runs from both lineages — which is the correct behavior.
+
+### Dependency on features-service
+
+Workflow-service needs `feature_dynasty_name` and `feature_dynasty_slug` from features-service. These are the stable, unversioned identifiers for a feature (as opposed to `feature_name`/`feature_slug` which may carry version suffixes).
+
+- Workflow-service receives only `feature_slug` from clients in requests.
+- It must call features-service to resolve `feature_dynasty_name` and `feature_dynasty_slug`.
+- This endpoint may not exist yet in features-service — it needs to be created.
+- Until features-service exposes this, workflow-service cannot fully implement the naming scheme.

--- a/migrations/001_dynasty_naming.sql
+++ b/migrations/001_dynasty_naming.sql
@@ -1,0 +1,37 @@
+-- Migration: Dynasty naming model
+-- Renames name→slug, display_name→name, adds dynasty_name + version columns.
+
+-- 1. Add new columns (before rename to avoid conflicts)
+ALTER TABLE workflows ADD COLUMN dynasty_name text;
+ALTER TABLE workflows ADD COLUMN version integer NOT NULL DEFAULT 1;
+
+-- 2. Rename columns
+ALTER TABLE workflows RENAME COLUMN name TO slug;
+ALTER TABLE workflows RENAME COLUMN display_name TO name;
+
+-- 3. Backfill dynasty_name from existing data (featureSlug + signatureName capitalized)
+UPDATE workflows SET dynasty_name = CONCAT(
+  INITCAP(REPLACE(feature_slug, '-', ' ')),
+  ' ',
+  INITCAP(signature_name)
+);
+
+-- 4. Backfill name (old display_name) where it was NULL — use dynasty_name
+UPDATE workflows SET name = dynasty_name WHERE name IS NULL;
+
+-- 5. Make dynasty_name NOT NULL after backfill
+ALTER TABLE workflows ALTER COLUMN dynasty_name SET NOT NULL;
+ALTER TABLE workflows ALTER COLUMN name SET NOT NULL;
+
+-- 6. Add unique indexes
+CREATE UNIQUE INDEX idx_workflows_slug_unique ON workflows (slug);
+CREATE UNIQUE INDEX idx_workflows_name_unique ON workflows (name);
+
+-- 7. Partial unique indexes for active workflows
+CREATE UNIQUE INDEX idx_workflows_active_sig
+  ON workflows (feature_slug, signature) WHERE status = 'active';
+CREATE UNIQUE INDEX idx_workflows_active_signame
+  ON workflows (feature_slug, signature_name) WHERE status = 'active';
+
+-- 8. Rename in workflow_runs
+ALTER TABLE workflow_runs RENAME COLUMN workflow_name TO workflow_slug;

--- a/openapi.json
+++ b/openapi.json
@@ -107,14 +107,17 @@
             "nullable": true,
             "description": "Base style name used for versioned naming (e.g. 'hormozi'). Null for non-styled workflows."
           },
+          "slug": {
+            "type": "string",
+            "description": "Unique technical identifier. Use this to execute via /workflows/by-slug/{slug}/execute."
+          },
           "name": {
             "type": "string",
-            "description": "Workflow name. Use this with orgId to execute via /workflows/by-name/{name}/execute."
+            "description": "Human-readable display name. Globally unique."
           },
-          "displayName": {
+          "dynastyName": {
             "type": "string",
-            "nullable": true,
-            "description": "Human-readable display name. Falls back to name if not set."
+            "description": "Stable name for the lineage. Constant across all versions of a dynasty."
           },
           "description": {
             "type": "string",
@@ -142,7 +145,11 @@
           },
           "signatureName": {
             "type": "string",
-            "description": "Human-readable name for this signature (e.g. 'Sequoia'). Used to distinguish workflow variants within the same feature."
+            "description": "Poetic word for this dynasty (e.g. 'sequoia'). Set once at dynasty creation."
+          },
+          "version": {
+            "type": "integer",
+            "description": "Version number within the dynasty. Starts at 1."
           },
           "dag": {
             "nullable": true,
@@ -203,8 +210,9 @@
           "campaignId",
           "subrequestId",
           "styleName",
+          "slug",
           "name",
-          "displayName",
+          "dynastyName",
           "description",
           "category",
           "channel",
@@ -212,6 +220,7 @@
           "tags",
           "signature",
           "signatureName",
+          "version",
           "status",
           "upgradedTo",
           "forkedFrom",
@@ -432,11 +441,6 @@
             "type": "string",
             "description": "Optional subrequest ID for cost tracking."
           },
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Workflow name. Must be unique within the orgId. Used to execute by name later."
-          },
           "description": {
             "type": "string",
             "description": "Human-readable description of what this workflow does."
@@ -444,7 +448,7 @@
           "featureSlug": {
             "type": "string",
             "minLength": 1,
-            "description": "Feature slug from features-service. Required — used to build the workflow name and for feature-level grouping."
+            "description": "Feature slug from features-service. Required — used to build the workflow slug/name and for feature-level grouping."
           },
           "category": {
             "$ref": "#/components/schemas/WorkflowCategory"
@@ -467,7 +471,6 @@
           }
         },
         "required": [
-          "name",
           "featureSlug",
           "dag"
         ]
@@ -554,14 +557,9 @@
               "_action": {
                 "type": "string",
                 "enum": [
-                  "updated",
-                  "forked"
+                  "updated"
                 ],
-                "description": "What happened: 'updated' means the existing workflow was modified in-place, 'forked' means a new workflow was created (check the new name and id)."
-              },
-              "_forkedFromName": {
-                "type": "string",
-                "description": "Only present when _action is 'forked'. The name of the original workflow that was forked."
+                "description": "What happened: 'updated' means the existing workflow was modified in-place (metadata only)."
               }
             },
             "required": [
@@ -577,8 +575,9 @@
           "campaignId": null,
           "subrequestId": null,
           "styleName": null,
-          "name": "pr-cold-email-outreach-sequoia",
-          "displayName": "pr-cold-email-outreach-sequoia",
+          "slug": "pr-cold-email-outreach-sequoia",
+          "name": "Pr Cold Email Outreach Sequoia",
+          "dynastyName": "Pr Cold Email Outreach Sequoia",
           "description": "Cold outreach sequence for PR campaigns",
           "featureSlug": "pr-cold-email-outreach",
           "category": "pr",
@@ -589,6 +588,7 @@
           ],
           "signature": "4c4239e8d9bec64c85a178cb12b6669d3a69b6e68bafc0cb45c1797377ce9a8a",
           "signatureName": "sequoia",
+          "version": 1,
           "dag": {
             "nodes": [
               {
@@ -642,41 +642,15 @@
           "windmillWorkspace": "prod",
           "createdAt": "2026-03-26T03:39:24.262Z",
           "updatedAt": "2026-03-26T06:23:27.287Z",
-          "_action": "forked",
-          "_forkedFromName": "pr-cold-email-outreach-ivory"
+          "_action": "updated"
         }
-      },
-      "WorkflowConflictResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "existingWorkflowId": {
-            "type": "string",
-            "format": "uuid",
-            "description": "ID of the existing workflow that already has this DAG signature."
-          },
-          "existingWorkflowName": {
-            "type": "string",
-            "description": "Name of the existing workflow that already has this DAG signature."
-          }
-        },
-        "required": [
-          "error",
-          "existingWorkflowId",
-          "existingWorkflowName"
-        ]
       },
       "UpdateWorkflowRequest": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string",
-            "minLength": 1
-          },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Updated description."
           },
           "tags": {
             "type": "array",
@@ -686,81 +660,22 @@
             "description": "Updated tags for filtering/grouping."
           },
           "dag": {
-            "$ref": "#/components/schemas/DAG"
-          }
-        },
-        "example": {
-          "dag": {
-            "nodes": [
+            "allOf": [
               {
-                "id": "fetch-lead",
-                "type": "http.call",
-                "config": {
-                  "service": "lead",
-                  "method": "POST",
-                  "path": "/buffer/next",
-                  "body": {
-                    "sourceType": "journalist"
-                  }
-                },
-                "inputMapping": {
-                  "body.campaignId": "$ref:flow_input.campaignId"
-                }
+                "$ref": "#/components/schemas/DAG"
               },
               {
-                "id": "check-lead",
-                "type": "condition"
-              },
-              {
-                "id": "send-email",
-                "type": "http.call",
-                "config": {
-                  "service": "email-gateway",
-                  "method": "POST",
-                  "path": "/send"
-                },
-                "inputMapping": {
-                  "body.to": "$ref:fetch-lead.output.lead.email"
-                },
-                "retries": 0
-              },
-              {
-                "id": "end-run",
-                "type": "http.call",
-                "config": {
-                  "service": "campaign",
-                  "method": "POST",
-                  "path": "/end-run",
-                  "body": {
-                    "success": true
-                  }
-                },
-                "inputMapping": {
-                  "body.campaignId": "$ref:flow_input.campaignId"
-                }
-              }
-            ],
-            "edges": [
-              {
-                "from": "fetch-lead",
-                "to": "check-lead"
-              },
-              {
-                "from": "check-lead",
-                "to": "send-email",
-                "condition": "results['fetch-lead'].found == true"
-              },
-              {
-                "from": "check-lead",
-                "to": "end-run",
-                "condition": "results['fetch-lead'].found == false"
-              },
-              {
-                "from": "send-email",
-                "to": "end-run"
+                "description": "DAG changes are NOT allowed via PUT on individual workflows. Use PUT /workflows/upgrade for structural changes. This field will be rejected if provided."
               }
             ]
           }
+        },
+        "example": {
+          "description": "Updated workflow description",
+          "tags": [
+            "email",
+            "outreach"
+          ]
         }
       },
       "TemplateRef": {
@@ -1066,9 +981,13 @@
             "type": "string",
             "format": "uuid"
           },
+          "slug": {
+            "type": "string",
+            "description": "Unique technical identifier: {featureDynastySlug}-{signatureName}[-v{N}]."
+          },
           "name": {
             "type": "string",
-            "description": "Auto-generated workflow name: {featureSlug}-{signatureName}."
+            "description": "Human-readable name: {dynastyName}[ v{N}]."
           },
           "featureSlug": {
             "type": "string",
@@ -1087,23 +1006,30 @@
           },
           "signatureName": {
             "type": "string",
-            "description": "Human-readable name for this DAG variant (auto-generated by workflow-service)."
+            "description": "Poetic word for this dynasty (auto-generated by workflow-service)."
+          },
+          "version": {
+            "type": "integer",
+            "description": "Version number within the dynasty."
           },
           "action": {
             "type": "string",
             "enum": [
               "created",
-              "updated"
+              "updated",
+              "deprecated-to-existing"
             ]
           }
         },
         "required": [
           "id",
+          "slug",
           "name",
           "featureSlug",
           "tags",
           "signature",
           "signatureName",
+          "version",
           "action"
         ]
       },
@@ -2175,8 +2101,8 @@
         }
       },
       "put": {
-        "summary": "Fork a workflow with modifications",
-        "description": "Creates a new workflow based on an existing one with a modified DAG. The original workflow remains active and unchanged. If only metadata (name, description, tags) is changed without a new DAG, the update is applied in-place. Returns the new forked workflow with a new name and signature.",
+        "summary": "Update workflow metadata",
+        "description": "Updates metadata (description, tags) on an existing workflow. DAG changes are NOT allowed — use PUT /workflows/upgrade for structural changes. Slug and name are immutable and cannot be changed.",
         "tags": [
           "Workflows"
         ],
@@ -2278,7 +2204,7 @@
         },
         "responses": {
           "200": {
-            "description": "Workflow updated in-place (metadata only or same DAG signature). _action='updated'.",
+            "description": "Workflow updated in-place (metadata only). _action='updated'.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2287,12 +2213,12 @@
               }
             }
           },
-          "201": {
-            "description": "Workflow forked (new workflow created with modified DAG). Check _action='forked' and the new name.",
+          "400": {
+            "description": "DAG changes not allowed via this endpoint",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowMutationResponse"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2303,16 +2229,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "A workflow with this DAG signature already exists",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowConflictResponse"
                 }
               }
             }
@@ -3265,7 +3181,7 @@
     "/workflows/upgrade": {
       "put": {
         "summary": "Upgrade (upsert) workflows by DAG signature",
-        "description": "Idempotent: creates new workflows or updates existing ones matched by (orgId + DAG signature). The workflow name is auto-generated as {featureSlug}-{signatureName}. signatureName is a human-readable word auto-assigned to each unique DAG. After deploying, execute workflows via POST /workflows/by-name/{name}/execute.",
+        "description": "Idempotent: creates new workflows or updates existing ones matched by (orgId + DAG signature). The workflow name is auto-generated as {featureSlug}-{signatureName}. signatureName is a human-readable word auto-assigned to each unique DAG. After deploying, execute workflows via POST /workflows/by-slug/{slug}/execute.",
         "tags": [
           "Workflows"
         ],
@@ -3990,9 +3906,9 @@
         }
       }
     },
-    "/workflows/by-name/{name}/execute": {
+    "/workflows/by-slug/{slug}/execute": {
       "post": {
-        "summary": "Execute a workflow by name",
+        "summary": "Execute a workflow by slug",
         "description": "Starts an async execution of a previously deployed workflow. Returns a run object with an ID — poll GET /workflow-runs/{id} for status (queued → running → completed/failed). Pass runtime data via inputs (accessible in nodes as $ref:flow_input.fieldName).",
         "tags": [
           "Workflow Runs"
@@ -4008,7 +3924,7 @@
               "type": "string"
             },
             "required": true,
-            "name": "name",
+            "name": "slug",
             "in": "path"
           },
           {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,11 +2,13 @@ import {
   pgTable,
   uuid,
   text,
+  integer,
   jsonb,
   timestamp,
   index,
   uniqueIndex,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 
 export const workflows = pgTable(
   "workflows",
@@ -18,8 +20,9 @@ export const workflows = pgTable(
     campaignId: text("campaign_id"),
     subrequestId: text("subrequest_id"),
     styleName: text("style_name"),
+    slug: text("slug").notNull(),
     name: text("name").notNull(),
-    displayName: text("display_name"),
+    dynastyName: text("dynasty_name").notNull(),
     description: text("description"),
     featureSlug: text("feature_slug").notNull(),
     category: text("category"),
@@ -27,6 +30,7 @@ export const workflows = pgTable(
     audienceType: text("audience_type"),
     signature: text("signature").notNull(),
     signatureName: text("signature_name").notNull(),
+    version: integer("version").notNull().default(1),
     dag: jsonb("dag").notNull(),
     tags: jsonb("tags").default([]),
     status: text("status").notNull().default("active"),
@@ -43,6 +47,8 @@ export const workflows = pgTable(
     index("idx_workflows_org").on(table.orgId),
     index("idx_workflows_campaign").on(table.campaignId),
     index("idx_workflows_org_style").on(table.orgId, table.styleName),
+    uniqueIndex("idx_workflows_slug_unique").on(table.slug),
+    uniqueIndex("idx_workflows_name_unique").on(table.name),
   ]
 );
 
@@ -56,7 +62,7 @@ export const workflowRuns = pgTable(
     campaignId: text("campaign_id"),
     brandId: text("brand_id"),
     featureSlug: text("feature_slug"),
-    workflowName: text("workflow_name"),
+    workflowSlug: text("workflow_slug"),
     subrequestId: text("subrequest_id"),
     runId: text("run_id"),
 

--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -1,0 +1,88 @@
+/**
+ * Client for features-service dynasty resolution.
+ *
+ * Workflow-service needs the stable (unversioned) dynasty identifiers for a feature
+ * to compose workflow names/slugs. Until features-service exposes
+ * GET /features/dynasty?slug=..., we fall back to deriving them from the featureSlug.
+ */
+
+export interface FeatureDynasty {
+  featureDynastyName: string;
+  featureDynastySlug: string;
+}
+
+function getFeaturesServiceConfig(): { baseUrl: string; apiKey: string } | null {
+  const baseUrl = process.env.FEATURES_SERVICE_URL;
+  const apiKey = process.env.FEATURES_SERVICE_API_KEY;
+  if (!baseUrl || !apiKey) return null;
+  return { baseUrl: baseUrl.replace(/\/$/, ""), apiKey };
+}
+
+/**
+ * Resolve the stable dynasty identifiers for a feature.
+ *
+ * Tries features-service first. Falls back to deriving from featureSlug:
+ * - Strip trailing version suffixes like "-v2", "-v3"
+ * - Capitalize words for the display name
+ */
+export async function resolveFeatureDynasty(
+  featureSlug: string,
+): Promise<FeatureDynasty> {
+  const config = getFeaturesServiceConfig();
+
+  if (config) {
+    try {
+      const res = await fetch(
+        `${config.baseUrl}/features/dynasty?slug=${encodeURIComponent(featureSlug)}`,
+        {
+          method: "GET",
+          headers: { "x-api-key": config.apiKey },
+        },
+      );
+
+      if (res.ok) {
+        const data = (await res.json()) as {
+          feature_dynasty_name?: string;
+          feature_dynasty_slug?: string;
+          featureDynastyName?: string;
+          featureDynastySlug?: string;
+        };
+
+        const dynastyName = data.featureDynastyName ?? data.feature_dynasty_name;
+        const dynastySlug = data.featureDynastySlug ?? data.feature_dynasty_slug;
+
+        if (dynastyName && dynastySlug) {
+          return { featureDynastyName: dynastyName, featureDynastySlug: dynastySlug };
+        }
+      }
+
+      console.warn(
+        `[workflow-service] features-service dynasty lookup failed (${res.status}), falling back to slug derivation`,
+      );
+    } catch (err) {
+      console.warn(
+        "[workflow-service] features-service unreachable, falling back to slug derivation:",
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  return deriveFromSlug(featureSlug);
+}
+
+/**
+ * Fallback: derive dynasty identifiers from featureSlug.
+ * Strips trailing -v{N} suffix and capitalizes words.
+ */
+function deriveFromSlug(featureSlug: string): FeatureDynasty {
+  // Strip trailing version suffix like "-v2", "-v3"
+  const dynastySlug = featureSlug.replace(/-v\d+$/, "");
+
+  // Capitalize each word for display name
+  const dynastyName = dynastySlug
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+
+  return { featureDynastyName: dynastyName, featureDynastySlug: dynastySlug };
+}

--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -104,14 +104,14 @@ export async function validateAndUpgradeWorkflows(
 
     if (result.fieldIssues.length > 0) {
       console.warn(
-        `[workflow-service] Workflow "${wf.name}" (${wf.id}) has ${result.fieldIssues.length} field issue(s):`,
+        `[workflow-service] Workflow "${wf.slug}" (${wf.id}) has ${result.fieldIssues.length} field issue(s):`,
         result.fieldIssues.map((f) => f.reason).join("; "),
       );
     }
 
     if (result.invalidEndpoints.length > 0) {
       console.warn(
-        `[workflow-service] Workflow "${wf.name}" (${wf.id}) has ${result.invalidEndpoints.length} broken endpoint(s):`,
+        `[workflow-service] Workflow "${wf.slug}" (${wf.id}) has ${result.invalidEndpoints.length} broken endpoint(s):`,
         result.invalidEndpoints.map((ep) => `${ep.method} ${ep.service}${ep.path}`).join(", "),
       );
     }
@@ -130,20 +130,20 @@ export async function validateAndUpgradeWorkflows(
       if (upgraded) {
         upgradedCount++;
         console.log(
-          `[workflow-service] Workflow "${wf.name}" upgraded successfully -> new ID: ${upgraded}`,
+          `[workflow-service] Workflow "${wf.slug}" upgraded successfully -> new ID: ${upgraded}`,
         );
       } else {
         // Upgrade skipped (no Anthropic key available) — keep workflow active
         failedCount++;
         console.warn(
-          `[workflow-service] Workflow "${wf.name}" has broken endpoints but upgrade skipped (platform key not available) — keeping active`,
+          `[workflow-service] Workflow "${wf.slug}" has broken endpoints but upgrade skipped (platform key not available) — keeping active`,
         );
       }
     } catch (err) {
       // Upgrade failed — keep workflow active rather than breaking all campaigns
       failedCount++;
       console.error(
-        `[workflow-service] Workflow "${wf.name}" upgrade failed — keeping active:`,
+        `[workflow-service] Workflow "${wf.slug}" upgrade failed — keeping active:`,
         err instanceof Error ? err.message : err,
       );
     }
@@ -153,7 +153,7 @@ export async function validateAndUpgradeWorkflows(
       await sendAdminNotification(wf, result.invalidEndpoints, upgradedCount > failedCount);
     } catch {
       // Non-blocking — log and continue
-      console.warn(`[workflow-service] Failed to send admin notification for "${wf.name}"`);
+      console.warn(`[workflow-service] Failed to send admin notification for "${wf.slug}"`);
     }
   }
 
@@ -183,7 +183,7 @@ export async function validateAndUpgradeWorkflows(
         synced++;
       } catch (err) {
         console.warn(
-          `[workflow-service] Failed to sync flow for "${wf.name}":`,
+          `[workflow-service] Failed to sync flow for "${wf.slug}":`,
           err instanceof Error ? err.message : err,
         );
       }
@@ -219,7 +219,7 @@ async function attemptUpgrade(
     const run = await createPlatformRun({
       serviceName: "workflow",
       taskName: "startup-upgrade",
-      workflowName: wf.name,
+      workflowName: wf.slug,
     });
     platformRunId = run.runId;
   } catch (err) {
@@ -260,7 +260,7 @@ async function attemptUpgrade(
     if (existingMatch) {
       await deprecateWorkflow(database, wf.id, existingMatch.id);
       console.log(
-        `[workflow-service] Workflow "${wf.name}" upgraded by dedup — points to existing ${existingMatch.id}`,
+        `[workflow-service] Workflow "${wf.slug}" upgraded by dedup — points to existing ${existingMatch.id}`,
       );
 
       if (platformRunId) {
@@ -278,21 +278,21 @@ async function attemptUpgrade(
 
     const newSignatureName = pickSignatureName(newSignature, usedNames);
 
-    // Build the new name with the new signatureName; displayName stays as the ancestor's name
-    const newName = `${result.category}-${result.channel}-${result.audienceType}-${newSignatureName}`;
+    // Build the new slug from the dynasty; increment version
+    const newVersion = wf.version + 1;
+    const baseSlug = wf.slug.replace(/-v\d+$/, "");
+    const newSlug = newVersion >= 2 ? `${baseSlug}-v${newVersion}` : baseSlug;
+    const newName = newVersion >= 2 ? `${wf.dynastyName} v${newVersion}` : wf.dynastyName;
 
     // Deploy to Windmill
-    const openFlow = dagToOpenFlow(result.dag, newName);
-    const flowPath = `f/workflows/${wf.orgId}/${newName.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
+    const openFlow = dagToOpenFlow(result.dag, newSlug);
+    const flowPath = `f/workflows/${wf.orgId}/${newSlug.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
     let windmillFlowPath: string | null = null;
 
     if (windmillClient) {
-      // Try updateFlow first (flow usually exists from previous startup).
-      // Only fall back to createFlow if the flow doesn't exist yet.
-      // This avoids Windmill logging noisy 400 "already exists" errors.
       try {
         await windmillClient.updateFlow(flowPath, {
-          summary: newName,
+          summary: newSlug,
           description: result.description,
           value: openFlow.value,
           schema: openFlow.schema,
@@ -304,7 +304,7 @@ async function attemptUpgrade(
           try {
             await windmillClient.createFlow({
               path: flowPath,
-              summary: newName,
+              summary: newSlug,
               description: result.description,
               value: openFlow.value,
               schema: openFlow.schema,
@@ -319,10 +319,10 @@ async function attemptUpgrade(
       }
     }
 
-    // Deprecate old workflow FIRST (frees the unique name index for the replacement)
+    // Deprecate old workflow FIRST (frees the unique slug index for the replacement)
     await deprecateWorkflow(database, wf.id, null);
 
-    // Insert new active workflow with the same name
+    // Insert new active workflow with incremented version
     const [created] = await database
       .insert(workflows)
       .values({
@@ -333,14 +333,16 @@ async function attemptUpgrade(
         campaignId: wf.campaignId,
         subrequestId: wf.subrequestId,
         styleName: wf.styleName,
+        slug: newSlug,
         name: newName,
-        displayName: wf.displayName ?? wf.name,
+        dynastyName: wf.dynastyName,
         description: result.description,
         category: result.category,
         channel: result.channel,
         audienceType: result.audienceType,
         signature: newSignature,
-        signatureName: newSignatureName,
+        signatureName: wf.signatureName,
+        version: newVersion,
         dag: result.dag,
         tags: wf.tags as string[],
         status: "active",
@@ -389,12 +391,10 @@ async function syncFlowToWindmill(
   }
 
   const dag = wf.dag as DAG;
-  const openFlow = dagToOpenFlow(dag, wf.name);
+  const openFlow = dagToOpenFlow(dag, wf.slug);
 
-  // Use the actual stored flow path — NOT a recalculated one.
-  // The path in DB is the source of truth for where the flow lives in Windmill.
   await windmillClient.updateFlow(wf.windmillFlowPath, {
-    summary: wf.name,
+    summary: wf.slug,
     description: wf.description ?? "",
     value: openFlow.value,
     schema: openFlow.schema,
@@ -434,10 +434,10 @@ async function sendAdminNotification(
     .join("\n");
 
   const subject = upgraded
-    ? `[Workflow Service] Workflow "${wf.name}" auto-upgraded`
-    : `[Workflow Service] Workflow "${wf.name}" deprecated — manual intervention required`;
+    ? `[Workflow Service] Workflow "${wf.slug}" auto-upgraded`
+    : `[Workflow Service] Workflow "${wf.slug}" deprecated — manual intervention required`;
 
-  const body = `Workflow: ${wf.name} (${wf.id})
+  const body = `Workflow: ${wf.slug} (${wf.id})
 Org ID: ${wf.orgId}
 Status: ${upgraded ? "Auto-upgraded successfully" : "Deprecated — upgrade failed"}
 

--- a/src/lib/workflow-scoring.ts
+++ b/src/lib/workflow-scoring.ts
@@ -78,10 +78,10 @@ export async function computeWorkflowScores(
     ];
   }
 
-  // 2. Collect all unique workflow names across all dynasty chains
+  // 2. Collect all unique workflow slugs across all dynasty chains
   const allChainNames = [
     ...new Set(
-      Object.values(chainWorkflowsById).flatMap((wfs) => wfs.map((w) => w.name))
+      Object.values(chainWorkflowsById).flatMap((wfs) => wfs.map((w) => w.slug))
     ),
   ];
 
@@ -109,7 +109,7 @@ export async function computeWorkflowScores(
   for (const wf of activeWorkflows) {
     const chainWfs = chainWorkflowsById[wf.id] ?? [];
     const chainIds = chainWfs.map((w) => w.id);
-    const chainNames = new Set(chainWfs.map((w) => w.name));
+    const chainNames = new Set(chainWfs.map((w) => w.slug));
 
     // Costs: aggregate across all dynasty workflow names
     let totalCost = 0;
@@ -176,8 +176,10 @@ export function formatScoreItem(entry: WorkflowScore) {
   return {
     workflow: {
       id: entry.workflow.id,
+      slug: entry.workflow.slug,
       name: entry.workflow.name,
-      displayName: entry.workflow.displayName,
+      dynastyName: entry.workflow.dynastyName,
+      version: entry.workflow.version,
       createdForBrandId: entry.workflow.createdForBrandId,
       featureSlug: entry.workflow.featureSlug,
       signature: entry.workflow.signature,
@@ -192,8 +194,10 @@ export function formatPublicScoreItem(entry: WorkflowScore) {
   return {
     workflow: {
       id: entry.workflow.id,
+      slug: entry.workflow.slug,
       name: entry.workflow.name,
-      displayName: entry.workflow.displayName,
+      dynastyName: entry.workflow.dynastyName,
+      version: entry.workflow.version,
       createdForBrandId: entry.workflow.createdForBrandId,
       featureSlug: entry.workflow.featureSlug,
       signature: entry.workflow.signature,

--- a/src/routes/public-workflows.ts
+++ b/src/routes/public-workflows.ts
@@ -231,8 +231,8 @@ router.get("/public/workflows/best", async (req, res) => {
         if (!entry) return null;
         return {
           workflowId: entry.score.workflow.id,
+          workflowSlug: entry.score.workflow.slug,
           workflowName: entry.score.workflow.name,
-          displayName: entry.score.workflow.displayName,
           createdForBrandId: entry.score.workflow.createdForBrandId,
           value: Math.round(entry.value * 100) / 100,
         };

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -35,9 +35,9 @@ function formatRun(r: typeof workflowRuns.$inferSelect) {
   return base;
 }
 
-// POST /workflows/by-name/:name/execute — Execute a workflow by name
+// POST /workflows/by-slug/:slug/execute — Execute a workflow by slug
 router.post(
-  "/workflows/by-name/:name/execute",
+  "/workflows/by-slug/:slug/execute",
   requireApiKey,
   requireExecutionHeaders,
   executeRateLimit,
@@ -46,13 +46,13 @@ router.post(
       const body = ExecuteByNameSchema.parse(req.body);
       const orgId = res.locals.orgId as string;
 
-      // Look up workflow by name — only active workflows can be executed
+      // Look up workflow by slug — only active workflows can be executed
       let [workflow] = await db
         .select()
         .from(workflows)
         .where(
           and(
-            eq(workflows.name, req.params.name),
+            eq(workflows.slug, req.params.slug),
             eq(workflows.status, "active"),
           )
         );
@@ -62,7 +62,7 @@ router.post(
         const [deprecated] = await db
           .select()
           .from(workflows)
-          .where(eq(workflows.name, req.params.name));
+          .where(eq(workflows.slug, req.params.slug));
 
         if (deprecated && deprecated.status === "deprecated") {
           // Follow upgrade chain to the latest active version
@@ -78,7 +78,7 @@ router.post(
             if (candidate.status === "active") {
               workflow = candidate;
               console.log(
-                `[workflow-service] Execute by name: "${req.params.name}" is deprecated, following upgrade chain to "${candidate.name}" (${candidate.id})`,
+                `[workflow-service] Execute by slug: "${req.params.slug}" is deprecated, following upgrade chain to "${candidate.slug}" (${candidate.id})`,
               );
               break;
             }
@@ -88,27 +88,27 @@ router.post(
 
           if (!workflow) {
             // Dead end — no active workflow at the end of the chain
-            let upgradedToName: string | null = null;
+            let upgradedToSlug: string | null = null;
             if (deprecated.upgradedTo) {
               const [replacement] = await db
                 .select()
                 .from(workflows)
                 .where(eq(workflows.id, deprecated.upgradedTo));
-              upgradedToName = replacement?.name ?? null;
+              upgradedToSlug = replacement?.slug ?? null;
             }
             res.status(410).json({
               error: "Workflow has been deprecated",
               upgradedTo: deprecated.upgradedTo,
-              upgradedToName,
+              upgradedToSlug,
             });
             return;
           }
         } else {
           console.warn(
-            `[workflow-service] Execute by name: workflow "${req.params.name}" not found (no active workflow with this name)`,
+            `[workflow-service] Execute by slug: workflow "${req.params.slug}" not found (no active workflow with this slug)`,
           );
           res.status(404).json({
-            error: `Workflow "${req.params.name}" not found`,
+            error: `Workflow "${req.params.slug}" not found`,
           });
           return;
         }
@@ -125,7 +125,6 @@ router.post(
       const callerRunId = res.locals.runId as string;
       const brandId = res.locals.brandId as string;
       const campaignId = res.locals.campaignId as string;
-      const workflowNameHeader = res.locals.workflowName as string;
       const featureSlug = res.locals.featureSlug as string;
 
       // Create a child run in runs-service (links to caller's run via parentRunId)
@@ -136,7 +135,7 @@ router.post(
           orgId,
           userId,
           taskName: "execute-workflow",
-          workflowName: workflow.name,
+          workflowName: workflow.slug,
           campaignId,
           brandId,
         });
@@ -152,7 +151,7 @@ router.post(
       const client = getWindmillClient();
       if (client) {
         try {
-          const flowInputs = { ...body.inputs, orgId, userId, runId: ownRunId, workflowName: workflow.name, campaignId, brandId, featureSlug, serviceEnvs: collectServiceEnvs() };
+          const flowInputs = { ...body.inputs, orgId, userId, runId: ownRunId, workflowName: workflow.slug, campaignId, brandId, featureSlug, serviceEnvs: collectServiceEnvs() };
           windmillJobId = await client.runFlow(
             workflow.windmillFlowPath,
             flowInputs
@@ -179,7 +178,7 @@ router.post(
           campaignId,
           brandId,
           featureSlug,
-          workflowName: workflow.name,
+          workflowSlug: workflow.slug,
           subrequestId: (body.inputs?.subrequestId as string | undefined) ?? workflow.subrequestId,
           runId: ownRunId,
           windmillJobId,
@@ -190,7 +189,7 @@ router.post(
         .returning();
 
       console.log(
-        `[workflow-service] Workflow "${workflow.name}" execution started: runId=${ownRunId}, windmillJobId=${windmillJobId ?? "none"}`,
+        `[workflow-service] Workflow "${workflow.slug}" execution started: runId=${ownRunId}, windmillJobId=${windmillJobId ?? "none"}`,
       );
 
       res.status(201).json(formatRun(run));
@@ -199,7 +198,7 @@ router.post(
         res.status(400).json({ error: "Validation error", details: err });
         return;
       }
-      console.error("[workflow-service] POST execute-by-name error:", err);
+      console.error("[workflow-service] POST execute-by-slug error:", err);
       res.status(500).json({ error: "Internal server error" });
     }
   }
@@ -251,7 +250,6 @@ router.post("/workflows/:id/execute", requireApiKey, requireExecutionHeaders, ex
     const callerRunId = res.locals.runId as string;
     const execBrandId = res.locals.brandId as string;
     const execCampaignId = res.locals.campaignId as string;
-    const execWorkflowName = res.locals.workflowName as string;
     const execFeatureSlug = res.locals.featureSlug as string;
 
     // Create a child run in runs-service (links to caller's run via parentRunId)
@@ -262,7 +260,7 @@ router.post("/workflows/:id/execute", requireApiKey, requireExecutionHeaders, ex
         orgId,
         userId: executeUserId,
         taskName: "execute-workflow",
-        workflowName: workflow.name,
+        workflowName: workflow.slug,
         campaignId: execCampaignId,
         brandId: execBrandId,
       });
@@ -278,7 +276,7 @@ router.post("/workflows/:id/execute", requireApiKey, requireExecutionHeaders, ex
     const client = getWindmillClient();
     if (client) {
       try {
-        const flowInputs = { ...body.inputs, orgId, userId: executeUserId, runId: ownRunId, workflowName: workflow.name, campaignId: execCampaignId, brandId: execBrandId, featureSlug: execFeatureSlug, serviceEnvs: collectServiceEnvs() };
+        const flowInputs = { ...body.inputs, orgId, userId: executeUserId, runId: ownRunId, workflowName: workflow.slug, campaignId: execCampaignId, brandId: execBrandId, featureSlug: execFeatureSlug, serviceEnvs: collectServiceEnvs() };
         windmillJobId = await client.runFlow(
           workflow.windmillFlowPath,
           flowInputs
@@ -302,7 +300,7 @@ router.post("/workflows/:id/execute", requireApiKey, requireExecutionHeaders, ex
         campaignId: execCampaignId,
         brandId: execBrandId,
         featureSlug: execFeatureSlug,
-        workflowName: workflow.name,
+        workflowSlug: workflow.slug,
         subrequestId: (body.inputs?.subrequestId as string | undefined) ?? workflow.subrequestId,
         runId: ownRunId,
         windmillJobId,

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -37,6 +37,7 @@ import {
   handleExternalServiceError,
   type WorkflowScore,
 } from "../lib/workflow-scoring.js";
+import { resolveFeatureDynasty } from "../lib/features-client.js";
 
 const router = Router();
 
@@ -48,12 +49,22 @@ function formatWorkflow(w: typeof workflows.$inferSelect) {
   };
 }
 
-function generateFlowPath(scope: string, name: string): string {
-  const slug = name
+function generateFlowPath(scope: string, slug: string): string {
+  const sanitized = slug
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_|_$/g, "");
-  return `f/workflows/${scope}/${slug}`;
+  return `f/workflows/${scope}/${sanitized}`;
+}
+
+/** Compose slug with version suffix: no -v1 for v1, -v2 for v2+. */
+function composeSlug(base: string, version: number): string {
+  return version >= 2 ? `${base}-v${version}` : base;
+}
+
+/** Compose display name with version suffix: no v1 for v1, v2 for v2+. */
+function composeName(base: string, version: number): string {
+  return version >= 2 ? `${base} v${version}` : base;
 }
 
 // POST /workflows/generate — Generate a workflow from natural language
@@ -82,19 +93,20 @@ router.post("/workflows/generate", requireApiKey, createRateLimit, async (req, r
       .where(sql`true`);
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
 
+    // Match by featureSlug — one active workflow per featureSlug
     const [existing] = await db
       .select()
       .from(workflows)
       .where(
         and(
-          eq(workflows.orgId, orgId),
-          eq(workflows.signature, signature),
+          eq(workflows.featureSlug, body.featureSlug),
           eq(workflows.status, "active"),
         )
       );
 
     type DeployResult = {
       id: string;
+      slug: string;
       name: string;
       featureSlug: string;
       tags: string[];
@@ -105,13 +117,13 @@ router.post("/workflows/generate", requireApiKey, createRateLimit, async (req, r
 
     let result: DeployResult;
 
-    if (existing) {
-      const openFlow = dagToOpenFlow(dag, existing.name);
+    if (existing && existing.signature === signature) {
+      const openFlow = dagToOpenFlow(dag, existing.slug);
       const client = getWindmillClient();
       if (client && existing.windmillFlowPath) {
         try {
           await client.updateFlow(existing.windmillFlowPath, {
-            summary: existing.name,
+            summary: existing.slug,
             description: generated.description,
             value: openFlow.value,
             schema: openFlow.schema,
@@ -136,6 +148,7 @@ router.post("/workflows/generate", requireApiKey, createRateLimit, async (req, r
 
       result = {
         id: updated.id,
+        slug: updated.slug,
         name: updated.name,
         featureSlug: updated.featureSlug,
         tags: (updated.tags as string[]) ?? [],
@@ -145,7 +158,6 @@ router.post("/workflows/generate", requireApiKey, createRateLimit, async (req, r
       };
     } else {
       let signatureName: string;
-      let displayName: string;
       let styleName: string | null = null;
       let humanId: string | null = null;
       let createdForBrandId: string | null = null;
@@ -169,7 +181,6 @@ router.post("/workflows/generate", requireApiKey, createRateLimit, async (req, r
         const version = sameStyle.length + 1;
 
         signatureName = `${styleName}-v${version}`;
-        displayName = `${body.style.name} v${version}`;
 
         if (body.style.type === "human" && body.style.humanId) {
           humanId = body.style.humanId;
@@ -179,19 +190,23 @@ router.post("/workflows/generate", requireApiKey, createRateLimit, async (req, r
         }
       } else {
         signatureName = pickSignatureName(signature, usedNames);
-        displayName = `${body.featureSlug}-${signatureName}`;
       }
 
-      const name = `${body.featureSlug}-${signatureName}`;
-      const openFlow = dagToOpenFlow(dag, name);
-      const flowPath = generateFlowPath(orgId, name);
+      const dynasty = await resolveFeatureDynasty(body.featureSlug);
+      const dynastyName = `${dynasty.featureDynastyName} ${signatureName.charAt(0).toUpperCase() + signatureName.slice(1)}`;
+      const newVersion = existing ? existing.version + 1 : 1;
+      const slug = composeSlug(`${dynasty.featureDynastySlug}-${signatureName}`, newVersion);
+      const name = composeName(dynastyName, newVersion);
+
+      const openFlow = dagToOpenFlow(dag, slug);
+      const flowPath = generateFlowPath(orgId, slug);
       const client = getWindmillClient();
 
       if (client) {
         try {
           await client.createFlow({
             path: flowPath,
-            summary: name,
+            summary: slug,
             description: generated.description,
             value: openFlow.value,
             schema: openFlow.schema,
@@ -201,12 +216,21 @@ router.post("/workflows/generate", requireApiKey, createRateLimit, async (req, r
         }
       }
 
+      // Deprecate existing if upgrading
+      if (existing) {
+        await db
+          .update(workflows)
+          .set({ status: "deprecated", updatedAt: new Date() })
+          .where(eq(workflows.id, existing.id));
+      }
+
       const [created] = await db
         .insert(workflows)
         .values({
           orgId,
+          slug,
           name,
-          displayName,
+          dynastyName,
           description: generated.description,
           featureSlug: body.featureSlug,
           category: generated.category,
@@ -214,6 +238,7 @@ router.post("/workflows/generate", requireApiKey, createRateLimit, async (req, r
           audienceType: generated.audienceType,
           signature,
           signatureName,
+          version: newVersion,
           dag: generated.dag,
           windmillFlowPath: flowPath,
           humanId,
@@ -224,14 +249,23 @@ router.post("/workflows/generate", requireApiKey, createRateLimit, async (req, r
         })
         .returning();
 
+      // Set upgradedTo pointer on the deprecated workflow
+      if (existing) {
+        await db
+          .update(workflows)
+          .set({ upgradedTo: created.id })
+          .where(eq(workflows.id, existing.id));
+      }
+
       result = {
         id: created.id,
+        slug: created.slug,
         name: created.name,
         featureSlug: created.featureSlug,
         tags: (created.tags as string[]) ?? [],
         signature: created.signature,
         signatureName: created.signatureName,
-        action: "created",
+        action: existing ? "updated" : "created",
       };
     }
 
@@ -282,9 +316,23 @@ router.post("/workflows", requireApiKey, createRateLimit, async (req, res) => {
       return;
     }
 
+    // Compute signature and naming
+    const signature = computeDAGSignature(body.dag);
+    const existingWorkflows = await db
+      .select({ signatureName: workflows.signatureName })
+      .from(workflows)
+      .where(eq(workflows.status, "active"));
+    const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
+    const signatureName = pickSignatureName(signature, usedNames);
+
+    const dynasty = await resolveFeatureDynasty(body.featureSlug);
+    const dynastyName = `${dynasty.featureDynastyName} ${signatureName.charAt(0).toUpperCase() + signatureName.slice(1)}`;
+    const slug = `${dynasty.featureDynastySlug}-${signatureName}`;
+    const name = dynastyName;
+
     // Translate to OpenFlow
-    const openFlow = dagToOpenFlow(dag, body.name);
-    const flowPath = generateFlowPath(orgId, body.name);
+    const openFlow = dagToOpenFlow(dag, slug);
+    const flowPath = generateFlowPath(orgId, slug);
 
     // Push to Windmill (if configured)
     const client = getWindmillClient();
@@ -292,7 +340,7 @@ router.post("/workflows", requireApiKey, createRateLimit, async (req, res) => {
       try {
         await client.createFlow({
           path: flowPath,
-          summary: body.name,
+          summary: slug,
           description: body.description,
           value: openFlow.value,
           schema: openFlow.schema,
@@ -301,15 +349,6 @@ router.post("/workflows", requireApiKey, createRateLimit, async (req, res) => {
         console.error("[workflow-service] Failed to create flow in Windmill:", err);
       }
     }
-
-    // Compute signature
-    const signature = computeDAGSignature(body.dag);
-    const existingWorkflows = await db
-      .select({ signatureName: workflows.signatureName })
-      .from(workflows)
-      .where(eq(workflows.status, "active"));
-    const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
-    const signatureName = pickSignatureName(signature, usedNames);
 
     // Store in DB
     const [workflow] = await db
@@ -320,7 +359,9 @@ router.post("/workflows", requireApiKey, createRateLimit, async (req, res) => {
         featureSlug: body.featureSlug,
         campaignId: body.campaignId,
         subrequestId: body.subrequestId,
-        name: body.name,
+        slug,
+        name,
+        dynastyName,
         description: body.description,
         category: body.category,
         channel: body.channel,
@@ -328,6 +369,7 @@ router.post("/workflows", requireApiKey, createRateLimit, async (req, res) => {
         tags: body.tags ?? [],
         signature,
         signatureName,
+        version: 1,
         dag: body.dag,
         windmillFlowPath: flowPath,
         createdByUserId: res.locals.userId as string,
@@ -464,36 +506,35 @@ router.put("/workflows/upgrade", requireApiKey, async (req, res) => {
       .where(sql`true`);
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
 
-    const results: { id: string; name: string; featureSlug: string; tags: string[]; signature: string; signatureName: string; action: "created" | "updated" }[] = [];
+    const results: { id: string; slug: string; name: string; featureSlug: string; tags: string[]; signature: string; signatureName: string; version: number; action: "created" | "updated" | "deprecated-to-existing" }[] = [];
 
     for (const wf of body.workflows) {
       const dag = wf.dag as DAG;
       const signature = computeDAGSignature(wf.dag);
 
-      // Check if workflow already exists for this (orgId, signature) — only active
-      const [existing] = await db
+      // Match by featureSlug — one active workflow per featureSlug
+      const [activeForFeature] = await db
         .select()
         .from(workflows)
         .where(
           and(
-            eq(workflows.orgId, orgId),
-            eq(workflows.signature, signature),
+            eq(workflows.featureSlug, wf.featureSlug),
             eq(workflows.status, "active"),
           )
         );
 
-      if (existing) {
-        // Same DAG already deployed — update metadata
+      if (activeForFeature && activeForFeature.signature === signature) {
+        // Same DAG already deployed — update metadata in-place
         console.log(
-          `[workflow-service] deploy: sig=${signature.slice(0, 12)} matched "${existing.name}" (${existing.id}) -> update`,
+          `[workflow-service] deploy: sig=${signature.slice(0, 12)} matched "${activeForFeature.slug}" (${activeForFeature.id}) -> update`,
         );
-        const openFlow = dagToOpenFlow(dag, existing.name);
+        const openFlow = dagToOpenFlow(dag, activeForFeature.slug);
         const client = getWindmillClient();
 
-        if (client && existing.windmillFlowPath) {
+        if (client && activeForFeature.windmillFlowPath) {
           try {
-            await client.updateFlow(existing.windmillFlowPath, {
-              summary: existing.name,
+            await client.updateFlow(activeForFeature.windmillFlowPath, {
+              summary: activeForFeature.slug,
               description: wf.description,
               value: openFlow.value,
               schema: openFlow.schema,
@@ -503,14 +544,14 @@ router.put("/workflows/upgrade", requireApiKey, async (req, res) => {
           }
         }
 
-        const updatedTags = wf.tags ?? (existing.tags as string[]) ?? [];
+        const updatedTags = wf.tags ?? (activeForFeature.tags as string[]) ?? [];
         const [updated] = await db
           .update(workflows)
           .set({
             orgId,
             createdForBrandId: wf.createdForBrandId,
-            featureSlug: wf.featureSlug ?? existing.featureSlug,
-            description: wf.description ?? existing.description,
+            featureSlug: wf.featureSlug ?? activeForFeature.featureSlug,
+            description: wf.description ?? activeForFeature.description,
             category: wf.category,
             channel: wf.channel,
             audienceType: wf.audienceType,
@@ -518,37 +559,167 @@ router.put("/workflows/upgrade", requireApiKey, async (req, res) => {
             dag: wf.dag,
             updatedAt: new Date(),
           })
-          .where(eq(workflows.id, existing.id))
+          .where(eq(workflows.id, activeForFeature.id))
           .returning();
 
         results.push({
           id: updated.id,
+          slug: updated.slug,
           name: updated.name,
           featureSlug: updated.featureSlug,
           tags: (updated.tags as string[]) ?? [],
           signature: updated.signature,
           signatureName: updated.signatureName,
+          version: updated.version,
           action: "updated",
         });
+      } else if (activeForFeature) {
+        // DAG changed — check if another active workflow already has this signature (convergence)
+        const [convergenceTarget] = await db
+          .select()
+          .from(workflows)
+          .where(
+            and(
+              eq(workflows.featureSlug, wf.featureSlug),
+              eq(workflows.signature, signature),
+              eq(workflows.status, "active"),
+            )
+          );
+
+        if (convergenceTarget) {
+          // Convergence: deprecate our predecessor, point to the existing active
+          console.log(
+            `[workflow-service] deploy: convergence — "${activeForFeature.slug}" -> existing "${convergenceTarget.slug}"`,
+          );
+
+          await db
+            .update(workflows)
+            .set({
+              status: "deprecated",
+              upgradedTo: convergenceTarget.id,
+              updatedAt: new Date(),
+            })
+            .where(eq(workflows.id, activeForFeature.id));
+
+          results.push({
+            id: convergenceTarget.id,
+            slug: convergenceTarget.slug,
+            name: convergenceTarget.name,
+            featureSlug: convergenceTarget.featureSlug,
+            tags: (convergenceTarget.tags as string[]) ?? [],
+            signature: convergenceTarget.signature,
+            signatureName: convergenceTarget.signatureName,
+            version: convergenceTarget.version,
+            action: "deprecated-to-existing",
+          });
+        } else {
+          // Upgrade: deprecate old, create new version in the same dynasty
+          const newVersion = activeForFeature.version + 1;
+          const dynastyName = activeForFeature.dynastyName;
+          const signatureName = activeForFeature.signatureName;
+
+          // Build slug base from dynasty slug (feature_dynasty_slug + signatureName)
+          // Extract the base slug by stripping version suffix from the existing slug
+          const baseSlug = activeForFeature.slug.replace(/-v\d+$/, "");
+          const newSlug = composeSlug(baseSlug, newVersion);
+          const newName = composeName(dynastyName, newVersion);
+
+          console.log(
+            `[workflow-service] deploy: sig=${signature.slice(0, 12)} upgrade "${activeForFeature.slug}" -> "${newSlug}" (v${newVersion})`,
+          );
+
+          const openFlow = dagToOpenFlow(dag, newSlug);
+          const flowPath = generateFlowPath(orgId, newSlug);
+          const client = getWindmillClient();
+
+          if (client) {
+            try {
+              await client.createFlow({
+                path: flowPath,
+                summary: newSlug,
+                description: wf.description,
+                value: openFlow.value,
+                schema: openFlow.schema,
+              });
+            } catch (err) {
+              console.error("[workflow-service] deploy: failed to create Windmill flow:", err);
+            }
+          }
+
+          // Deprecate old workflow FIRST
+          await db
+            .update(workflows)
+            .set({
+              status: "deprecated",
+              updatedAt: new Date(),
+            })
+            .where(eq(workflows.id, activeForFeature.id));
+
+          const [created] = await db
+            .insert(workflows)
+            .values({
+              orgId,
+              createdForBrandId: wf.createdForBrandId,
+              featureSlug: wf.featureSlug,
+              slug: newSlug,
+              name: newName,
+              dynastyName,
+              description: wf.description,
+              category: wf.category,
+              channel: wf.channel,
+              audienceType: wf.audienceType,
+              tags: wf.tags ?? [],
+              signature,
+              signatureName,
+              version: newVersion,
+              dag: wf.dag,
+              windmillFlowPath: flowPath,
+              createdByUserId: res.locals.userId as string,
+              createdByRunId: res.locals.runId as string,
+            })
+            .returning();
+
+          // Set upgradedTo pointer on the deprecated workflow
+          await db
+            .update(workflows)
+            .set({ upgradedTo: created.id })
+            .where(eq(workflows.id, activeForFeature.id));
+
+          results.push({
+            id: created.id,
+            slug: created.slug,
+            name: created.name,
+            featureSlug: created.featureSlug,
+            tags: (created.tags as string[]) ?? [],
+            signature: created.signature,
+            signatureName: created.signatureName,
+            version: created.version,
+            action: "created",
+          });
+        }
       } else {
-        // New DAG — generate signatureName and build name
+        // No active workflow for this featureSlug — new dynasty
         const signatureName = pickSignatureName(signature, usedNames);
         usedNames.add(signatureName);
 
-        const name = `${wf.featureSlug}-${signatureName}`;
+        const dynasty = await resolveFeatureDynasty(wf.featureSlug);
+        const dynastyName = `${dynasty.featureDynastyName} ${signatureName.charAt(0).toUpperCase() + signatureName.slice(1)}`;
+        const slug = `${dynasty.featureDynastySlug}-${signatureName}`;
+        const name = dynastyName;
+
         console.log(
-          `[workflow-service] deploy: sig=${signature.slice(0, 12)} no active match -> create "${name}"`,
+          `[workflow-service] deploy: sig=${signature.slice(0, 12)} new dynasty -> "${slug}"`,
         );
 
-        const openFlow = dagToOpenFlow(dag, name);
-        const flowPath = generateFlowPath(orgId, name);
+        const openFlow = dagToOpenFlow(dag, slug);
+        const flowPath = generateFlowPath(orgId, slug);
         const client = getWindmillClient();
 
         if (client) {
           try {
             await client.createFlow({
               path: flowPath,
-              summary: name,
+              summary: slug,
               description: wf.description,
               value: openFlow.value,
               schema: openFlow.schema,
@@ -564,8 +735,9 @@ router.put("/workflows/upgrade", requireApiKey, async (req, res) => {
             orgId,
             createdForBrandId: wf.createdForBrandId,
             featureSlug: wf.featureSlug,
+            slug,
             name,
-            displayName: name,
+            dynastyName,
             description: wf.description,
             category: wf.category,
             channel: wf.channel,
@@ -573,6 +745,7 @@ router.put("/workflows/upgrade", requireApiKey, async (req, res) => {
             tags: wf.tags ?? [],
             signature,
             signatureName,
+            version: 1,
             dag: wf.dag,
             windmillFlowPath: flowPath,
             createdByUserId: res.locals.userId as string,
@@ -582,11 +755,13 @@ router.put("/workflows/upgrade", requireApiKey, async (req, res) => {
 
         results.push({
           id: created.id,
+          slug: created.slug,
           name: created.name,
           featureSlug: created.featureSlug,
           tags: (created.tags as string[]) ?? [],
           signature: created.signature,
           signatureName: created.signatureName,
+          version: created.version,
           action: "created",
         });
       }
@@ -838,8 +1013,8 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
         if (!entry) return null;
         return {
           workflowId: entry.score.workflow.id,
+          workflowSlug: entry.score.workflow.slug,
           workflowName: entry.score.workflow.name,
-          displayName: entry.score.workflow.displayName,
           createdForBrandId: entry.score.workflow.createdForBrandId,
           value: Math.round(entry.value * 100) / 100,
         };
@@ -976,11 +1151,17 @@ router.get("/workflows/:id/required-providers", requireApiKey, async (req, res) 
   }
 });
 
-// PUT /workflows/:id — Fork a workflow (DAG change creates a new workflow; metadata-only updates in-place)
+// PUT /workflows/:id — Metadata-only update (DAG changes are forbidden; use PUT /workflows/upgrade for structural changes)
 router.put("/workflows/:id", requireApiKey, async (req, res) => {
   try {
     const body = UpdateWorkflowSchema.parse(req.body);
-    const orgId = res.locals.orgId as string;
+
+    if (body.dag) {
+      res.status(400).json({
+        error: "DAG changes are not allowed via PATCH/PUT on individual workflows. Use PUT /workflows/upgrade for structural changes.",
+      });
+      return;
+    }
 
     const [existing] = await db
       .select()
@@ -992,188 +1173,24 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
       return;
     }
 
-    // No DAG provided — metadata-only in-place update
-    if (!body.dag) {
-      const updates: Record<string, unknown> = { updatedAt: new Date() };
-      if (body.name) updates.name = body.name;
-      if (body.description !== undefined) updates.description = body.description;
-      if (body.tags !== undefined) updates.tags = body.tags;
+    // Metadata-only in-place update
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
+    if (body.description !== undefined) updates.description = body.description;
+    if (body.tags !== undefined) updates.tags = body.tags;
 
-      const [updated] = await db
-        .update(workflows)
-        .set(updates)
-        .where(eq(workflows.id, req.params.id))
-        .returning();
+    const [updated] = await db
+      .update(workflows)
+      .set(updates)
+      .where(eq(workflows.id, req.params.id))
+      .returning();
 
-      res.json({ ...formatWorkflow(updated), _action: "updated" as const });
-      return;
-    }
-
-    // DAG provided — validate it
-    const dag = body.dag as DAG;
-    const validation = validateDAG(dag);
-    if (!validation.valid) {
-      res.status(400).json({ error: "Invalid DAG", details: validation.errors });
-      return;
-    }
-
-    const newSignature = computeDAGSignature(body.dag);
-
-    // Same signature — no structural change, update in-place
-    if (newSignature === existing.signature) {
-      const updates: Record<string, unknown> = { updatedAt: new Date(), dag: body.dag };
-      if (body.name) updates.name = body.name;
-      if (body.description !== undefined) updates.description = body.description;
-      if (body.tags !== undefined) updates.tags = body.tags;
-
-      const flowName = body.name ?? existing.name;
-      const openFlow = dagToOpenFlow(dag, flowName);
-      if (existing.windmillFlowPath) {
-        const client = getWindmillClient();
-        if (client) {
-          try {
-            await client.updateFlow(existing.windmillFlowPath, {
-              summary: flowName,
-              value: openFlow.value,
-              schema: openFlow.schema,
-            });
-          } catch (err) {
-            console.error("[workflow-service] Failed to update flow in Windmill:", err);
-          }
-        }
-      }
-
-      const [updated] = await db
-        .update(workflows)
-        .set(updates)
-        .where(eq(workflows.id, req.params.id))
-        .returning();
-
-      res.json({ ...formatWorkflow(updated), _action: "updated" as const });
-      return;
-    }
-
-    // Different signature — FORK: create a new workflow, keep original untouched
-    // Check for existing active workflow with same signature (would violate unique index)
-    const [conflicting] = await db
-      .select()
-      .from(workflows)
-      .where(
-        and(
-          eq(workflows.orgId, orgId),
-          eq(workflows.signature, newSignature),
-          eq(workflows.status, "active"),
-        )
-      );
-
-    if (conflicting) {
-      res.status(409).json({
-        error: "A workflow with this DAG signature already exists",
-        existingWorkflowId: conflicting.id,
-        existingWorkflowName: conflicting.name,
-      });
-      return;
-    }
-
-    // Generate new signatureName (include deprecated to avoid recycling names)
-    const existingWorkflows = await db
-      .select({ signatureName: workflows.signatureName })
-      .from(workflows)
-      .where(sql`true`);
-    const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
-    const signatureName = pickSignatureName(newSignature, usedNames);
-
-    // Build new name from original's featureSlug + new signatureName
-    const newName = `${existing.featureSlug}-${signatureName}`;
-
-    const openFlow = dagToOpenFlow(dag, newName);
-    const flowPath = generateFlowPath(orgId, newName);
-    const client = getWindmillClient();
-
-    if (client) {
-      try {
-        await client.createFlow({
-          path: flowPath,
-          summary: newName,
-          description: body.description ?? existing.description ?? undefined,
-          value: openFlow.value,
-          schema: openFlow.schema,
-        });
-      } catch (err) {
-        // If flow already exists (e.g. retry after partial failure), update it instead
-        if (err instanceof Error && err.message.includes("already exists")) {
-          try {
-            await client.updateFlow(flowPath, {
-              summary: newName,
-              description: body.description ?? existing.description ?? undefined,
-              value: openFlow.value,
-              schema: openFlow.schema,
-            });
-          } catch (updateErr) {
-            console.error("[workflow-service] Failed to update existing forked flow in Windmill:", updateErr);
-          }
-        } else {
-          console.error("[workflow-service] Failed to create forked flow in Windmill:", err);
-        }
-      }
-    }
-
-    let forked;
-    try {
-      const [row] = await db
-        .insert(workflows)
-        .values({
-          orgId: existing.orgId,
-          createdForBrandId: existing.createdForBrandId,
-          featureSlug: existing.featureSlug,
-          humanId: existing.humanId,
-          campaignId: existing.campaignId,
-          subrequestId: existing.subrequestId,
-          styleName: existing.styleName,
-          name: newName,
-          displayName: newName,
-          description: body.description ?? existing.description,
-          category: existing.category,
-          channel: existing.channel,
-          audienceType: existing.audienceType,
-          tags: body.tags ?? (existing.tags as string[]) ?? [],
-          signature: newSignature,
-          signatureName,
-          dag: body.dag,
-          status: "active",
-          forkedFrom: existing.id,
-          windmillFlowPath: flowPath,
-          createdByUserId: res.locals.userId as string,
-          createdByRunId: res.locals.runId as string,
-        })
-        .returning();
-      forked = row;
-    } catch (dbErr: unknown) {
-      if (dbErr instanceof Error && "code" in dbErr && (dbErr as any).code === "23505") {
-        res.status(409).json({
-          error: "A workflow with this name already exists",
-          detail: (dbErr as any).detail,
-        });
-        return;
-      }
-      throw dbErr;
-    }
-
-    console.log(
-      `[workflow-service] fork: "${existing.name}" (${existing.id}) -> "${newName}" (${forked.id})`,
-    );
-
-    res.status(201).json({
-      ...formatWorkflow(forked),
-      _action: "forked" as const,
-      _forkedFromName: existing.name,
-    });
+    res.json({ ...formatWorkflow(updated), _action: "updated" as const });
   } catch (err: unknown) {
     if (err instanceof Error && err.name === "ZodError") {
       res.status(400).json({ error: "Validation error", details: err });
       return;
     }
-    console.error("[workflow-service] PUT fork error:", err);
+    console.error("[workflow-service] PUT update error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -149,9 +149,8 @@ export const CreateWorkflowSchema = z
     createdForBrandId: z.string().optional().describe("Optional brand ID — records which brand context created this workflow."),
     campaignId: z.string().optional().describe("Optional campaign ID for scoping."),
     subrequestId: z.string().optional().describe("Optional subrequest ID for cost tracking."),
-    name: z.string().min(1).describe("Workflow name. Must be unique within the orgId. Used to execute by name later."),
     description: z.string().optional().describe("Human-readable description of what this workflow does."),
-    featureSlug: z.string().min(1).describe("Feature slug from features-service. Required — used to build the workflow name and for feature-level grouping."),
+    featureSlug: z.string().min(1).describe("Feature slug from features-service. Required — used to build the workflow slug/name and for feature-level grouping."),
     category: WorkflowCategorySchema.optional().describe("Optional workflow category tag."),
     channel: WorkflowChannelSchema.optional().describe("Optional workflow channel tag."),
     audienceType: WorkflowAudienceTypeSchema.optional().describe("Optional workflow audience type tag."),
@@ -164,27 +163,14 @@ export const CreateWorkflowSchema = z
 
 export const UpdateWorkflowSchema = z
   .object({
-    name: z.string().min(1).optional(),
-    description: z.string().optional(),
+    description: z.string().optional().describe("Updated description."),
     tags: z.array(z.string()).optional().describe("Updated tags for filtering/grouping."),
-    dag: DAGSchema.optional(),
+    dag: DAGSchema.optional().describe("DAG changes are NOT allowed via PUT on individual workflows. Use PUT /workflows/upgrade for structural changes. This field will be rejected if provided."),
   })
   .openapi("UpdateWorkflowRequest", {
     example: {
-      dag: {
-        nodes: [
-          { id: "fetch-lead", type: "http.call", config: { service: "lead", method: "POST", path: "/buffer/next", body: { sourceType: "journalist" } }, inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" } },
-          { id: "check-lead", type: "condition" },
-          { id: "send-email", type: "http.call", config: { service: "email-gateway", method: "POST", path: "/send" }, inputMapping: { "body.to": "$ref:fetch-lead.output.lead.email" }, retries: 0 },
-          { id: "end-run", type: "http.call", config: { service: "campaign", method: "POST", path: "/end-run", body: { success: true } }, inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" } },
-        ],
-        edges: [
-          { from: "fetch-lead", to: "check-lead" },
-          { from: "check-lead", to: "send-email", condition: "results['fetch-lead'].found == true" },
-          { from: "check-lead", to: "end-run", condition: "results['fetch-lead'].found == false" },
-          { from: "send-email", to: "end-run" },
-        ],
-      },
+      description: "Updated workflow description",
+      tags: ["email", "outreach"],
     },
   });
 
@@ -198,15 +184,17 @@ export const WorkflowResponseSchema = z
     campaignId: z.string().nullable(),
     subrequestId: z.string().nullable(),
     styleName: z.string().nullable().describe("Base style name used for versioned naming (e.g. 'hormozi'). Null for non-styled workflows."),
-    name: z.string().describe("Workflow name. Use this with orgId to execute via /workflows/by-name/{name}/execute."),
-    displayName: z.string().nullable().describe("Human-readable display name. Falls back to name if not set."),
+    slug: z.string().describe("Unique technical identifier. Use this to execute via /workflows/by-slug/{slug}/execute."),
+    name: z.string().describe("Human-readable display name. Globally unique."),
+    dynastyName: z.string().describe("Stable name for the lineage. Constant across all versions of a dynasty."),
     description: z.string().nullable(),
     category: WorkflowCategorySchema.nullable().describe("Optional workflow category tag."),
     channel: WorkflowChannelSchema.nullable().describe("Optional workflow channel tag."),
     audienceType: WorkflowAudienceTypeSchema.nullable().describe("Optional workflow audience type tag."),
     tags: z.array(z.string()).describe("Free-form tags for filtering/grouping (e.g. [\"email\", \"linkedin\"])."),
     signature: z.string().describe("Deterministic SHA-256 hash of the canonical DAG JSON. Changes when any node, edge, or config changes."),
-    signatureName: z.string().describe("Human-readable name for this signature (e.g. 'Sequoia'). Used to distinguish workflow variants within the same feature."),
+    signatureName: z.string().describe("Poetic word for this dynasty (e.g. 'sequoia'). Set once at dynasty creation."),
+    version: z.number().int().describe("Version number within the dynasty. Starts at 1."),
     dag: z.unknown().describe("The DAG definition as submitted."),
     status: z.enum(["active", "deprecated"]).describe("Workflow lifecycle status. Only active workflows can be executed."),
     upgradedTo: z.string().uuid().nullable().describe("If deprecated, the ID of the replacement workflow."),
@@ -221,12 +209,8 @@ export const WorkflowResponseSchema = z
   .openapi("WorkflowResponse");
 
 export const WorkflowMutationResponseSchema = WorkflowResponseSchema.extend({
-  _action: z.enum(["updated", "forked"]).describe(
-    "What happened: 'updated' means the existing workflow was modified in-place, " +
-    "'forked' means a new workflow was created (check the new name and id)."
-  ),
-  _forkedFromName: z.string().optional().describe(
-    "Only present when _action is 'forked'. The name of the original workflow that was forked."
+  _action: z.enum(["updated"]).describe(
+    "What happened: 'updated' means the existing workflow was modified in-place (metadata only)."
   ),
 }).openapi("WorkflowMutationResponse", {
   example: {
@@ -237,8 +221,9 @@ export const WorkflowMutationResponseSchema = WorkflowResponseSchema.extend({
     campaignId: null,
     subrequestId: null,
     styleName: null,
-    name: "pr-cold-email-outreach-sequoia",
-    displayName: "pr-cold-email-outreach-sequoia",
+    slug: "pr-cold-email-outreach-sequoia",
+    name: "Pr Cold Email Outreach Sequoia",
+    dynastyName: "Pr Cold Email Outreach Sequoia",
     description: "Cold outreach sequence for PR campaigns",
     featureSlug: "pr-cold-email-outreach",
     category: "pr",
@@ -247,6 +232,7 @@ export const WorkflowMutationResponseSchema = WorkflowResponseSchema.extend({
     tags: ["email"],
     signature: "4c4239e8d9bec64c85a178cb12b6669d3a69b6e68bafc0cb45c1797377ce9a8a",
     signatureName: "sequoia",
+    version: 1,
     dag: {
       nodes: [
         { id: "fetch-lead", type: "http.call", config: { service: "lead", method: "POST", path: "/buffer/next" }, inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" } },
@@ -267,9 +253,8 @@ export const WorkflowMutationResponseSchema = WorkflowResponseSchema.extend({
     windmillWorkspace: "prod",
     createdAt: "2026-03-26T03:39:24.262Z",
     updatedAt: "2026-03-26T06:23:27.287Z",
-    _action: "forked",
-    _forkedFromName: "pr-cold-email-outreach-ivory",
-  } as z.infer<typeof WorkflowResponseSchema> & { _action: "forked"; _forkedFromName: string },
+    _action: "updated",
+  } as z.infer<typeof WorkflowResponseSchema> & { _action: "updated" },
 });
 
 export const TemplateContractIssueSchema = z
@@ -407,12 +392,14 @@ export const DeployWorkflowsSchema = z
 export const DeployWorkflowResultSchema = z
   .object({
     id: z.string().uuid(),
-    name: z.string().describe("Auto-generated workflow name: {featureSlug}-{signatureName}."),
+    slug: z.string().describe("Unique technical identifier: {featureDynastySlug}-{signatureName}[-v{N}]."),
+    name: z.string().describe("Human-readable name: {dynastyName}[ v{N}]."),
     featureSlug: z.string().describe("Feature slug used to build the name."),
     tags: z.array(z.string()).describe("Tags assigned to this workflow."),
     signature: z.string().describe("SHA-256 hash of the canonical DAG JSON."),
-    signatureName: z.string().describe("Human-readable name for this DAG variant (auto-generated by workflow-service)."),
-    action: z.enum(["created", "updated"]),
+    signatureName: z.string().describe("Poetic word for this dynasty (auto-generated by workflow-service)."),
+    version: z.number().int().describe("Version number within the dynasty."),
+    action: z.enum(["created", "updated", "deprecated-to-existing"]),
   })
   .openapi("DeployWorkflowResult");
 
@@ -430,8 +417,8 @@ export const WorkflowDeprecatedResponseSchema = z
     upgradedTo: z.string().uuid().nullable().describe(
       "ID of the replacement workflow. Null if no replacement was set."
     ),
-    upgradedToName: z.string().nullable().optional().describe(
-      "Name of the replacement workflow (for by-name lookups)."
+    upgradedToSlug: z.string().nullable().optional().describe(
+      "Slug of the replacement workflow (for by-slug lookups)."
     ),
   })
   .openapi("WorkflowDeprecatedResponse");
@@ -762,7 +749,7 @@ export const WorkflowConflictResponseSchema = z
   .object({
     error: z.string(),
     existingWorkflowId: z.string().uuid().describe("ID of the existing workflow that already has this DAG signature."),
-    existingWorkflowName: z.string().describe("Name of the existing workflow that already has this DAG signature."),
+    existingWorkflowSlug: z.string().describe("Slug of the existing workflow that already has this DAG signature."),
   })
   .openapi("WorkflowConflictResponse");
 
@@ -937,12 +924,11 @@ registry.registerPath({
 registry.registerPath({
   method: "put",
   path: "/workflows/{id}",
-  summary: "Fork a workflow with modifications",
+  summary: "Update workflow metadata",
   description:
-    "Creates a new workflow based on an existing one with a modified DAG. " +
-    "The original workflow remains active and unchanged. " +
-    "If only metadata (name, description, tags) is changed without a new DAG, the update is applied in-place. " +
-    "Returns the new forked workflow with a new name and signature.",
+    "Updates metadata (description, tags) on an existing workflow. " +
+    "DAG changes are NOT allowed — use PUT /workflows/upgrade for structural changes. " +
+    "Slug and name are immutable and cannot be changed.",
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
   request: {
@@ -954,21 +940,17 @@ registry.registerPath({
     },
   },
   responses: {
-    201: {
-      description: "Workflow forked (new workflow created with modified DAG). Check _action='forked' and the new name.",
+    200: {
+      description: "Workflow updated in-place (metadata only). _action='updated'.",
       content: { "application/json": { schema: WorkflowMutationResponseSchema } },
     },
-    200: {
-      description: "Workflow updated in-place (metadata only or same DAG signature). _action='updated'.",
-      content: { "application/json": { schema: WorkflowMutationResponseSchema } },
+    400: {
+      description: "DAG changes not allowed via this endpoint",
+      content: { "application/json": { schema: ErrorResponseSchema } },
     },
     404: {
       description: "Not found",
       content: { "application/json": { schema: ErrorResponseSchema } },
-    },
-    409: {
-      description: "A workflow with this DAG signature already exists",
-      content: { "application/json": { schema: WorkflowConflictResponseSchema } },
     },
   },
 });
@@ -1157,7 +1139,7 @@ registry.registerPath({
     "Idempotent: creates new workflows or updates existing ones matched by (orgId + DAG signature). " +
     "The workflow name is auto-generated as {featureSlug}-{signatureName}. " +
     "signatureName is a human-readable word auto-assigned to each unique DAG. " +
-    "After deploying, execute workflows via POST /workflows/by-name/{name}/execute.",
+    "After deploying, execute workflows via POST /workflows/by-slug/{slug}/execute.",
   tags: ["Workflows"],
   security: [{ apiKey: [] }],
   request: {
@@ -1341,8 +1323,8 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/workflows/by-name/{name}/execute",
-  summary: "Execute a workflow by name",
+  path: "/workflows/by-slug/{slug}/execute",
+  summary: "Execute a workflow by slug",
   description:
     "Starts an async execution of a previously deployed workflow. " +
     "Returns a run object with an ID — poll GET /workflow-runs/{id} for status (queued → running → completed/failed). " +
@@ -1351,7 +1333,7 @@ registry.registerPath({
   security: [{ apiKey: [] }],
   request: {
     headers: ExecutionHeaders,
-    params: z.object({ name: z.string() }),
+    params: z.object({ slug: z.string() }),
     body: {
       required: true,
       content: { "application/json": { schema: ExecuteByNameSchema } },

--- a/tests/integration/best-workflow.test.ts
+++ b/tests/integration/best-workflow.test.ts
@@ -135,14 +135,16 @@ const BASE_QUERY = {
   objective: "replies",
 };
 
-const DEFAULT_WF_NAME = "sales-email-cold-outreach-alpha";
+const DEFAULT_WF_SLUG = "sales-email-cold-outreach-alpha";
 
 function makeWorkflow(overrides: Record<string, unknown> = {}) {
   return {
     id: "wf-" + Math.random().toString(36).slice(2, 10),
     orgId: "org1",
-    name: DEFAULT_WF_NAME,
-    displayName: null,
+    slug: DEFAULT_WF_SLUG,
+    name: "Sales Email Cold Outreach Alpha",
+    dynastyName: "Sales Email Cold Outreach Alpha",
+    version: 1,
     createdForBrandId: null,
     description: null,
     featureSlug: "sales-cold-email-outreach",
@@ -232,8 +234,8 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-1"), makeRun("wf-a", "ext-run-2"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 300, runCount: 2 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 10 } } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 300, runCount: 2 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { replied: 10 } } });
 
     const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
 
@@ -251,10 +253,10 @@ describe("GET /workflows/ranked", () => {
     // Verify workflowNames filter is passed to both endpoints
     expect(mockFetchRunCostsAuth).toHaveBeenCalledWith(
       expect.objectContaining({ orgId: "org-1" }),
-      [DEFAULT_WF_NAME],
+      [DEFAULT_WF_SLUG],
     );
     expect(mockFetchEmailStatsAuth).toHaveBeenCalledWith(
-      [DEFAULT_WF_NAME],
+      [DEFAULT_WF_SLUG],
       expect.objectContaining({ orgId: "org-1" }),
     );
   });
@@ -263,12 +265,12 @@ describe("GET /workflows/ranked", () => {
     const wfOldName = "sales-email-cold-outreach-old";
     mockWorkflowRows.push(
       makeWorkflow({ id: "wf-active" }),
-      makeWorkflow({ id: "wf-old", name: wfOldName, status: "deprecated", upgradedTo: "wf-active" }),
+      makeWorkflow({ id: "wf-old", slug: wfOldName, status: "deprecated", upgradedTo: "wf-active" }),
     );
     mockWorkflowRunRows.push(makeRun("wf-active", "ext-run-active"), makeRun("wf-old", "ext-run-old"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, [wfOldName]: { cost: 200, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 5 } }, [wfOldName]: { transactional: { replied: 5 } } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 }, [wfOldName]: { cost: 200, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { replied: 5 } }, [wfOldName]: { transactional: { replied: 5 } } });
 
     const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(200);
@@ -276,12 +278,12 @@ describe("GET /workflows/ranked", () => {
     // Both dynasty names should be passed to both endpoints
     const costNames = mockFetchRunCostsAuth.mock.calls[0][1] as string[];
     expect(costNames).toHaveLength(2);
-    expect(costNames).toContain(DEFAULT_WF_NAME);
+    expect(costNames).toContain(DEFAULT_WF_SLUG);
     expect(costNames).toContain(wfOldName);
 
     const emailNames = mockFetchEmailStatsAuth.mock.calls[0][0] as string[];
     expect(emailNames).toHaveLength(2);
-    expect(emailNames).toContain(DEFAULT_WF_NAME);
+    expect(emailNames).toContain(DEFAULT_WF_SLUG);
     expect(emailNames).toContain(wfOldName);
   });
 
@@ -289,8 +291,8 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRows.push(makeWorkflow({ id: "wf-a" }));
     mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-1"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 500, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { clicked: 25 }, broadcast: { clicked: 25 } } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 500, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { clicked: 25 }, broadcast: { clicked: 25 } } });
 
     const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, objective: "clicks" }).set(AUTH);
 
@@ -309,7 +311,7 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRows.push(makeWorkflow({ id: "wf-a" }));
     mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-1"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 } });
     mockFetchEmailStatsAuth.mockRejectedValue(
       new Error("email-gateway-service error: GET /stats -> 500 Internal Server Error: boom")
     );
@@ -328,8 +330,8 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRows.push(makeWorkflow({ id: "wf-a" }));
     mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-1"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: {} });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: {} });
 
     const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(200);
@@ -341,12 +343,12 @@ describe("GET /workflows/ranked", () => {
     const wfOldName = "sales-email-cold-outreach-old";
     mockWorkflowRows.push(
       makeWorkflow({ id: "wf-active" }),
-      makeWorkflow({ id: "wf-old", name: wfOldName, status: "deprecated", upgradedTo: "wf-active" }),
+      makeWorkflow({ id: "wf-old", slug: wfOldName, status: "deprecated", upgradedTo: "wf-active" }),
     );
     mockWorkflowRunRows.push(makeRun("wf-active", "ext-run-active"), makeRun("wf-old", "ext-run-old"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, [wfOldName]: { cost: 200, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 5 } }, [wfOldName]: { transactional: { replied: 5 } } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 }, [wfOldName]: { cost: 200, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { replied: 5 } }, [wfOldName]: { transactional: { replied: 5 } } });
 
     const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(200);
@@ -361,13 +363,13 @@ describe("GET /workflows/ranked", () => {
     const nameV1 = "sales-email-cold-outreach-v1";
     mockWorkflowRows.push(
       makeWorkflow({ id: "wf-v3" }),
-      makeWorkflow({ id: "wf-v2", name: nameV2, status: "deprecated", upgradedTo: "wf-v3" }),
-      makeWorkflow({ id: "wf-v1", name: nameV1, status: "deprecated", upgradedTo: "wf-v2" }),
+      makeWorkflow({ id: "wf-v2", slug: nameV2, status: "deprecated", upgradedTo: "wf-v3" }),
+      makeWorkflow({ id: "wf-v1", slug: nameV1, status: "deprecated", upgradedTo: "wf-v2" }),
     );
     mockWorkflowRunRows.push(makeRun("wf-v3", "ext-run-v3"), makeRun("wf-v2", "ext-run-v2"), makeRun("wf-v1", "ext-run-v1"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 50, runCount: 1 }, [nameV2]: { cost: 100, runCount: 1 }, [nameV1]: { cost: 150, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 5 } }, [nameV2]: { transactional: { replied: 5 } }, [nameV1]: { transactional: { replied: 5 } } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 50, runCount: 1 }, [nameV2]: { cost: 100, runCount: 1 }, [nameV1]: { cost: 150, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { replied: 5 } }, [nameV2]: { transactional: { replied: 5 } }, [nameV1]: { transactional: { replied: 5 } } });
 
     const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(200);
@@ -382,9 +384,9 @@ describe("GET /workflows/ranked", () => {
     const nameB = "sales-email-cold-outreach-beta";
     const nameC = "sales-email-cold-outreach-gamma";
     mockWorkflowRows.push(
-      makeWorkflow({ id: "wf-a", name: nameA, signatureName: "alpha" }),
-      makeWorkflow({ id: "wf-b", name: nameB, signatureName: "beta" }),
-      makeWorkflow({ id: "wf-c", name: nameC, signatureName: "gamma" }),
+      makeWorkflow({ id: "wf-a", slug: nameA, signatureName: "alpha" }),
+      makeWorkflow({ id: "wf-b", slug: nameB, signatureName: "beta" }),
+      makeWorkflow({ id: "wf-c", slug: nameC, signatureName: "gamma" }),
     );
     mockWorkflowRunRows.push(makeRun("wf-a", "ext-run-a"), makeRun("wf-b", "ext-run-b"), makeRun("wf-c", "ext-run-c"));
 
@@ -403,16 +405,17 @@ describe("GET /workflows/ranked", () => {
     expect(res.body.results[2].workflow.id).toBe("wf-b");
   });
 
-  it("includes displayName and createdForBrandId in workflow response", async () => {
-    mockWorkflowRows.push(makeWorkflow({ id: "wf-dn", displayName: "sales-email-cold-outreach-jasmine", createdForBrandId: "brand-123" }));
+  it("includes name, dynastyName and createdForBrandId in workflow response", async () => {
+    mockWorkflowRows.push(makeWorkflow({ id: "wf-dn", name: "Sales Email Cold Outreach Jasmine", dynastyName: "Sales Email Cold Outreach Jasmine", createdForBrandId: "brand-123" }));
     mockWorkflowRunRows.push(makeRun("wf-dn", "ext-run-dn"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 5 } } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { replied: 5 } } });
 
     const res = await request.get("/workflows/ranked").query(BASE_QUERY).set(AUTH);
     expect(res.status).toBe(200);
-    expect(res.body.results[0].workflow.displayName).toBe("sales-email-cold-outreach-jasmine");
+    expect(res.body.results[0].workflow.name).toBe("Sales Email Cold Outreach Jasmine");
+    expect(res.body.results[0].workflow.dynastyName).toBe("Sales Email Cold Outreach Jasmine");
     expect(res.body.results[0].workflow.createdForBrandId).toBe("brand-123");
   });
 
@@ -420,11 +423,11 @@ describe("GET /workflows/ranked", () => {
     const costs: Record<string, { cost: number; runCount: number }> = {};
     const emails: Record<string, { transactional?: StatsOverrides }> = {};
     for (let i = 0; i < 5; i++) {
-      const name = `sales-email-cold-outreach-wf${i}`;
-      mockWorkflowRows.push(makeWorkflow({ id: `wf-${i}`, name }));
+      const slug = `sales-email-cold-outreach-wf${i}`;
+      mockWorkflowRows.push(makeWorkflow({ id: `wf-${i}`, slug }));
       mockWorkflowRunRows.push(makeRun(`wf-${i}`, `ext-run-${i}`));
-      costs[name] = { cost: 100, runCount: 1 };
-      emails[name] = { transactional: { replied: 5 } };
+      costs[slug] = { cost: 100, runCount: 1 };
+      emails[slug] = { transactional: { replied: 5 } };
     }
 
     setupCostsMock(costs);
@@ -439,8 +442,8 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRows.push(makeWorkflow({ id: "wf-1", createdForBrandId: "brand-1" }));
     mockWorkflowRunRows.push(makeRun("wf-1", "ext-run-1", "brand-1"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 5 } } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { replied: 5 } } });
 
     const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, brandId: "brand-1" }).set(AUTH);
     expect(res.status).toBe(200);
@@ -450,12 +453,12 @@ describe("GET /workflows/ranked", () => {
   it("returns grouped brands with groupBy=brand (from runs)", async () => {
     mockWorkflowRows.push(
       makeWorkflow({ id: "wf-1", createdForBrandId: "brand-A" }),
-      makeWorkflow({ id: "wf-2", name: "sales-email-cold-outreach-beta", createdForBrandId: "brand-B" }),
+      makeWorkflow({ id: "wf-2", slug: "sales-email-cold-outreach-beta", createdForBrandId: "brand-B" }),
     );
     mockWorkflowRunRows.push(makeRun("wf-1", "ext-run-1", "brand-A"), makeRun("wf-2", "ext-run-2", "brand-B"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, "sales-email-cold-outreach-beta": { cost: 200, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 5 } }, "sales-email-cold-outreach-beta": { transactional: { replied: 5 } } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 }, "sales-email-cold-outreach-beta": { cost: 200, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { replied: 5 } }, "sales-email-cold-outreach-beta": { transactional: { replied: 5 } } });
 
     const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, groupBy: "brand" }).set(AUTH);
     expect(res.status).toBe(200);
@@ -472,12 +475,12 @@ describe("GET /workflows/ranked", () => {
   it("excludes runs without brandId when groupBy=brand", async () => {
     mockWorkflowRows.push(
       makeWorkflow({ id: "wf-branded", createdForBrandId: "brand-X" }),
-      makeWorkflow({ id: "wf-no-brand", name: "sales-email-cold-outreach-nobrand" }),
+      makeWorkflow({ id: "wf-no-brand", slug: "sales-email-cold-outreach-nobrand" }),
     );
     mockWorkflowRunRows.push(makeRun("wf-branded", "ext-run-1", "brand-X"), makeRun("wf-no-brand", "ext-run-2"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, "sales-email-cold-outreach-nobrand": { cost: 200, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { replied: 5 } }, "sales-email-cold-outreach-nobrand": { transactional: { replied: 5 } } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 }, "sales-email-cold-outreach-nobrand": { cost: 200, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { replied: 5 } }, "sales-email-cold-outreach-nobrand": { transactional: { replied: 5 } } });
 
     const res = await request.get("/workflows/ranked").query({ ...BASE_QUERY, groupBy: "brand" }).set(AUTH);
     expect(res.status).toBe(200);
@@ -488,7 +491,7 @@ describe("GET /workflows/ranked", () => {
   it("returns grouped features with groupBy=feature", async () => {
     const nameS1 = "sales-cold-email-outreach-s1";
     const nameS2 = "sales-cold-email-outreach-s2";
-    mockWorkflowRows.push(makeWorkflow({ id: "wf-sales", name: nameS1 }), makeWorkflow({ id: "wf-sales2", name: nameS2 }));
+    mockWorkflowRows.push(makeWorkflow({ id: "wf-sales", slug: nameS1 }), makeWorkflow({ id: "wf-sales2", slug: nameS2 }));
     mockWorkflowRunRows.push(makeRun("wf-sales", "ext-run-s1"), makeRun("wf-sales2", "ext-run-s2"));
 
     setupCostsMock({ [nameS1]: { cost: 100, runCount: 1 }, [nameS2]: { cost: 200, runCount: 1 } });
@@ -521,8 +524,8 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-hero", "ext-run-hero"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { opened: 10, replied: 5 } } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { opened: 10, replied: 5 } } });
 
     const res = await request
       .get("/workflows/best")
@@ -543,8 +546,8 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-no-outcomes", "ext-run-no"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: {} });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: {} });
 
     const res = await request
       .get("/workflows/best")
@@ -572,32 +575,32 @@ describe("GET /workflows/best (hero records)", () => {
     expect(res.status).toBe(401);
   });
 
-  it("includes displayName in hero records", async () => {
-    const wf = makeWorkflow({ id: "wf-dn-hero", displayName: "sales-email-cold-outreach-jasmine" });
+  it("includes workflowName in hero records", async () => {
+    const wf = makeWorkflow({ id: "wf-dn-hero", name: "Sales Email Cold Outreach Jasmine" });
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-dn-hero", "ext-run-dn"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { opened: 10, replied: 5 } } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { opened: 10, replied: 5 } } });
 
     const res = await request
       .get("/workflows/best")
       .set(AUTH);
 
     expect(res.status).toBe(200);
-    expect(res.body.bestCostPerOpen.displayName).toBe("sales-email-cold-outreach-jasmine");
-    expect(res.body.bestCostPerReply.displayName).toBe("sales-email-cold-outreach-jasmine");
+    expect(res.body.bestCostPerOpen.workflowName).toBe("Sales Email Cold Outreach Jasmine");
+    expect(res.body.bestCostPerReply.workflowName).toBe("Sales Email Cold Outreach Jasmine");
   });
 
   it("filters by brandId", async () => {
     const wf1 = makeWorkflow({ id: "wf-b1", createdForBrandId: "brand-target" });
-    const wf2 = makeWorkflow({ id: "wf-b2", name: "sales-email-cold-outreach-other", createdForBrandId: "brand-other" });
+    const wf2 = makeWorkflow({ id: "wf-b2", slug: "sales-email-cold-outreach-other", createdForBrandId: "brand-other" });
     mockWorkflowRows.push(wf1, wf2);
     mockWorkflowRunRows.push(makeRun("wf-b1", "ext-run-b1", "brand-target"), makeRun("wf-b2", "ext-run-b2", "brand-other"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 }, "sales-email-cold-outreach-other": { cost: 200, runCount: 1 } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 }, "sales-email-cold-outreach-other": { cost: 200, runCount: 1 } });
     setupEmailMock({
-      [DEFAULT_WF_NAME]: { transactional: { opened: 10, replied: 5 } },
+      [DEFAULT_WF_SLUG]: { transactional: { opened: 10, replied: 5 } },
       "sales-email-cold-outreach-other": { transactional: { opened: 10, replied: 5 } },
     });
 
@@ -615,8 +618,8 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRows.push(wf1);
     mockWorkflowRunRows.push(makeRun("wf-1", "ext-run-a", "brand-A"), makeRun("wf-1", "ext-run-b", "brand-A"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 600, runCount: 2 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { opened: 20, replied: 10 } } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 600, runCount: 2 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { opened: 20, replied: 10 } } });
 
     const res = await request
       .get("/workflows/best")
@@ -636,8 +639,8 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-no-brand", "ext-run-nb"));
 
-    setupCostsMock({ [DEFAULT_WF_NAME]: { cost: 100, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_NAME]: { transactional: { opened: 10, replied: 5 } } });
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { opened: 10, replied: 5 } } });
 
     const res = await request
       .get("/workflows/best")
@@ -652,8 +655,8 @@ describe("GET /workflows/best (hero records)", () => {
   it("picks the best from multiple workflows", async () => {
     const nameExp = "sales-email-cold-outreach-expensive";
     const nameCheap = "sales-email-cold-outreach-cheap";
-    const wfExpensive = makeWorkflow({ id: "wf-expensive", name: nameExp });
-    const wfCheap = makeWorkflow({ id: "wf-cheap", name: nameCheap });
+    const wfExpensive = makeWorkflow({ id: "wf-expensive", slug: nameExp });
+    const wfCheap = makeWorkflow({ id: "wf-cheap", slug: nameCheap });
     mockWorkflowRows.push(wfExpensive, wfCheap);
     mockWorkflowRunRows.push(makeRun("wf-expensive", "ext-run-1"), makeRun("wf-cheap", "ext-run-2"));
 

--- a/tests/integration/generate-workflow.test.ts
+++ b/tests/integration/generate-workflow.test.ts
@@ -118,7 +118,7 @@ describe("POST /workflows/generate", () => {
     expect(res.body.workflow).toBeDefined();
     expect(res.body.workflow.action).toBe("created");
     expect(res.body.workflow.featureSlug).toBe("cold-email-outreach");
-    expect(res.body.workflow.name).toContain("cold-email-outreach-");
+    expect(res.body.workflow.slug).toContain("cold-email-outreach-");
     expect(res.body.dag).toEqual(VALID_LINEAR_DAG);
     expect(res.body.generatedDescription).toBe("Search leads, generate email, send");
     expect(mockFetchAnthropicKey).toHaveBeenCalledWith({ orgId: "org-1", userId: "user-1", runId: "run-caller-1" });
@@ -263,7 +263,7 @@ describe("POST /workflows/generate", () => {
     expect(res.status).toBe(200);
     expect(res.body.workflow.action).toBe("created");
     expect(res.body.workflow.signatureName).toBe("hormozi-v1");
-    expect(res.body.workflow.name).toBe("cold-email-outreach-hormozi-v1");
+    expect(res.body.workflow.slug).toBe("cold-email-outreach-hormozi-v1");
     // Verify style was passed through to generator
     expect(mockGenerateWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -294,7 +294,7 @@ describe("POST /workflows/generate", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.workflow.signatureName).toBe("my-brand-v1");
-    expect(res.body.workflow.name).toBe("cold-email-outreach-my-brand-v1");
+    expect(res.body.workflow.slug).toBe("cold-email-outreach-my-brand-v1");
   });
 
   it("rejects human style without humanId", async () => {
@@ -342,7 +342,7 @@ describe("POST /workflows/generate", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.workflow.signatureName).not.toContain("-v");
-    expect(res.body.workflow.name).toContain("cold-email-outreach-");
+    expect(res.body.workflow.slug).toContain("cold-email-outreach-");
     // signatureName should be a random word, not a versioned style name
     expect(res.body.workflow.signatureName).toMatch(/^[a-z]+$/);
   });

--- a/tests/integration/public-workflows.test.ts
+++ b/tests/integration/public-workflows.test.ts
@@ -97,14 +97,16 @@ const EMPTY_STATS = {
   replied: 0, bounced: 0, unsubscribed: 0, recipients: 0,
 };
 
-const DEFAULT_WF_NAME = "sales-email-cold-outreach-alpha";
+const DEFAULT_WF_SLUG = "sales-email-cold-outreach-alpha";
 
 function makeWorkflow(overrides: Record<string, unknown> = {}) {
   return {
     id: "wf-" + Math.random().toString(36).slice(2, 10),
     orgId: "org1",
-    name: DEFAULT_WF_NAME,
-    displayName: null,
+    slug: DEFAULT_WF_SLUG,
+    name: "Sales Email Cold Outreach Alpha",
+    dynastyName: "Sales Email Cold Outreach Alpha",
+    version: 1,
     createdForBrandId: null,
     description: null,
     featureSlug: "sales-email-cold-outreach",
@@ -171,10 +173,10 @@ describe("GET /public/workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-pub", "ext-run-1"));
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
+      { workflowName: DEFAULT_WF_SLUG, totalCostInUsdCents: 100, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { replied: 10 } }),
+      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { replied: 10 } }),
     ]);
 
     const res = await request
@@ -194,10 +196,10 @@ describe("GET /public/workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-nodag", "ext-run-1"));
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 50, runCount: 1 },
+      { workflowName: DEFAULT_WF_SLUG, totalCostInUsdCents: 50, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { replied: 5 } }),
+      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { replied: 5 } }),
     ]);
 
     const res = await request
@@ -234,10 +236,10 @@ describe("GET /public/workflows/ranked", () => {
     mockWorkflowRunRows.push(makeRun("wf-sec", "ext-run-1"));
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
+      { workflowName: DEFAULT_WF_SLUG, totalCostInUsdCents: 100, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { replied: 5, sent: 50 } }),
+      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { replied: 5, sent: 50 } }),
     ]);
 
     const res = await request
@@ -269,10 +271,10 @@ describe("GET /public/workflows/ranked", () => {
     );
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 350, runCount: 2 },
+      { workflowName: DEFAULT_WF_SLUG, totalCostInUsdCents: 350, runCount: 2 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { replied: 5 } }),
+      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { replied: 5 } }),
     ]);
 
     const res = await request
@@ -293,10 +295,10 @@ describe("GET /public/workflows/ranked", () => {
     );
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
+      { workflowName: DEFAULT_WF_SLUG, totalCostInUsdCents: 100, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { replied: 10 } }),
+      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { replied: 10 } }),
     ]);
 
     const res = await request
@@ -326,10 +328,10 @@ describe("GET /public/workflows/best", () => {
     mockWorkflowRunRows.push(makeRun("wf-hero-pub", "ext-run-hero"));
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
+      { workflowName: DEFAULT_WF_SLUG, totalCostInUsdCents: 100, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { opened: 10, replied: 5 } }),
+      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { opened: 10, replied: 5 } }),
     ]);
 
     const res = await request
@@ -350,10 +352,10 @@ describe("GET /public/workflows/best", () => {
     mockWorkflowRunRows.push(makeRun("wf-no-out", "ext-run-no"));
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
+      { workflowName: DEFAULT_WF_SLUG, totalCostInUsdCents: 100, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_NAME),
+      makeEmailGroup(DEFAULT_WF_SLUG),
     ]);
 
     const res = await request
@@ -379,7 +381,7 @@ describe("GET /public/workflows/best", () => {
 
     mockFetchRunCostsPublic.mockResolvedValue([]);
     mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { opened: 10 } }),
+      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { opened: 10 } }),
     ]);
 
     await request.get("/public/workflows/best");
@@ -399,10 +401,10 @@ describe("GET /public/workflows/best", () => {
     );
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 600, runCount: 2 },
+      { workflowName: DEFAULT_WF_SLUG, totalCostInUsdCents: 600, runCount: 2 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { opened: 20, replied: 10 } }),
+      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { opened: 20, replied: 10 } }),
     ]);
 
     const res = await request
@@ -421,10 +423,10 @@ describe("GET /public/workflows/best", () => {
     mockWorkflowRunRows.push(makeRun("wf-brand-filter", "ext-run-bz"));
 
     mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowName: DEFAULT_WF_NAME, totalCostInUsdCents: 100, runCount: 1 },
+      { workflowName: DEFAULT_WF_SLUG, totalCostInUsdCents: 100, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_NAME, { transactional: { opened: 10, replied: 5 } }),
+      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { opened: 10, replied: 5 } }),
     ]);
 
     const res = await request

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -125,7 +125,10 @@ describe("POST /workflows/:id/execute", () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "org-1",
+      slug: "test-flow",
       name: "Test Flow",
+      dynastyName: "Test Flow Obsidian",
+      version: 1,
       windmillFlowPath: "f/workflows/org_1/test_flow",
       windmillWorkspace: "prod",
       dag: VALID_LINEAR_DAG,
@@ -147,7 +150,10 @@ describe("POST /workflows/:id/execute", () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "org-1",
+      slug: "test-flow",
       name: "Test Flow",
+      dynastyName: "Test Flow Obsidian",
+      version: 1,
       windmillFlowPath: "f/workflows/org_1/test_flow",
       windmillWorkspace: "prod",
       dag: VALID_LINEAR_DAG,
@@ -163,7 +169,7 @@ describe("POST /workflows/:id/execute", () => {
       orgId: "org-1",
       userId: "user-1",
       taskName: "execute-workflow",
-      workflowName: "Test Flow",
+      workflowName: "test-flow",
       campaignId: "camp-1",
       brandId: "brand-1",
     });
@@ -173,7 +179,10 @@ describe("POST /workflows/:id/execute", () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "org-1",
+      slug: "test-flow",
       name: "Test Flow",
+      dynastyName: "Test Flow Obsidian",
+      version: 1,
       windmillFlowPath: "f/workflows/org_1/test_flow",
       windmillWorkspace: "prod",
       dag: VALID_LINEAR_DAG,
@@ -194,7 +203,10 @@ describe("POST /workflows/:id/execute", () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "deployer-org-different",
+      slug: "test-flow",
       name: "Test Flow",
+      dynastyName: "Test Flow Obsidian",
+      version: 1,
       windmillFlowPath: "f/workflows/org_1/test_flow",
       windmillWorkspace: "prod",
       dag: VALID_LINEAR_DAG,
@@ -214,7 +226,7 @@ describe("POST /workflows/:id/execute", () => {
       orgId: "org-1", // from header
       userId: "user-1",
       taskName: "execute-workflow",
-      workflowName: "Test Flow",
+      workflowName: "test-flow",
       campaignId: "camp-1",
       brandId: "brand-1",
     });
@@ -228,7 +240,10 @@ describe("POST /workflows/:id/execute", () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "org-1",
+      slug: "test-flow",
       name: "Test Flow",
+      dynastyName: "Test Flow Obsidian",
+      version: 1,
       windmillFlowPath: "f/workflows/org_1/test_flow",
       windmillWorkspace: "prod",
       dag: VALID_LINEAR_DAG,
@@ -267,7 +282,10 @@ describe("POST /workflows/:id/execute", () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "org-1",
+      slug: "test-flow",
       name: "Test Flow",
+      dynastyName: "Test Flow Obsidian",
+      version: 1,
       campaignId: "camp-from-wf",
       subrequestId: null,
       windmillFlowPath: "f/workflows/org_1/test_flow",
@@ -306,7 +324,7 @@ describe("POST /workflows/:id/execute", () => {
   });
 });
 
-describe("POST /workflows/by-name/:name/execute", () => {
+describe("POST /workflows/by-slug/:slug/execute", () => {
   beforeEach(() => {
     mockWorkflows.length = 0;
     mockRuns.length = 0;
@@ -316,18 +334,21 @@ describe("POST /workflows/by-name/:name/execute", () => {
     mockCreateRun.mockResolvedValue({ runId: "run-own-456" });
   });
 
-  it("executes a workflow by name (name-only lookup, no org filter)", async () => {
+  it("executes a workflow by slug (slug-only lookup, no org filter)", async () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "deployer-org",
-      name: "newsletter-subscribe",
+      slug: "newsletter-subscribe",
+      name: "Newsletter Subscribe",
+      dynastyName: "Newsletter Subscribe Obsidian",
+      version: 1,
       windmillFlowPath: "f/workflows/org-1/newsletter_subscribe",
       windmillWorkspace: "prod",
       dag: VALID_LINEAR_DAG,
     });
 
     const res = await request
-      .post("/workflows/by-name/newsletter-subscribe/execute")
+      .post("/workflows/by-slug/newsletter-subscribe/execute")
       .set(AUTH)
       .send({ inputs: { email: "test@example.com" } });
 
@@ -342,14 +363,17 @@ describe("POST /workflows/by-name/:name/execute", () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "deployer-org",
-      name: "create-user-flow",
+      slug: "create-user-flow",
+      name: "Create User Flow",
+      dynastyName: "Create User Flow Obsidian",
+      version: 1,
       windmillFlowPath: "f/workflows/org_1/create_user_flow",
       windmillWorkspace: "prod",
       dag: VALID_LINEAR_DAG,
     });
 
     await request
-      .post("/workflows/by-name/create-user-flow/execute")
+      .post("/workflows/by-slug/create-user-flow/execute")
       .set(AUTH)
       .send({ inputs: {} });
 
@@ -369,14 +393,17 @@ describe("POST /workflows/by-name/:name/execute", () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "deployer-org",
-      name: "create-user-flow",
+      slug: "create-user-flow",
+      name: "Create User Flow",
+      dynastyName: "Create User Flow Obsidian",
+      version: 1,
       windmillFlowPath: "f/workflows/org_1/create_user_flow",
       windmillWorkspace: "prod",
       dag: VALID_LINEAR_DAG,
     });
 
     await request
-      .post("/workflows/by-name/create-user-flow/execute")
+      .post("/workflows/by-slug/create-user-flow/execute")
       .set(AUTH)
       .send({ inputs: { email: "user@test.com" } });
 
@@ -391,7 +418,10 @@ describe("POST /workflows/by-name/:name/execute", () => {
     mockWorkflows.push({
       id: "wf-cross",
       orgId: "8c734aed-45ac-4780-a4ee-1fdcbbedeab1",
-      name: "sales-email-cold-outreach-pharaoh",
+      slug: "sales-email-cold-outreach-pharaoh",
+      name: "Sales Email Cold Outreach Pharaoh",
+      dynastyName: "Sales Email Cold Outreach Pharaoh",
+      version: 1,
       windmillFlowPath: "f/workflows/upgradeer/sales_email_cold_outreach_pharaoh",
       windmillWorkspace: "prod",
       dag: VALID_LINEAR_DAG,
@@ -410,7 +440,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
     };
 
     const res = await request
-      .post("/workflows/by-name/sales-email-cold-outreach-pharaoh/execute")
+      .post("/workflows/by-slug/sales-email-cold-outreach-pharaoh/execute")
       .set(CROSS_ORG_AUTH)
       .send({ inputs: {} });
 
@@ -425,14 +455,17 @@ describe("POST /workflows/by-name/:name/execute", () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "deployer-org",
-      name: "simple-flow",
+      slug: "simple-flow",
+      name: "Simple Flow",
+      dynastyName: "Simple Flow Obsidian",
+      version: 1,
       windmillFlowPath: "f/workflows/org_1/simple_flow",
       windmillWorkspace: "prod",
       dag: VALID_LINEAR_DAG,
     });
 
     const res = await request
-      .post("/workflows/by-name/simple-flow/execute")
+      .post("/workflows/by-slug/simple-flow/execute")
       .set(AUTH)
       .send({ inputs: {} }); // no orgId in body
 
@@ -441,9 +474,9 @@ describe("POST /workflows/by-name/:name/execute", () => {
     expect(res.body.orgId).toBe("org-1");
   });
 
-  it("returns 404 for unknown workflow name", async () => {
+  it("returns 404 for unknown workflow slug", async () => {
     const res = await request
-      .post("/workflows/by-name/nonexistent/execute")
+      .post("/workflows/by-slug/nonexistent/execute")
       .set(AUTH)
       .send({});
 
@@ -456,13 +489,19 @@ describe("POST /workflows/by-name/:name/execute", () => {
       [],  // 1. active-only lookup → not found
       [{   // 2. any-status lookup → deprecated workflow
         id: "wf-old",
-        name: "deprecated-flow",
+        slug: "deprecated-flow",
+        name: "Deprecated Flow",
+        dynastyName: "Deprecated Flow Obsidian",
+        version: 1,
         status: "deprecated",
         upgradedTo: "wf-new",
       }],
       [{   // 3. chain follow: replacement is active → execute it
         id: "wf-new",
-        name: "replacement-flow",
+        slug: "replacement-flow",
+        name: "Replacement Flow",
+        dynastyName: "Replacement Flow Obsidian",
+        version: 2,
         status: "active",
         windmillFlowPath: "f/workflows/org_1/replacement_flow",
         windmillWorkspace: "prod",
@@ -471,7 +510,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
     );
 
     const res = await request
-      .post("/workflows/by-name/deprecated-flow/execute")
+      .post("/workflows/by-slug/deprecated-flow/execute")
       .set(AUTH)
       .send({ inputs: {} });
 
@@ -488,19 +527,28 @@ describe("POST /workflows/by-name/:name/execute", () => {
       [],  // 1. active-only lookup → not found
       [{   // 2. any-status lookup → deprecated v1
         id: "wf-v1",
-        name: "old-flow",
+        slug: "old-flow",
+        name: "Old Flow",
+        dynastyName: "Old Flow Obsidian",
+        version: 1,
         status: "deprecated",
         upgradedTo: "wf-v2",
       }],
       [{   // 3. chain hop 1: v2 is also deprecated
         id: "wf-v2",
-        name: "mid-flow",
+        slug: "mid-flow",
+        name: "Mid Flow",
+        dynastyName: "Mid Flow Obsidian",
+        version: 2,
         status: "deprecated",
         upgradedTo: "wf-v3",
       }],
       [{   // 4. chain hop 2: v3 is active → execute it
         id: "wf-v3",
-        name: "current-flow",
+        slug: "current-flow",
+        name: "Current Flow",
+        dynastyName: "Current Flow Obsidian",
+        version: 3,
         status: "active",
         windmillFlowPath: "f/workflows/org_1/current_flow",
         windmillWorkspace: "prod",
@@ -509,7 +557,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
     );
 
     const res = await request
-      .post("/workflows/by-name/old-flow/execute")
+      .post("/workflows/by-slug/old-flow/execute")
       .set(AUTH)
       .send({ inputs: { key: "value" } });
 
@@ -526,21 +574,24 @@ describe("POST /workflows/by-name/:name/execute", () => {
       [],  // 1. active-only lookup → not found
       [{   // 2. any-status lookup → deprecated, no replacement
         id: "wf-dead",
-        name: "dead-flow",
+        slug: "dead-flow",
+        name: "Dead Flow",
+        dynastyName: "Dead Flow Obsidian",
+        version: 1,
         status: "deprecated",
         upgradedTo: null,
       }],
     );
 
     const res = await request
-      .post("/workflows/by-name/dead-flow/execute")
+      .post("/workflows/by-slug/dead-flow/execute")
       .set(AUTH)
       .send({ inputs: {} });
 
     expect(res.status).toBe(410);
     expect(res.body.error).toBe("Workflow has been deprecated");
     expect(res.body.upgradedTo).toBeNull();
-    expect(res.body.upgradedToName).toBeNull();
+    expect(res.body.upgradedToSlug).toBeNull();
   });
 
   it("returns 410 when upgrade chain points to missing workflow", async () => {
@@ -548,18 +599,21 @@ describe("POST /workflows/by-name/:name/execute", () => {
       [],  // 1. active-only lookup → not found
       [{   // 2. any-status lookup → deprecated with upgradedTo
         id: "wf-old",
-        name: "orphan-flow",
+        slug: "orphan-flow",
+        name: "Orphan Flow",
+        dynastyName: "Orphan Flow Obsidian",
+        version: 1,
         status: "deprecated",
         upgradedTo: "wf-missing",
       }],
       [],  // 3. chain follow: replacement not found → dead end
-      [{   // 4. 410 replacement name lookup → not found
+      [{   // 4. 410 replacement slug lookup → not found
         // empty — replacement doesn't exist
       }],
     );
 
     const res = await request
-      .post("/workflows/by-name/orphan-flow/execute")
+      .post("/workflows/by-slug/orphan-flow/execute")
       .set(AUTH)
       .send({ inputs: {} });
 
@@ -568,11 +622,14 @@ describe("POST /workflows/by-name/:name/execute", () => {
     expect(res.body.upgradedTo).toBe("wf-missing");
   });
 
-  it("uses campaignId from header into Windmill flow inputs (by name)", async () => {
+  it("uses campaignId from header into Windmill flow inputs (by slug)", async () => {
     mockWorkflows.push({
       id: "wf-1",
       orgId: "deployer-org",
-      name: "campaign-flow",
+      slug: "campaign-flow",
+      name: "Campaign Flow",
+      dynastyName: "Campaign Flow Obsidian",
+      version: 1,
       campaignId: "camp-on-record",
       createdForBrandId: "brand-on-record",
       subrequestId: null,
@@ -582,7 +639,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
     });
 
     await request
-      .post("/workflows/by-name/campaign-flow/execute")
+      .post("/workflows/by-slug/campaign-flow/execute")
       .set(AUTH) // x-campaign-id: "camp-1", x-brand-id: "brand-1"
       .send({ inputs: {} });
 
@@ -595,9 +652,9 @@ describe("POST /workflows/by-name/:name/execute", () => {
     );
   });
 
-  it("returns 400 when required execution headers are missing (by name)", async () => {
+  it("returns 400 when required execution headers are missing (by slug)", async () => {
     const res = await request
-      .post("/workflows/by-name/some-flow/execute")
+      .post("/workflows/by-slug/some-flow/execute")
       .set({ "x-api-key": "test-api-key", "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-1" })
       .send({ inputs: {} });
 
@@ -611,7 +668,10 @@ describe("POST /workflows/by-name/:name/execute", () => {
       [],  // 1. active-only lookup → not found
       [{   // 2. any-status lookup → deprecated workflow
         id: "wf-old",
-        name: "old-flow",
+        slug: "old-flow",
+        name: "Old Flow",
+        dynastyName: "Old Flow Obsidian",
+        version: 1,
         status: "deprecated",
         campaignId: null,
         subrequestId: null,
@@ -619,7 +679,10 @@ describe("POST /workflows/by-name/:name/execute", () => {
       }],
       [{   // 3. chain follow: replacement is active
         id: "wf-new",
-        name: "new-flow",
+        slug: "new-flow",
+        name: "New Flow",
+        dynastyName: "New Flow Obsidian",
+        version: 2,
         status: "active",
         campaignId: null,
         subrequestId: null,
@@ -630,7 +693,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
     );
 
     const res = await request
-      .post("/workflows/by-name/old-flow/execute")
+      .post("/workflows/by-slug/old-flow/execute")
       .set(AUTH) // x-campaign-id: "camp-1"
       .send({ inputs: { subrequestId: "sub-runtime" } });
 
@@ -641,7 +704,7 @@ describe("POST /workflows/by-name/:name/execute", () => {
 
   it("requires authentication", async () => {
     const res = await request
-      .post("/workflows/by-name/test-flow/execute")
+      .post("/workflows/by-slug/test-flow/execute")
       .set(IDENTITY)
       .send({});
 
@@ -847,7 +910,10 @@ describe("x-feature-slug tracking", () => {
   const WORKFLOW_FIXTURE = {
     id: "wf-feat",
     orgId: "org-1",
-    name: "sales-email-cold-outreach-sequoia",
+    slug: "sales-email-cold-outreach-sequoia",
+    name: "Sales Email Cold Outreach Sequoia",
+    dynastyName: "Sales Email Cold Outreach Sequoia",
+    version: 1,
     campaignId: null,
     subrequestId: null,
     createdForBrandId: null,
@@ -856,11 +922,11 @@ describe("x-feature-slug tracking", () => {
     dag: VALID_LINEAR_DAG,
   };
 
-  it("stores featureSlug from x-feature-slug header in the run (execute by name)", async () => {
+  it("stores featureSlug from x-feature-slug header in the run (execute by slug)", async () => {
     mockWorkflows.push(WORKFLOW_FIXTURE);
 
     const res = await request
-      .post("/workflows/by-name/sales-email-cold-outreach-sequoia/execute")
+      .post("/workflows/by-slug/sales-email-cold-outreach-sequoia/execute")
       .set({ ...AUTH, "x-feature-slug": "sales-email-cold-outreach" })
       .send({ inputs: {} });
 
@@ -884,7 +950,7 @@ describe("x-feature-slug tracking", () => {
     mockWorkflows.push(WORKFLOW_FIXTURE);
 
     const res = await request
-      .post("/workflows/by-name/sales-email-cold-outreach-sequoia/execute")
+      .post("/workflows/by-slug/sales-email-cold-outreach-sequoia/execute")
       .set({ ...AUTH, "x-feature-slug": "from-header" })
       .send({ inputs: { featureSlug: "from-inputs" } });
 
@@ -896,7 +962,7 @@ describe("x-feature-slug tracking", () => {
     mockWorkflows.push(WORKFLOW_FIXTURE);
 
     await request
-      .post("/workflows/by-name/sales-email-cold-outreach-sequoia/execute")
+      .post("/workflows/by-slug/sales-email-cold-outreach-sequoia/execute")
       .set({ ...AUTH, "x-feature-slug": "sales-email-cold-outreach" })
       .send({ inputs: { email: "test@example.com" } });
 

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -103,7 +103,6 @@ describe("POST /workflows", () => {
       .post("/workflows")
       .set(AUTH)
       .send({
-        name: "Test Flow",
         createdForBrandId: "brand-test-001",
         featureSlug: "sales-cold-email-outreach",
         category: "sales",
@@ -113,7 +112,10 @@ describe("POST /workflows", () => {
       });
 
     expect(res.status).toBe(201);
-    expect(res.body.name).toBe("Test Flow");
+    expect(res.body.slug).toBeTruthy();
+    expect(res.body.name).toBeTruthy();
+    expect(res.body.dynastyName).toBeTruthy();
+    expect(res.body.version).toBe(1);
     expect(res.body.orgId).toBe("org-1");
     expect(res.body.featureSlug).toBe("sales-cold-email-outreach");
     expect(res.body.tags).toEqual([]);
@@ -127,7 +129,6 @@ describe("POST /workflows", () => {
       .post("/workflows")
       .set(AUTH)
       .send({
-        name: "Multi-Channel Flow",
         createdForBrandId: "brand-test-001",
         featureSlug: "sales-multi-channel",
         category: "sales",
@@ -146,7 +147,6 @@ describe("POST /workflows", () => {
       .post("/workflows")
       .set(AUTH)
       .send({
-        name: "Bad Flow",
         createdForBrandId: "brand-test-001",
         featureSlug: "sales-bad-flow",
         category: "sales",
@@ -166,7 +166,7 @@ describe("POST /workflows", () => {
       .post("/workflows")
       .set(IDENTITY)
       .send({
-        name: "No Auth",
+        featureSlug: "no-auth-test",
         dag: VALID_LINEAR_DAG,
       });
 
@@ -175,8 +175,8 @@ describe("POST /workflows", () => {
 
   it("validates request body with Zod", async () => {
     const res = await request.post("/workflows").set(AUTH).send({
-      // Missing required fields
-      name: "Incomplete",
+      // Missing required fields (no featureSlug, no dag)
+      description: "Incomplete",
     });
 
     expect(res.status).toBe(400);
@@ -192,7 +192,10 @@ describe("GET /workflows", () => {
     mockDbRows.push({
       id: "wf-1",
       orgId: "org-1",
+      slug: "flow-1",
       name: "Flow 1",
+      dynastyName: "Flow 1",
+      version: 1,
       dag: VALID_LINEAR_DAG,
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -208,7 +211,10 @@ describe("GET /workflows", () => {
     mockDbRows.push({
       id: "wf-1",
       orgId: "org-1",
+      slug: "flow-1",
       name: "Flow 1",
+      dynastyName: "Flow 1",
+      version: 1,
       dag: VALID_LINEAR_DAG,
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -228,7 +234,6 @@ describe("GET /workflows", () => {
       .post("/workflows")
       .set(AUTH)
       .send({
-        name: "Feature Flow",
         createdForBrandId: "brand-test-001",
         featureSlug: "outlet-database-discovery",
         category: "outlets",
@@ -245,7 +250,10 @@ describe("GET /workflows", () => {
     mockDbRows.push({
       id: "wf-feature",
       orgId: "org-1",
-      name: "outlets-database-discovery-sequoia",
+      slug: "outlet-database-discovery-sequoia",
+      name: "Outlet Database Discovery Sequoia",
+      dynastyName: "Outlet Database Discovery Sequoia",
+      version: 1,
       featureSlug: "outlet-database-discovery",
       category: "outlets",
       channel: "database",
@@ -270,8 +278,10 @@ describe("GET /workflows", () => {
     mockDbRows.push({
       id: "wf-1",
       orgId: "org-1",
-      name: "sales-cold-email-outreach-sequoia",
-      displayName: "Sales Flow",
+      slug: "sales-cold-email-outreach-sequoia",
+      name: "Sales Cold Email Outreach Sequoia",
+      dynastyName: "Sales Cold Email Outreach Sequoia",
+      version: 1,
       featureSlug: "sales-cold-email-outreach",
       category: "sales",
       channel: "email",
@@ -388,10 +398,10 @@ describe("PUT /workflows/upgrade", () => {
     expect(wf.featureSlug).toBe("sales-cold-email-outreach");
     expect(wf.signature).toMatch(/^[a-f0-9]{64}$/);
     expect(wf.signatureName).toBeTruthy();
-    expect(wf.name).toBe(`sales-cold-email-outreach-${wf.signatureName}`);
+    expect(wf.slug).toBe(`sales-cold-email-outreach-${wf.signatureName}`);
   });
 
-  it("creates outlets-database-discovery workflow with correct name", async () => {
+  it("creates outlets-database-discovery workflow with correct slug", async () => {
     const res = await request
       .put("/workflows/upgrade")
       .set(AUTH)
@@ -411,10 +421,10 @@ describe("PUT /workflows/upgrade", () => {
     expect(res.status).toBe(200);
     const wf = res.body.workflows[0];
     expect(wf.featureSlug).toBe("outlet-database-discovery");
-    expect(wf.name).toBe(`outlet-database-discovery-${wf.signatureName}`);
+    expect(wf.slug).toBe(`outlet-database-discovery-${wf.signatureName}`);
   });
 
-  it("creates journalists-database-discovery workflow with correct name", async () => {
+  it("creates journalists-database-discovery workflow with correct slug", async () => {
     const res = await request
       .put("/workflows/upgrade")
       .set(AUTH)
@@ -434,7 +444,7 @@ describe("PUT /workflows/upgrade", () => {
     expect(res.status).toBe(200);
     const wf = res.body.workflows[0];
     expect(wf.featureSlug).toBe("journalist-database-discovery");
-    expect(wf.name).toBe(`journalist-database-discovery-${wf.signatureName}`);
+    expect(wf.slug).toBe(`journalist-database-discovery-${wf.signatureName}`);
   });
 
   it("stores orgId from x-org-id header in DB", async () => {
@@ -463,7 +473,10 @@ describe("PUT /workflows/upgrade", () => {
     mockDbRows.push({
       id: "wf-existing",
       orgId: "org-deploy",
-      name: "sales-cold-email-outreach-sequoia",
+      slug: "sales-cold-email-outreach-sequoia",
+      name: "Sales Cold Email Outreach Sequoia",
+      dynastyName: "Sales Cold Email Outreach Sequoia",
+      version: 1,
       signatureName: "sequoia",
       signature: sig,
       featureSlug: "sales-cold-email-outreach",
@@ -782,7 +795,10 @@ describe("GET /workflows/:id/required-providers", () => {
     mockDbRows.push({
       id: "wf-http",
       orgId: "org-1",
+      slug: "http-flow",
       name: "HTTP Flow",
+      dynastyName: "HTTP Flow",
+      version: 1,
       dag: DAG_WITH_HTTP_CALL_CHAIN,
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -819,7 +835,10 @@ describe("GET /workflows/:id/required-providers", () => {
     mockDbRows.push({
       id: "wf-http",
       orgId: "org-1",
+      slug: "http-flow",
       name: "HTTP Flow",
+      dynastyName: "HTTP Flow",
+      version: 1,
       dag: DAG_WITH_HTTP_CALL_CHAIN,
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -848,7 +867,10 @@ describe("GET /workflows/:id/required-providers", () => {
     mockDbRows.push({
       id: "wf-legacy",
       orgId: "org-1",
+      slug: "legacy-flow",
       name: "Legacy Flow",
+      dynastyName: "Legacy Flow",
+      version: 1,
       dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -878,7 +900,10 @@ describe("GET /workflows/:id/required-providers", () => {
     mockDbRows.push({
       id: "wf-http",
       orgId: "org-1",
+      slug: "http-flow",
       name: "HTTP Flow",
+      dynastyName: "HTTP Flow",
+      version: 1,
       dag: DAG_WITH_HTTP_CALL,
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -902,7 +927,10 @@ describe("GET /workflows/:id/required-providers", () => {
     mockDbRows.push({
       id: "wf-http",
       orgId: "org-1",
+      slug: "http-flow",
       name: "HTTP Flow",
+      dynastyName: "HTTP Flow",
+      version: 1,
       dag: DAG_WITH_HTTP_CALL,
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -925,7 +953,10 @@ describe("GET /workflows/:id/required-providers", () => {
     mockDbRows.push({
       id: "wf-http",
       orgId: "org-1",
+      slug: "http-flow",
       name: "HTTP Flow",
+      dynastyName: "HTTP Flow",
+      version: 1,
       dag: DAG_WITH_HTTP_CALL,
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -953,79 +984,20 @@ describe("GET /workflows/:id/required-providers", () => {
   });
 });
 
-describe("PUT /workflows/:id — fork", () => {
+describe("PUT /workflows/:id — metadata update", () => {
   beforeEach(() => {
     mockDbRows.length = 0;
     mockSelectResponses.length = 0;
-  });
-
-  it("forks a workflow when DAG changes (returns 201 with new ID)", async () => {
-    const originalWorkflow = {
-      id: "wf-original",
-      orgId: "org-1",
-      createdForBrandId: "brand-1",
-      humanId: null,
-      campaignId: "camp-1",
-      subrequestId: null,
-      styleName: null,
-      name: "sales-email-cold-outreach-jasmine",
-      displayName: "Jasmine Flow",
-      description: "Original description",
-      category: "sales",
-      channel: "email",
-      audienceType: "cold-outreach",
-      tags: ["email"],
-      signature: "aaa111",
-      signatureName: "jasmine",
-      dag: VALID_LINEAR_DAG,
-      status: "active",
-      upgradedTo: null,
-      forkedFrom: null,
-      windmillFlowPath: "f/workflows/org-1/sales_email_cold_outreach_jasmine",
-      windmillWorkspace: "prod",
-      createdByUserId: "user-1",
-      createdByRunId: "run-1",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-
-    // Queue: 1st select = find existing workflow, 2nd = check conflicting signature, 3rd = get used signatureNames
-    mockSelectResponses.push(
-      [originalWorkflow],  // existing workflow lookup
-      [],                  // no conflicting signature
-      [{ signatureName: "jasmine" }],  // existing signatureNames in org
-    );
-
-    const res = await request
-      .put("/workflows/wf-original")
-      .set(AUTH)
-      .send({
-        dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
-        description: "Forked with new DAG",
-      });
-
-    expect(res.status).toBe(201);
-    expect(res.body.id).not.toBe("wf-original");
-    expect(res.body.forkedFrom).toBe("wf-original");
-    expect(res.body._action).toBe("forked");
-    expect(res.body._forkedFromName).toBe("sales-email-cold-outreach-jasmine");
-    expect(res.body.name).not.toBe("sales-email-cold-outreach-jasmine");
-    expect(res.body.category).toBe("sales");
-    expect(res.body.channel).toBe("email");
-    expect(res.body.audienceType).toBe("cold-outreach");
-    expect(res.body.description).toBe("Forked with new DAG");
-    expect(res.body.status).toBe("active");
-    // displayName uses the new generated name (not the parent's)
-    expect(res.body.displayName).toBe(res.body.name);
-    // Original should still be in mockDbRows unchanged
-    expect(originalWorkflow.status).toBe("active");
   });
 
   it("updates in-place when only metadata changes (no DAG)", async () => {
     mockDbRows.push({
       id: "wf-meta",
       orgId: "org-1",
-      name: "sales-email-cold-outreach-maple",
+      slug: "sales-email-cold-outreach-maple",
+      name: "Sales Email Cold Outreach Maple",
+      dynastyName: "Sales Email Cold Outreach Maple",
+      version: 1,
       description: "Old desc",
       dag: VALID_LINEAR_DAG,
       createdAt: new Date(),
@@ -1042,40 +1014,30 @@ describe("PUT /workflows/:id — fork", () => {
 
     expect(res.status).toBe(200);
     expect(res.body._action).toBe("updated");
-    expect(res.body._forkedFromName).toBeUndefined();
     expect(res.body.description).toBe("Updated description");
     expect(res.body.tags).toEqual(["updated"]);
-    // No forkedFrom — it's the same workflow
-    expect(res.body.forkedFrom).toBeUndefined();
   });
 
-  it("updates in-place when DAG is provided but signature is unchanged", async () => {
-    const { computeDAGSignature } = await import("../../src/lib/dag-signature.js");
-    const sig = computeDAGSignature(VALID_LINEAR_DAG);
-
+  it("rejects DAG changes via PUT (must use upgrade)", async () => {
     mockDbRows.push({
-      id: "wf-same-sig",
+      id: "wf-dag-reject",
       orgId: "org-1",
-      name: "sales-email-cold-outreach-cedar",
-      signature: sig,
+      slug: "sales-email-cold-outreach-pine",
+      name: "Sales Email Cold Outreach Pine",
+      dynastyName: "Sales Email Cold Outreach Pine",
+      version: 1,
       dag: VALID_LINEAR_DAG,
-      windmillFlowPath: "f/workflows/org-1/flow",
       createdAt: new Date(),
       updatedAt: new Date(),
     });
 
     const res = await request
-      .put("/workflows/wf-same-sig")
+      .put("/workflows/wf-dag-reject")
       .set(AUTH)
-      .send({
-        dag: VALID_LINEAR_DAG,
-        description: "Same DAG, new desc",
-      });
+      .send({ dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND });
 
-    expect(res.status).toBe(200);
-    expect(res.body._action).toBe("updated");
-    expect(res.body._forkedFromName).toBeUndefined();
-    expect(res.body.description).toBe("Same DAG, new desc");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("DAG changes are not allowed");
   });
 
   it("returns 404 for non-existent workflow", async () => {
@@ -1086,359 +1048,6 @@ describe("PUT /workflows/:id — fork", () => {
 
     expect(res.status).toBe(404);
     expect(res.body.error).toBe("Workflow not found");
-  });
-
-  it("returns 409 when forked DAG conflicts with existing active workflow", async () => {
-    const { computeDAGSignature } = await import("../../src/lib/dag-signature.js");
-    const conflictingSig = computeDAGSignature(DAG_WITH_TRANSACTIONAL_EMAIL_SEND);
-
-    const originalWorkflow = {
-      id: "wf-src",
-      orgId: "org-1",
-      name: "sales-email-cold-outreach-oak",
-      signature: "different-sig",
-      dag: VALID_LINEAR_DAG,
-      status: "active",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-
-    mockSelectResponses.push(
-      [originalWorkflow],  // existing workflow lookup
-      [{ id: "wf-conflict", name: "sales-email-cold-outreach-birch", signature: conflictingSig, status: "active" }],  // conflicting workflow
-    );
-
-    const res = await request
-      .put("/workflows/wf-src")
-      .set(AUTH)
-      .send({ dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND });
-
-    expect(res.status).toBe(409);
-    expect(res.body.error).toContain("already exists");
-    expect(res.body.existingWorkflowId).toBe("wf-conflict");
-    expect(res.body.existingWorkflowName).toBe("sales-email-cold-outreach-birch");
-  });
-
-  it("forking a fork sets forkedFrom to immediate parent", async () => {
-    const fork1 = {
-      id: "wf-fork1",
-      orgId: "org-1",
-      createdForBrandId: null,
-      humanId: null,
-      campaignId: null,
-      subrequestId: null,
-      styleName: null,
-      name: "sales-email-cold-outreach-birch",
-      displayName: "Birch Flow",
-      description: "First fork",
-      category: "sales",
-      channel: "email",
-      audienceType: "cold-outreach",
-      tags: [],
-      signature: "bbb222",
-      signatureName: "birch",
-      dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
-      status: "active",
-      upgradedTo: null,
-      forkedFrom: "wf-original",
-      windmillFlowPath: "f/workflows/org-1/flow",
-      windmillWorkspace: "prod",
-      createdByUserId: "user-1",
-      createdByRunId: "run-1",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-
-    mockSelectResponses.push(
-      [fork1],             // existing workflow lookup
-      [],                  // no conflicting signature
-      [{ signatureName: "birch" }, { signatureName: "jasmine" }],  // existing signatureNames
-    );
-
-    const res = await request
-      .put("/workflows/wf-fork1")
-      .set(AUTH)
-      .send({ dag: VALID_LINEAR_DAG });
-
-    expect(res.status).toBe(201);
-    expect(res.body.forkedFrom).toBe("wf-fork1"); // immediate parent, not wf-original
-  });
-
-  it("inherits metadata from parent workflow", async () => {
-    const parent = {
-      id: "wf-parent",
-      orgId: "org-1",
-      createdForBrandId: "brand-xyz",
-      humanId: "human-abc",
-      campaignId: "camp-123",
-      subrequestId: "sub-456",
-      styleName: "hormozi",
-      name: "sales-email-cold-outreach-sequoia",
-      displayName: "Sequoia Flow",
-      description: "Parent description",
-      category: "sales",
-      channel: "email",
-      audienceType: "cold-outreach",
-      tags: ["inherited"],
-      signature: "ccc333",
-      signatureName: "sequoia",
-      dag: VALID_LINEAR_DAG,
-      status: "active",
-      upgradedTo: null,
-      forkedFrom: null,
-      windmillFlowPath: "f/workflows/org-1/flow",
-      windmillWorkspace: "prod",
-      createdByUserId: "user-1",
-      createdByRunId: "run-1",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-
-    mockSelectResponses.push(
-      [parent],
-      [],
-      [{ signatureName: "sequoia" }],
-    );
-
-    const res = await request
-      .put("/workflows/wf-parent")
-      .set(AUTH)
-      .send({ dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND });
-
-    expect(res.status).toBe(201);
-    expect(res.body.createdForBrandId).toBe("brand-xyz");
-    expect(res.body.category).toBe("sales");
-    expect(res.body.channel).toBe("email");
-    expect(res.body.audienceType).toBe("cold-outreach");
-    expect(res.body.tags).toEqual(["inherited"]);
-  });
-
-  it("forks successfully when existing workflow has null description", async () => {
-    const originalWorkflow = {
-      id: "wf-null-desc",
-      orgId: "org-1",
-      createdForBrandId: null,
-      humanId: null,
-      campaignId: null,
-      subrequestId: null,
-      styleName: null,
-      name: "sales-email-cold-outreach-cedar",
-      displayName: "Cedar Flow",
-      description: null,
-      category: "sales",
-      channel: "email",
-      audienceType: "cold-outreach",
-      tags: [],
-      signature: "ccc333",
-      signatureName: "cedar",
-      dag: VALID_LINEAR_DAG,
-      status: "active",
-      upgradedTo: null,
-      forkedFrom: null,
-      windmillFlowPath: "f/workflows/org-1/sales_email_cold_outreach_cedar",
-      windmillWorkspace: "prod",
-      createdByUserId: "user-1",
-      createdByRunId: "run-1",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-
-    mockSelectResponses.push(
-      [originalWorkflow],
-      [],
-      [{ signatureName: "cedar" }],
-    );
-
-    const res = await request
-      .put("/workflows/wf-null-desc")
-      .set(AUTH)
-      .send({ dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND });
-
-    expect(res.status).toBe(201);
-    expect(res.body.forkedFrom).toBe("wf-null-desc");
-  });
-
-  it("forked workflow displayName uses new name, not parent displayName", async () => {
-    const originalWorkflow = {
-      id: "wf-display",
-      orgId: "org-1",
-      createdForBrandId: "brand-1",
-      humanId: null,
-      campaignId: null,
-      subrequestId: null,
-      styleName: null,
-      name: "sales-email-cold-outreach-jasmine",
-      displayName: "sales-email-cold-outreach-jasmine",
-      description: "Original",
-      category: "sales",
-      channel: "email",
-      audienceType: "cold-outreach",
-      tags: [],
-      signature: "old-sig-111",
-      signatureName: "jasmine",
-      dag: VALID_LINEAR_DAG,
-      status: "active",
-      upgradedTo: null,
-      forkedFrom: null,
-      windmillFlowPath: "f/workflows/org-1/sales_email_cold_outreach_jasmine",
-      windmillWorkspace: "prod",
-      createdByUserId: "user-1",
-      createdByRunId: "run-1",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-
-    mockSelectResponses.push(
-      [originalWorkflow],
-      [],
-      [{ signatureName: "jasmine" }],
-    );
-
-    const res = await request
-      .put("/workflows/wf-display")
-      .set(AUTH)
-      .send({ dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND });
-
-    expect(res.status).toBe(201);
-    // The new displayName must match the new name (with new signatureName), NOT the parent's
-    expect(res.body.displayName).toBe(res.body.name);
-    expect(res.body.displayName).not.toBe("sales-email-cold-outreach-jasmine");
-    expect(res.body.signatureName).not.toBe("jasmine");
-  });
-
-  it("fork avoids signatureNames used by other orgs (global uniqueness)", async () => {
-    const { computeDAGSignature } = await import("../../src/lib/dag-signature.js");
-    const { pickSignatureName } = await import("../../src/lib/signature-words.js");
-
-    const newDag = DAG_WITH_TRANSACTIONAL_EMAIL_SEND;
-    const newSig = computeDAGSignature(newDag);
-
-    // Determine what signatureName pickSignatureName would pick if no names were used
-    const firstPick = pickSignatureName(newSig, new Set());
-
-    const originalWorkflow = {
-      id: "wf-global-test",
-      orgId: "org-1",
-      createdForBrandId: null,
-      humanId: null,
-      campaignId: null,
-      subrequestId: null,
-      styleName: null,
-      name: "sales-email-cold-outreach-cedar",
-      displayName: "Cedar Flow",
-      description: "Original",
-      category: "sales",
-      channel: "email",
-      audienceType: "cold-outreach",
-      tags: [],
-      signature: "old-sig-global",
-      signatureName: "cedar",
-      dag: VALID_LINEAR_DAG,
-      status: "active",
-      upgradedTo: null,
-      forkedFrom: null,
-      windmillFlowPath: "f/workflows/org-1/flow",
-      windmillWorkspace: "prod",
-      createdByUserId: "user-1",
-      createdByRunId: "run-1",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-
-    // Mock: the signatureNames query returns the first-pick name as already used
-    // (simulating another org already having that signatureName globally)
-    mockSelectResponses.push(
-      [originalWorkflow],  // existing workflow lookup
-      [],                  // no conflicting signature
-      [{ signatureName: "cedar" }, { signatureName: firstPick }],  // globally used signatureNames
-    );
-
-    const res = await request
-      .put("/workflows/wf-global-test")
-      .set(AUTH)
-      .send({ dag: newDag });
-
-    expect(res.status).toBe(201);
-    // Must NOT use the firstPick since it's globally taken
-    expect(res.body.signatureName).not.toBe(firstPick);
-    expect(res.body.signatureName).not.toBe("cedar");
-  });
-
-  it("fork avoids signatureNames used by deprecated workflows", async () => {
-    const { computeDAGSignature } = await import("../../src/lib/dag-signature.js");
-    const { pickSignatureName } = await import("../../src/lib/signature-words.js");
-
-    const newDag = DAG_WITH_TRANSACTIONAL_EMAIL_SEND;
-    const newSig = computeDAGSignature(newDag);
-
-    // Determine what signatureName pickSignatureName would pick if no names were used
-    const firstPick = pickSignatureName(newSig, new Set());
-
-    const originalWorkflow = {
-      id: "wf-deprecated-test",
-      orgId: "org-1",
-      createdForBrandId: null,
-      humanId: null,
-      campaignId: null,
-      subrequestId: null,
-      styleName: null,
-      name: `sales-email-cold-outreach-aldebaran`,
-      displayName: `sales-email-cold-outreach-${firstPick}`,
-      description: "Original",
-      category: "sales",
-      channel: "email",
-      audienceType: "cold-outreach",
-      tags: [],
-      signature: "old-sig-deprecated",
-      signatureName: "aldebaran",
-      dag: VALID_LINEAR_DAG,
-      status: "active",
-      upgradedTo: null,
-      forkedFrom: null,
-      windmillFlowPath: "f/workflows/org-1/flow",
-      windmillWorkspace: "prod",
-      createdByUserId: "user-1",
-      createdByRunId: "run-1",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-
-    // Mock: the signatureNames query includes a DEPRECATED workflow using the firstPick name
-    // This simulates the bug where a deprecated workflow's signatureName was recycled
-    mockSelectResponses.push(
-      [originalWorkflow],  // existing workflow lookup
-      [],                  // no conflicting signature
-      [{ signatureName: "aldebaran" }, { signatureName: firstPick }],  // firstPick is taken (by deprecated wf)
-    );
-
-    const res = await request
-      .put("/workflows/wf-deprecated-test")
-      .set(AUTH)
-      .send({ dag: newDag });
-
-    expect(res.status).toBe(201);
-    // Must NOT reuse the firstPick even though the workflow using it is deprecated
-    expect(res.body.signatureName).not.toBe(firstPick);
-    expect(res.body.signatureName).not.toBe("aldebaran");
-  });
-
-  it("rejects invalid DAG on fork", async () => {
-    mockDbRows.push({
-      id: "wf-bad",
-      orgId: "org-1",
-      name: "sales-email-cold-outreach-pine",
-      dag: VALID_LINEAR_DAG,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
-
-    const res = await request
-      .put("/workflows/wf-bad")
-      .set(AUTH)
-      .send({ dag: DAG_WITH_UNKNOWN_TYPE });
-
-    expect(res.status).toBe(400);
-    expect(res.body.error).toBe("Invalid DAG");
   });
 });
 
@@ -1451,7 +1060,10 @@ describe("POST /workflows/:id/validate", () => {
     mockDbRows.push({
       id: "wf-1",
       orgId: "org-1",
+      slug: "flow-1",
       name: "Flow 1",
+      dynastyName: "Flow 1",
+      version: 1,
       dag: VALID_LINEAR_DAG,
       createdAt: new Date(),
       updatedAt: new Date(),

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -163,12 +163,12 @@ describe("Execute endpoint rate limiting", () => {
     expect(res.status).toBe(201);
   });
 
-  it("rate limits by-name execute endpoint too", async () => {
+  it("rate limits by-slug execute endpoint too", async () => {
     const promises = [];
     for (let i = 0; i < 61; i++) {
       promises.push(
         request
-          .post("/workflows/by-name/Rate Test Flow/execute")
+          .post("/workflows/by-slug/rate-test-flow/execute")
           .set(AUTH)
           .send({ inputs: {} })
       );

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -85,7 +85,11 @@ describe("validateAndUpgradeWorkflows", () => {
   const VALID_WORKFLOW = {
     id: "wf-1",
     orgId: "org-1",
-    name: "sales-email-cold-outreach-Sequoia",
+    slug: "sales-email-cold-outreach-Sequoia",
+    name: "Sales Cold Outreach Sequoia",
+    dynastyName: "Sales Cold Outreach Sequoia",
+    version: 1,
+    featureSlug: "sales-email-cold-outreach",
     category: "sales",
     channel: "email",
     audienceType: "cold-outreach",
@@ -111,7 +115,6 @@ describe("validateAndUpgradeWorkflows", () => {
     campaignId: null,
     subrequestId: null,
     styleName: null,
-    displayName: null,
     upgradedTo: null,
     createdByUserId: null,
     createdByRunId: null,
@@ -122,7 +125,9 @@ describe("validateAndUpgradeWorkflows", () => {
   const BROKEN_WORKFLOW = {
     ...VALID_WORKFLOW,
     id: "wf-2",
-    name: "sales-email-cold-outreach-Broken",
+    slug: "sales-email-cold-outreach-Broken",
+    name: "Sales Cold Outreach Broken",
+    dynastyName: "Sales Cold Outreach Broken",
     signatureName: "Broken",
     dag: {
       nodes: [
@@ -274,7 +279,7 @@ describe("validateAndUpgradeWorkflows", () => {
     expect(mockUpdateFlow).toHaveBeenCalledWith(
       "f/workflows/org-1/flow", // exact path from DB, not recalculated
       expect.objectContaining({
-        summary: VALID_WORKFLOW.name,
+        summary: VALID_WORKFLOW.slug,
         value: expect.any(Object),
         schema: expect.any(Object),
       }),
@@ -346,7 +351,7 @@ describe("validateAndUpgradeWorkflows", () => {
     expect(mockCreatePlatformRun).toHaveBeenCalledWith({
       serviceName: "workflow",
       taskName: "startup-upgrade",
-      workflowName: "sales-email-cold-outreach-Broken",
+      workflowName: "sales-email-cold-outreach-Broken",  // uses wf.slug
     });
 
     // Should have called upgradeWorkflow with the platform key and no identity
@@ -359,13 +364,14 @@ describe("validateAndUpgradeWorkflows", () => {
       expect.objectContaining({ category: "sales" }),
     );
 
-    // Should have inserted a new workflow with a NEW name (using new signatureName)
+    // Should have inserted a new workflow with a NEW slug (versioned)
     expect(dbInserts.length).toBe(1);
     expect(dbInserts[0].status).toBe("active");
-    expect(dbInserts[0].name).toMatch(/^sales-email-cold-outreach-/);
-    expect(dbInserts[0].name).not.toBe(BROKEN_WORKFLOW.name); // name must change with new signature
-    // displayName stays as the ancestor's name (stable display identity)
-    expect(dbInserts[0].displayName).toBe(BROKEN_WORKFLOW.displayName ?? BROKEN_WORKFLOW.name);
+    expect(dbInserts[0].slug).toMatch(/^sales-email-cold-outreach-/);
+    expect(dbInserts[0].slug).not.toBe(BROKEN_WORKFLOW.slug); // slug must change with new version
+    // name is the human-readable display name (dynasty name + version suffix)
+    expect(dbInserts[0].name).toMatch(/^Sales Cold Outreach Broken/);
+    expect(dbInserts[0].dynastyName).toBe(BROKEN_WORKFLOW.dynastyName);
     expect(dbInserts[0].createdByUserId).toBe("workflow-service");
     expect(dbInserts[0].createdByRunId).toBe("platform-run-123");
 
@@ -398,7 +404,9 @@ describe("validateAndUpgradeWorkflows", () => {
     const FIELD_ISSUES_WORKFLOW = {
       ...VALID_WORKFLOW,
       id: "wf-field",
-      name: "sales-email-cold-outreach-FieldIssue",
+      slug: "sales-email-cold-outreach-FieldIssue",
+      name: "Sales Cold Outreach FieldIssue",
+      dynastyName: "Sales Cold Outreach FieldIssue",
       signatureName: "FieldIssue",
       dag: {
         nodes: [
@@ -496,7 +504,9 @@ describe("validateAndUpgradeWorkflows", () => {
     const WARNING_ONLY_WORKFLOW = {
       ...VALID_WORKFLOW,
       id: "wf-warning",
-      name: "sales-email-cold-outreach-WarningOnly",
+      slug: "sales-email-cold-outreach-WarningOnly",
+      name: "Sales Cold Outreach WarningOnly",
+      dynastyName: "Sales Cold Outreach WarningOnly",
       signatureName: "WarningOnly",
       dag: {
         nodes: [
@@ -773,14 +783,18 @@ describe("validateAndUpgradeWorkflows", () => {
     const BROKEN_A = {
       ...BROKEN_WORKFLOW,
       id: "wf-dup-a",
-      name: "sales-email-cold-outreach-DupA",
+      slug: "sales-email-cold-outreach-DupA",
+      name: "Sales Cold Outreach DupA",
+      dynastyName: "Sales Cold Outreach DupA",
       signatureName: "DupA",
       signature: "old-sig-a",
     };
     const BROKEN_B = {
       ...BROKEN_WORKFLOW,
       id: "wf-dup-b",
-      name: "sales-email-cold-outreach-DupB",
+      slug: "sales-email-cold-outreach-DupB",
+      name: "Sales Cold Outreach DupB",
+      dynastyName: "Sales Cold Outreach DupB",
       signatureName: "DupB",
       signature: "old-sig-b",
     };
@@ -857,13 +871,17 @@ describe("validateAndUpgradeWorkflows", () => {
     const DORMANT_BROKEN = {
       ...BROKEN_WORKFLOW,
       id: "wf-dormant",
-      name: "sales-email-cold-outreach-Dormant",
+      slug: "sales-email-cold-outreach-Dormant",
+      name: "Sales Cold Outreach Dormant",
+      dynastyName: "Sales Cold Outreach Dormant",
       signatureName: "Dormant",
     };
     const ACTIVE_BROKEN = {
       ...BROKEN_WORKFLOW,
       id: "wf-active",
-      name: "sales-email-cold-outreach-Active",
+      slug: "sales-email-cold-outreach-Active",
+      name: "Sales Cold Outreach Active",
+      dynastyName: "Sales Cold Outreach Active",
       signatureName: "Active",
     };
 


### PR DESCRIPTION
## Summary

- **Column renames**: `name` → `slug`, `displayName` → `name`, `workflowName` → `workflowSlug` (in runs)
- **New columns**: `dynastyName` (stable lineage name), `version` (integer, auto-incremented on upgrade)
- **Route rename**: `/workflows/by-name/:name/execute` → `/workflows/by-slug/:slug/execute`
- **Metadata-only PATCH**: `PUT /workflows/:id` now rejects DAG changes (structural changes go through `PUT /workflows/upgrade`)
- **Global matching**: Upgrades match by `featureSlug` globally, not per-org
- **Features-service client**: Resolves `feature_dynasty_name` / `feature_dynasty_slug` with fallback
- **Migration script**: `migrations/001_dynasty_naming.sql` for column renames, backfill, and indexes
- **Documentation**: Comprehensive naming/versioning spec in `CLAUDE.md`

## Test plan

- [x] All 476 tests pass (33 test files)
- [x] TypeScript compiles with zero errors
- [x] OpenAPI spec regenerated
- [ ] Run migration on staging DB before deploying
- [ ] Verify features-service fallback works (endpoint not yet created)
- [ ] Coordinate with clients using `/by-name/` route to switch to `/by-slug/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)