### PR TITLE
refactor: rename x-workflow-name to x-workflow-slug

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -825,10 +825,10 @@
             "nullable": true,
             "description": "Feature slug from features-service. Used for per-feature analytics."
           },
-          "workflowName": {
+          "workflowSlug": {
             "type": "string",
             "nullable": true,
-            "description": "Name of the workflow that was executed."
+            "description": "Slug of the workflow that was executed. Use this to re-execute via /workflows/by-slug/{slug}/execute."
           },
           "subrequestId": {
             "type": "string",
@@ -912,7 +912,7 @@
           "campaignId",
           "brandId",
           "featureSlug",
-          "workflowName",
+          "workflowSlug",
           "subrequestId",
           "userId",
           "runId",
@@ -1316,12 +1316,21 @@
             "type": "string",
             "format": "uuid"
           },
-          "name": {
-            "type": "string"
-          },
-          "displayName": {
+          "slug": {
             "type": "string",
-            "nullable": true
+            "description": "Unique technical identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable display name."
+          },
+          "dynastyName": {
+            "type": "string",
+            "description": "Stable lineage name (constant across versions)."
+          },
+          "version": {
+            "type": "integer",
+            "description": "Version number within the dynasty."
           },
           "createdForBrandId": {
             "type": "string",
@@ -1340,8 +1349,10 @@
         },
         "required": [
           "id",
+          "slug",
           "name",
-          "displayName",
+          "dynastyName",
+          "version",
           "createdForBrandId",
           "featureSlug",
           "signature",
@@ -1517,14 +1528,13 @@
             "format": "uuid",
             "description": "ID of the workflow holding the record."
           },
+          "workflowSlug": {
+            "type": "string",
+            "description": "Unique technical identifier of the workflow."
+          },
           "workflowName": {
             "type": "string",
-            "description": "Name of the workflow."
-          },
-          "displayName": {
-            "type": "string",
-            "nullable": true,
-            "description": "Stable display name of the workflow family."
+            "description": "Human-readable display name of the workflow."
           },
           "createdForBrandId": {
             "type": "string",
@@ -1538,8 +1548,8 @@
         },
         "required": [
           "workflowId",
+          "workflowSlug",
           "workflowName",
-          "displayName",
           "createdForBrandId",
           "value"
         ],
@@ -1606,7 +1616,7 @@
           "results"
         ]
       },
-      "ExecuteByNameRequest": {
+      "ExecuteBySlugRequest": {
         "type": "object",
         "properties": {
           "inputs": {
@@ -1717,11 +1727,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -1942,11 +1952,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -2059,11 +2069,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -2174,11 +2184,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -2308,11 +2318,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -2423,11 +2433,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -2549,11 +2559,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -2655,11 +2665,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name. Required on execute endpoints — propagated to all downstream http.call nodes."
+              "description": "Workflow slug. Required on execute endpoints — propagated to all downstream http.call nodes."
             },
             "required": true,
-            "description": "Workflow name. Required on execute endpoints — propagated to all downstream http.call nodes.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug. Required on execute endpoints — propagated to all downstream http.call nodes.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -2772,11 +2782,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -2879,11 +2889,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -3029,11 +3039,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -3146,11 +3156,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -3181,7 +3191,7 @@
     "/workflows/upgrade": {
       "put": {
         "summary": "Upgrade (upsert) workflows by DAG signature",
-        "description": "Idempotent: creates new workflows or updates existing ones matched by (orgId + DAG signature). The workflow name is auto-generated as {featureSlug}-{signatureName}. signatureName is a human-readable word auto-assigned to each unique DAG. After deploying, execute workflows via POST /workflows/by-slug/{slug}/execute.",
+        "description": "Idempotent: creates new workflows or updates existing ones matched by featureSlug. If the DAG signature is unchanged, updates metadata in-place. If the DAG signature changed, deprecates the old workflow and creates a new version. The workflow slug is auto-generated as {featureDynastySlug}-{signatureName}[-v{N}]. signatureName is a poetic word auto-assigned once per dynasty. After deploying, execute workflows via POST /workflows/by-slug/{slug}/execute.",
         "tags": [
           "Workflows"
         ],
@@ -3244,11 +3254,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -3362,11 +3372,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -3551,11 +3561,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -3698,11 +3708,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name for tracking. Optional on non-execute endpoints."
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
             },
             "required": false,
-            "description": "Workflow name for tracking. Optional on non-execute endpoints.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -3980,11 +3990,11 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name. Required on execute endpoints — propagated to all downstream http.call nodes."
+              "description": "Workflow slug. Required on execute endpoints — propagated to all downstream http.call nodes."
             },
             "required": true,
-            "description": "Workflow name. Required on execute endpoints — propagated to all downstream http.call nodes.",
-            "name": "x-workflow-name",
+            "description": "Workflow slug. Required on execute endpoints — propagated to all downstream http.call nodes.",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -4003,7 +4013,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ExecuteByNameRequest"
+                "$ref": "#/components/schemas/ExecuteBySlugRequest"
               }
             }
           }

