### PR TITLE
chore: update features-client for live dynasty endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,6 @@ This means: if dynasty A and dynasty B converge, the active workflow's stats inc
 Workflow-service needs `feature_dynasty_name` and `feature_dynasty_slug` from features-service. These are the stable, unversioned identifiers for a feature (as opposed to `feature_name`/`feature_slug` which may carry version suffixes).
 
 - Workflow-service receives only `feature_slug` from clients in requests.
-- It must call features-service to resolve `feature_dynasty_name` and `feature_dynasty_slug`.
-- This endpoint may not exist yet in features-service — it needs to be created.
-- Until features-service exposes this, workflow-service cannot fully implement the naming scheme.
+- It calls `GET /features/dynasty?slug=<featureSlug>` on features-service to resolve `feature_dynasty_name` and `feature_dynasty_slug`.
+- Falls back to slug derivation (strip `-v{N}`, capitalize words) if features-service is not configured or unreachable.
+- Requires env vars: `FEATURES_SERVICE_URL`, `FEATURES_SERVICE_API_KEY`.

--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -1,9 +1,9 @@
 /**
  * Client for features-service dynasty resolution.
  *
- * Workflow-service needs the stable (unversioned) dynasty identifiers for a feature
- * to compose workflow names/slugs. Until features-service exposes
- * GET /features/dynasty?slug=..., we fall back to deriving them from the featureSlug.
+ * Calls GET /features/dynasty?slug=<featureSlug> to get the stable (unversioned)
+ * dynasty identifiers for a feature. Falls back to slug derivation if
+ * features-service is not configured or unreachable.
  */
 
 export interface FeatureDynasty {
@@ -21,9 +21,11 @@ function getFeaturesServiceConfig(): { baseUrl: string; apiKey: string } | null 
 /**
  * Resolve the stable dynasty identifiers for a feature.
  *
- * Tries features-service first. Falls back to deriving from featureSlug:
- * - Strip trailing version suffixes like "-v2", "-v3"
- * - Capitalize words for the display name
+ * Calls features-service GET /features/dynasty?slug=... which returns
+ * { feature_dynasty_name, feature_dynasty_slug }.
+ *
+ * Falls back to deriving from featureSlug if features-service is
+ * not configured or unreachable.
  */
 export async function resolveFeatureDynasty(
   featureSlug: string,
@@ -42,17 +44,15 @@ export async function resolveFeatureDynasty(
 
       if (res.ok) {
         const data = (await res.json()) as {
-          feature_dynasty_name?: string;
-          feature_dynasty_slug?: string;
-          featureDynastyName?: string;
-          featureDynastySlug?: string;
+          feature_dynasty_name: string;
+          feature_dynasty_slug: string;
         };
 
-        const dynastyName = data.featureDynastyName ?? data.feature_dynasty_name;
-        const dynastySlug = data.featureDynastySlug ?? data.feature_dynasty_slug;
-
-        if (dynastyName && dynastySlug) {
-          return { featureDynastyName: dynastyName, featureDynastySlug: dynastySlug };
+        if (data.feature_dynasty_name && data.feature_dynasty_slug) {
+          return {
+            featureDynastyName: data.feature_dynasty_name,
+            featureDynastySlug: data.feature_dynasty_slug,
+          };
         }
       }
 
@@ -75,10 +75,8 @@ export async function resolveFeatureDynasty(
  * Strips trailing -v{N} suffix and capitalizes words.
  */
 function deriveFromSlug(featureSlug: string): FeatureDynasty {
-  // Strip trailing version suffix like "-v2", "-v3"
   const dynastySlug = featureSlug.replace(/-v\d+$/, "");
 
-  // Capitalize each word for display name
   const dynastyName = dynastySlug
     .split("-")
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))


### PR DESCRIPTION
## Summary

- Features-service now exposes `GET /features/dynasty?slug=<featureSlug>` — clean up the client to use the confirmed response format (`feature_dynasty_name`, `feature_dynasty_slug` in snake_case)
- Remove stale comments about the endpoint not existing yet
- Update CLAUDE.md dependency section to reflect the endpoint is live

## Test plan

- [x] All 476 tests pass
- [x] Client correctly parses snake_case response from features-service
- [x] Fallback still works when features-service is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)