--- a/src/lib/dag-to-openflow.ts
+++ b/src/lib/dag-to-openflow.ts
@@ -74,7 +74,7 @@ export function dagToOpenFlow(dag: DAG, name: string): OpenFlow {
     serviceEnvs: { type: "object", description: "Service URLs and API keys injected by workflow-service" },
     campaignId: { type: "string", description: "Campaign identifier (auto-injected)" },
     brandId: { type: "string", description: "Brand identifier (auto-injected)" },
-    workflowName: { type: "string", description: "Workflow name (auto-injected)" },
+    workflowSlug: { type: "string", description: "Workflow slug (auto-injected)" },
     featureSlug: { type: "string", description: "Feature slug from features-service (auto-injected)" },
   };
   for (const node of dag.nodes) {
@@ -405,7 +405,7 @@ function nodeToModule(node: DAGNode, dag: DAG): FlowModule | null {
     serviceEnvs: "flow_input.serviceEnvs",
     campaignId: "flow_input.campaignId",
     brandId: "flow_input.brandId",
-    workflowName: "flow_input.workflowName",
+    workflowSlug: "flow_input.workflowSlug",
     featureSlug: "flow_input.featureSlug",
   };
   for (const [key, expr] of Object.entries(autoInjects)) {
@@ -452,7 +452,7 @@ function buildFailureModule(node: DAGNode): FlowModule | null {
     serviceEnvs: "flow_input.serviceEnvs",
     campaignId: "flow_input.campaignId",
     brandId: "flow_input.brandId",
-    workflowName: "flow_input.workflowName",
+    workflowSlug: "flow_input.workflowSlug",
     featureSlug: "flow_input.featureSlug",
   };
   for (const [key, expr] of Object.entries(failureAutoInjects)) {

--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -236,7 +236,7 @@ When using content-generation service (\`POST /generate\`):
   - \`"body.variables.clientCompanyOverview": "$ref:brand-profile.output.profile.companyOverview"\`
   - \`"body.variables.clientValueProposition": "$ref:brand-profile.output.profile.valueProposition"\`
   - \`"body.variables.clientTargetAudience": "$ref:brand-profile.output.profile.targetAudience"\`
-- Include tracking fields: \`body.brandId\`, \`body.campaignId\`, \`body.leadId\`, \`body.workflowName\`, \`body.apolloEnrichmentId\`
+- Include tracking fields: \`body.brandId\`, \`body.campaignId\`, \`body.leadId\`, \`body.workflowSlug\`, \`body.apolloEnrichmentId\`
 - Response contains \`subject\` (string) and \`sequence\` (array of { step, bodyHtml, bodyText, daysSinceLastStep })
 
 When sending via email-gateway (\`POST /send\` with \`type: "broadcast"\`):
@@ -305,7 +305,7 @@ Campaign service orchestrates workflow execution with budget constraints. Key co
         "body.brandId": "$ref:start-run.output.brandId",
         "body.campaignId": "$ref:flow_input.campaignId",
         "body.leadId": "$ref:fetch-lead.output.lead.leadId",
-        "body.workflowName": "$ref:start-run.output.workflowName",
+        "body.workflowSlug": "$ref:start-run.output.workflowSlug",
         "body.apolloEnrichmentId": "$ref:fetch-lead.output.lead.externalId",
         "body.variables.leadEmail": "$ref:fetch-lead.output.lead.data.email",
         "body.variables.leadFirstName": "$ref:fetch-lead.output.lead.data.firstName",
@@ -331,7 +331,7 @@ Campaign service orchestrates workflow execution with budget constraints. Key co
         "body.leadId": "$ref:fetch-lead.output.lead.leadId",
         "body.brandId": "$ref:start-run.output.brandId",
         "body.campaignId": "$ref:flow_input.campaignId",
-        "body.workflowName": "$ref:start-run.output.workflowName",
+        "body.workflowSlug": "$ref:start-run.output.workflowSlug",
         "body.recipientFirstName": "$ref:fetch-lead.output.lead.data.firstName",
         "body.recipientLastName": "$ref:fetch-lead.output.lead.data.lastName",
         "body.recipientCompany": "$ref:fetch-lead.output.lead.data.organizationName"

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -23,7 +23,7 @@ export interface CreateRunResult {
  * @param opts.orgId - Organization ID
  * @param opts.userId - User ID
  * @param opts.taskName - Name of the task being executed
- * @param opts.workflowName - Optional workflow name for tracking
+ * @param opts.workflowSlug - Optional workflow name for tracking
  * @returns The newly created run's ID
  */
 export async function createRun(opts: {
@@ -31,7 +31,7 @@ export async function createRun(opts: {
   orgId: string;
   userId: string;
   taskName: string;
-  workflowName?: string;
+  workflowSlug?: string;
   campaignId?: string;
   brandId?: string;
 }): Promise<CreateRunResult> {
@@ -41,7 +41,7 @@ export async function createRun(opts: {
     serviceName: "workflow",
     taskName: opts.taskName,
   };
-  if (opts.workflowName) body.workflowName = opts.workflowName;
+  if (opts.workflowSlug) body.workflowSlug = opts.workflowSlug;
   if (opts.campaignId) body.campaignId = opts.campaignId;
   if (opts.brandId) body.brandId = opts.brandId;
 
@@ -54,7 +54,7 @@ export async function createRun(opts: {
   };
   if (opts.campaignId) headers["x-campaign-id"] = opts.campaignId;
   if (opts.brandId) headers["x-brand-id"] = opts.brandId;
-  if (opts.workflowName) headers["x-workflow-name"] = opts.workflowName;
+  if (opts.workflowSlug) headers["x-workflow-slug"] = opts.workflowSlug;
 
   const res = await fetch(`${baseUrl}/v1/runs`, {
     method: "POST",
@@ -77,7 +77,7 @@ export async function createRun(opts: {
 export async function createPlatformRun(opts: {
   serviceName: string;
   taskName: string;
-  workflowName?: string;
+  workflowSlug?: string;
 }): Promise<CreateRunResult> {
   const { baseUrl, apiKey } = getRunsServiceConfig();
 
@@ -85,8 +85,8 @@ export async function createPlatformRun(opts: {
     serviceName: opts.serviceName,
     taskName: opts.taskName,
   };
-  if (opts.workflowName) {
-    body.workflowName = opts.workflowName;
+  if (opts.workflowSlug) {
+    body.workflowSlug = opts.workflowSlug;
   }
 
   const res = await fetch(`${baseUrl}/v1/platform-runs`, {

--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -219,7 +219,7 @@ async function attemptUpgrade(
     const run = await createPlatformRun({
       serviceName: "workflow",
       taskName: "startup-upgrade",
-      workflowName: wf.slug,
+      workflowSlug: wf.slug,
     });
     platformRunId = run.runId;
   } catch (err) {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -38,10 +38,10 @@ export function requireIdentity(
   if (brandId) res.locals.brandId = brandId;
 
   const campaignId = req.headers["x-campaign-id"] as string | undefined;
-  const workflowName = req.headers["x-workflow-name"] as string | undefined;
+  const workflowSlug = req.headers["x-workflow-slug"] as string | undefined;
   const featureSlug = req.headers["x-feature-slug"] as string | undefined;
   if (campaignId) res.locals.campaignId = campaignId;
-  if (workflowName) res.locals.workflowName = workflowName;
+  if (workflowSlug) res.locals.workflowSlug = workflowSlug;
   if (featureSlug) res.locals.featureSlug = featureSlug;
 
   next();
@@ -68,7 +68,7 @@ const REQUIRED_EXECUTION_HEADERS = [
   "x-run-id",
   "x-brand-id",
   "x-campaign-id",
-  "x-workflow-name",
+  "x-workflow-slug",
   "x-feature-slug",
 ] as const;
 

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -135,7 +135,7 @@ router.post(
           orgId,
           userId,
           taskName: "execute-workflow",
-          workflowName: workflow.slug,
+          workflowSlug: workflow.slug,
           campaignId,
           brandId,
         });
@@ -151,7 +151,7 @@ router.post(
       const client = getWindmillClient();
       if (client) {
         try {
-          const flowInputs = { ...body.inputs, orgId, userId, runId: ownRunId, workflowName: workflow.slug, campaignId, brandId, featureSlug, serviceEnvs: collectServiceEnvs() };
+          const flowInputs = { ...body.inputs, orgId, userId, runId: ownRunId, workflowSlug: workflow.slug, campaignId, brandId, featureSlug, serviceEnvs: collectServiceEnvs() };
           windmillJobId = await client.runFlow(
             workflow.windmillFlowPath,
             flowInputs
@@ -260,7 +260,7 @@ router.post("/workflows/:id/execute", requireApiKey, requireExecutionHeaders, ex
         orgId,
         userId: executeUserId,
         taskName: "execute-workflow",
-        workflowName: workflow.slug,
+        workflowSlug: workflow.slug,
         campaignId: execCampaignId,
         brandId: execBrandId,
       });
@@ -276,7 +276,7 @@ router.post("/workflows/:id/execute", requireApiKey, requireExecutionHeaders, ex
     const client = getWindmillClient();
     if (client) {
       try {
-        const flowInputs = { ...body.inputs, orgId, userId: executeUserId, runId: ownRunId, workflowName: workflow.slug, campaignId: execCampaignId, brandId: execBrandId, featureSlug: execFeatureSlug, serviceEnvs: collectServiceEnvs() };
+        const flowInputs = { ...body.inputs, orgId, userId: executeUserId, runId: ownRunId, workflowSlug: workflow.slug, campaignId: execCampaignId, brandId: execBrandId, featureSlug: execFeatureSlug, serviceEnvs: collectServiceEnvs() };
         windmillJobId = await client.runFlow(
           workflow.windmillFlowPath,
           flowInputs

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -320,7 +320,7 @@ export const WorkflowRunResponseSchema = z
     campaignId: z.string().nullable(),
     brandId: z.string().nullable(),
     featureSlug: z.string().nullable().describe("Feature slug from features-service. Used for per-feature analytics."),
-    workflowName: z.string().nullable().describe("Name of the workflow that was executed."),
+    workflowSlug: z.string().nullable().describe("Slug of the workflow that was executed. Use this to re-execute via /workflows/by-slug/{slug}/execute."),
     subrequestId: z.string().nullable(),
     userId: z.string().nullable().describe("User ID from the execution context."),
     runId: z.string().nullable().describe("Runs-service run ID for this execution (auto-created)."),
@@ -423,7 +423,7 @@ export const WorkflowDeprecatedResponseSchema = z
   })
   .openapi("WorkflowDeprecatedResponse");
 
-// --- Execute by name schema ---
+// --- Execute by slug schema ---
 
 export const ExecuteByNameSchema = z
   .object({
@@ -431,7 +431,7 @@ export const ExecuteByNameSchema = z
       "Runtime inputs for the workflow. Accessible in nodes via $ref:flow_input.fieldName."
     ),
   })
-  .openapi("ExecuteByNameRequest", {
+  .openapi("ExecuteBySlugRequest", {
     example: {
       inputs: {
         orgId: "b645207b-d8e9-40b0-9391-072b777cd9a9",
@@ -554,8 +554,10 @@ export const WorkflowStatsSchema = z
 export const WorkflowMetadataSchema = z
   .object({
     id: z.string().uuid(),
-    name: z.string(),
-    displayName: z.string().nullable(),
+    slug: z.string().describe("Unique technical identifier."),
+    name: z.string().describe("Human-readable display name."),
+    dynastyName: z.string().describe("Stable lineage name (constant across versions)."),
+    version: z.number().int().describe("Version number within the dynasty."),
     createdForBrandId: z.string().nullable(),
     featureSlug: z.string().describe("Feature slug for grouping and naming."),
     signature: z.string(),
@@ -681,8 +683,8 @@ export const BestWorkflowQuerySchema = z
 export const BestWorkflowRecordSchema = z
   .object({
     workflowId: z.string().uuid().describe("ID of the workflow holding the record."),
-    workflowName: z.string().describe("Name of the workflow."),
-    displayName: z.string().nullable().describe("Stable display name of the workflow family."),
+    workflowSlug: z.string().describe("Unique technical identifier of the workflow."),
+    workflowName: z.string().describe("Human-readable display name of the workflow."),
     createdForBrandId: z.string().nullable().describe("Brand ID that created this workflow (creation context, not execution brand)."),
     value: z.number().describe("The record value in USD cents."),
   })
@@ -779,7 +781,7 @@ const IdentityHeaders = z.object({
   "x-run-id": z.string().describe("Run ID for tracing across services. Required."),
   "x-campaign-id": z.string().optional().describe("Campaign ID for tracking. Optional on non-execute endpoints."),
   "x-brand-id": z.string().optional().describe("Brand ID for tracking. Optional on non-execute endpoints."),
-  "x-workflow-name": z.string().optional().describe("Workflow name for tracking. Optional on non-execute endpoints."),
+  "x-workflow-slug": z.string().optional().describe("Workflow slug for tracking. Optional on non-execute endpoints."),
   "x-feature-slug": z.string().optional().describe("Feature slug from features-service. Optional on non-execute endpoints."),
 });
 
@@ -790,7 +792,7 @@ const ExecutionHeaders = z.object({
   "x-run-id": z.string().describe("Run ID for tracing across services. Required."),
   "x-campaign-id": z.string().describe("Campaign ID. Required on execute endpoints — propagated to all downstream http.call nodes."),
   "x-brand-id": z.string().describe("Brand ID. Required on execute endpoints — propagated to all downstream http.call nodes."),
-  "x-workflow-name": z.string().describe("Workflow name. Required on execute endpoints — propagated to all downstream http.call nodes."),
+  "x-workflow-slug": z.string().describe("Workflow slug. Required on execute endpoints — propagated to all downstream http.call nodes."),
   "x-feature-slug": z.string().describe("Feature slug. Required on execute endpoints — propagated to all downstream http.call nodes."),
 });
 
@@ -1136,9 +1138,11 @@ registry.registerPath({
   path: "/workflows/upgrade",
   summary: "Upgrade (upsert) workflows by DAG signature",
   description:
-    "Idempotent: creates new workflows or updates existing ones matched by (orgId + DAG signature). " +
-    "The workflow name is auto-generated as {featureSlug}-{signatureName}. " +
-    "signatureName is a human-readable word auto-assigned to each unique DAG. " +
+    "Idempotent: creates new workflows or updates existing ones matched by featureSlug. " +
+    "If the DAG signature is unchanged, updates metadata in-place. " +
+    "If the DAG signature changed, deprecates the old workflow and creates a new version. " +
+    "The workflow slug is auto-generated as {featureDynastySlug}-{signatureName}[-v{N}]. " +
+    "signatureName is a poetic word auto-assigned once per dynasty. " +
     "After deploying, execute workflows via POST /workflows/by-slug/{slug}/execute.",
   tags: ["Workflows"],
   security: [{ apiKey: [] }],

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -106,7 +106,7 @@ const IDENTITY = {
   "x-run-id": "run-caller-1",
   "x-brand-id": "brand-1",
   "x-campaign-id": "camp-1",
-  "x-workflow-name": "test-workflow",
+  "x-workflow-slug": "test-workflow",
   "x-feature-slug": "test-feature",
 };
 const AUTH = { "x-api-key": "test-api-key", ...IDENTITY };
@@ -169,7 +169,7 @@ describe("POST /workflows/:id/execute", () => {
       orgId: "org-1",
       userId: "user-1",
       taskName: "execute-workflow",
-      workflowName: "test-flow",
+      workflowSlug: "test-flow",
       campaignId: "camp-1",
       brandId: "brand-1",
     });
@@ -226,7 +226,7 @@ describe("POST /workflows/:id/execute", () => {
       orgId: "org-1", // from header
       userId: "user-1",
       taskName: "execute-workflow",
-      workflowName: "test-flow",
+      workflowSlug: "test-flow",
       campaignId: "camp-1",
       brandId: "brand-1",
     });
@@ -383,7 +383,7 @@ describe("POST /workflows/by-slug/:slug/execute", () => {
       orgId: "org-1",
       userId: "user-1",
       taskName: "execute-workflow",
-      workflowName: "create-user-flow",
+      workflowSlug: "create-user-flow",
       campaignId: "camp-1",
       brandId: "brand-1",
     });
@@ -435,7 +435,7 @@ describe("POST /workflows/by-slug/:slug/execute", () => {
       "x-run-id": "run-caller-b",
       "x-brand-id": "brand-b",
       "x-campaign-id": "camp-b",
-      "x-workflow-name": "sales-outreach",
+      "x-workflow-slug": "sales-outreach",
       "x-feature-slug": "cold-outreach",
     };
 

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -212,9 +212,9 @@ describe("dagToOpenFlow", () => {
           type: "javascript",
           expr: "flow_input.brandId",
         });
-        expect(transforms.workflowName).toEqual({
+        expect(transforms.workflowSlug).toEqual({
           type: "javascript",
-          expr: "flow_input.workflowName",
+          expr: "flow_input.workflowSlug",
         });
       }
     }

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -106,7 +106,7 @@ const AUTH = {
   "x-run-id": "run-1",
   "x-brand-id": "brand-1",
   "x-campaign-id": "camp-1",
-  "x-workflow-name": "test-workflow",
+  "x-workflow-slug": "test-workflow",
   "x-feature-slug": "test-feature",
 };
 

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -52,7 +52,7 @@ describe("createRun", () => {
     );
   });
 
-  it("includes workflowName in body when provided", async () => {
+  it("includes workflowSlug in body when provided", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -66,7 +66,7 @@ describe("createRun", () => {
       orgId: "org-1",
       userId: "user-1",
       taskName: "execute-workflow",
-      workflowName: "sales-email-cold-outreach",
+      workflowSlug: "sales-email-cold-outreach",
     });
 
     expect(fetch).toHaveBeenCalledWith(
@@ -75,7 +75,7 @@ describe("createRun", () => {
         body: JSON.stringify({
           serviceName: "workflow",
           taskName: "execute-workflow",
-          workflowName: "sales-email-cold-outreach",
+          workflowSlug: "sales-email-cold-outreach",
         }),
       })
     );
@@ -95,7 +95,7 @@ describe("createRun", () => {
       orgId: "org-1",
       userId: "user-1",
       taskName: "execute-workflow",
-      workflowName: "sales-email-cold-outreach",
+      workflowSlug: "sales-email-cold-outreach",
       campaignId: "camp-123",
       brandId: "brand-456",
     });
@@ -106,12 +106,12 @@ describe("createRun", () => {
         headers: expect.objectContaining({
           "x-campaign-id": "camp-123",
           "x-brand-id": "brand-456",
-          "x-workflow-name": "sales-email-cold-outreach",
+          "x-workflow-slug": "sales-email-cold-outreach",
         }),
         body: JSON.stringify({
           serviceName: "workflow",
           taskName: "execute-workflow",
-          workflowName: "sales-email-cold-outreach",
+          workflowSlug: "sales-email-cold-outreach",
           campaignId: "camp-123",
           brandId: "brand-456",
         }),
@@ -138,7 +138,7 @@ describe("createRun", () => {
     const calledHeaders = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
     expect(calledHeaders).not.toHaveProperty("x-campaign-id");
     expect(calledHeaders).not.toHaveProperty("x-brand-id");
-    expect(calledHeaders).not.toHaveProperty("x-workflow-name");
+    expect(calledHeaders).not.toHaveProperty("x-workflow-slug");
   });
 
   it("does not send orgId, userId, or parentRunId in request body", async () => {
@@ -274,7 +274,7 @@ describe("createPlatformRun", () => {
     expect(calledHeaders).not.toHaveProperty("x-run-id");
   });
 
-  it("includes workflowName when provided", async () => {
+  it("includes workflowSlug when provided", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -286,7 +286,7 @@ describe("createPlatformRun", () => {
     await createPlatformRun({
       serviceName: "workflow",
       taskName: "startup-upgrade",
-      workflowName: "sales-email-cold-outreach",
+      workflowSlug: "sales-email-cold-outreach",
     });
 
     expect(fetch).toHaveBeenCalledWith(
@@ -295,7 +295,7 @@ describe("createPlatformRun", () => {
         body: JSON.stringify({
           serviceName: "workflow",
           taskName: "startup-upgrade",
-          workflowName: "sales-email-cold-outreach",
+          workflowSlug: "sales-email-cold-outreach",
         }),
       })
     );

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -351,7 +351,7 @@ describe("validateAndUpgradeWorkflows", () => {
     expect(mockCreatePlatformRun).toHaveBeenCalledWith({
       serviceName: "workflow",
       taskName: "startup-upgrade",
-      workflowName: "sales-email-cold-outreach-Broken",  // uses wf.slug
+      workflowSlug: "sales-email-cold-outreach-Broken",  // uses wf.slug
     });
 
     // Should have called upgradeWorkflow with the platform key and no identity

--- a/tests/unit/tracking-headers.test.ts
+++ b/tests/unit/tracking-headers.test.ts
@@ -10,14 +10,14 @@ function mockReqRes(headers: Record<string, string>, body?: Record<string, unkno
 }
 
 describe("requireIdentity – tracking headers", () => {
-  it("extracts x-brand-id and optional x-campaign-id, x-workflow-name, x-feature-slug into res.locals", () => {
+  it("extracts x-brand-id and optional x-campaign-id, x-workflow-slug, x-feature-slug into res.locals", () => {
     const { req, res, locals } = mockReqRes({
       "x-org-id": "org-1",
       "x-user-id": "user-1",
       "x-run-id": "run-1",
       "x-brand-id": "brand-xyz",
       "x-campaign-id": "camp-abc",
-      "x-workflow-name": "sales-email-cold-outreach",
+      "x-workflow-slug": "sales-email-cold-outreach",
       "x-feature-slug": "sales-email-cold-outreach",
     });
 
@@ -29,7 +29,7 @@ describe("requireIdentity – tracking headers", () => {
     expect(called).toBe(true);
     expect(locals.brandId).toBe("brand-xyz");
     expect(locals.campaignId).toBe("camp-abc");
-    expect(locals.workflowName).toBe("sales-email-cold-outreach");
+    expect(locals.workflowSlug).toBe("sales-email-cold-outreach");
     expect(locals.featureSlug).toBe("sales-email-cold-outreach");
   });
 
@@ -48,7 +48,7 @@ describe("requireIdentity – tracking headers", () => {
     expect(called).toBe(true);
     expect(locals).not.toHaveProperty("brandId");
     expect(locals).not.toHaveProperty("campaignId");
-    expect(locals).not.toHaveProperty("workflowName");
+    expect(locals).not.toHaveProperty("workflowSlug");
     expect(locals).not.toHaveProperty("featureSlug");
   });
 
@@ -146,7 +146,7 @@ describe("requireExecutionHeaders – all 7 headers required", () => {
       "x-run-id": "run-1",
       "x-brand-id": "brand-1",
       "x-campaign-id": "camp-1",
-      "x-workflow-name": "my-workflow",
+      "x-workflow-slug": "my-workflow",
       "x-feature-slug": "my-feature",
     });
 
@@ -179,7 +179,7 @@ describe("requireExecutionHeaders – all 7 headers required", () => {
     expect(statusCode).toBe(400);
     expect(errorBody.error).toContain("x-brand-id");
     expect(errorBody.error).toContain("x-campaign-id");
-    expect(errorBody.error).toContain("x-workflow-name");
+    expect(errorBody.error).toContain("x-workflow-slug");
     expect(errorBody.error).toContain("x-feature-slug");
   });
 
@@ -190,7 +190,7 @@ describe("requireExecutionHeaders – all 7 headers required", () => {
       "x-run-id": "run-1",
       "x-brand-id": "brand-1",
       // x-campaign-id missing
-      "x-workflow-name": "my-workflow",
+      "x-workflow-slug": "my-workflow",
       "x-feature-slug": "my-feature",
     } } as unknown as Request;
     let statusCode = 0;


### PR DESCRIPTION
## Summary

Follow-up to #180. Renames the `x-workflow-name` header to `x-workflow-slug` across the entire service, and fixes the OpenAPI spec to be complete and accurate with the new naming.

- **Header rename**: `x-workflow-name` → `x-workflow-slug` (inbound middleware + outbound calls to runs-service)
- **OpenAPI fixes**: `WorkflowRunResponse.workflowName` → `workflowSlug`, `WorkflowMetadata` now has `slug`/`name`/`dynastyName`/`version`, `BestWorkflowRecord` updated, `ExecuteBySlugRequest` renamed
- **Windmill flow inputs**: `flow_input.workflowName` → `flow_input.workflowSlug`
- **Prompt templates**: `body.workflowName` → `body.workflowSlug`
- **Regenerated `openapi.json`**

## Test plan

- [x] All 476 tests pass
- [x] TypeScript compiles with zero errors
- [x] OpenAPI spec regenerated and committed
- [ ] Coordinate with all services to rename their `x-workflow-name` header in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)