### PR TITLE
feat: add GET /workflows/dynasties endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1602,6 +1602,46 @@
         "default": "workflow",
         "description": "Granularity: best workflow or best brand. Defaults to 'workflow'."
       },
+      "DynastyEntry": {
+        "type": "object",
+        "properties": {
+          "dynastySlug": {
+            "type": "string",
+            "description": "Stable dynasty slug."
+          },
+          "dynastyName": {
+            "type": "string",
+            "description": "Human-readable dynasty name."
+          },
+          "slugs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "All versioned workflow slugs in this dynasty."
+          }
+        },
+        "required": [
+          "dynastySlug",
+          "dynastyName",
+          "slugs"
+        ]
+      },
+      "DynastiesResponse": {
+        "type": "object",
+        "properties": {
+          "dynasties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DynastyEntry"
+            },
+            "description": "All dynasties with their versioned slugs."
+          }
+        },
+        "required": [
+          "dynasties"
+        ]
+      },
       "DynastySlugsResponse": {
         "type": "object",
         "properties": {
@@ -3812,6 +3852,104 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/dynasties": {
+      "get": {
+        "summary": "List all dynasties with their versioned slugs",
+        "description": "Returns all dynasties with the list of versioned workflow slugs for each. Useful for building a reverse map (slug → dynastySlug) to aggregate stats by dynasty.",
+        "tags": [
+          "Dynasty"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal org UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal org UUID (from client-service). Required.",
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Internal user UUID (from client-service). Required."
+            },
+            "required": true,
+            "description": "Internal user UUID (from client-service). Required.",
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Run ID for tracing across services. Required."
+            },
+            "required": true,
+            "description": "Run ID for tracing across services. Required.",
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID for tracking. Optional on non-execute endpoints."
+            },
+            "required": false,
+            "description": "Campaign ID for tracking. Optional on non-execute endpoints.",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID for tracking. Optional on non-execute endpoints."
+            },
+            "required": false,
+            "description": "Brand ID for tracking. Optional on non-execute endpoints.",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug for tracking. Optional on non-execute endpoints."
+            },
+            "required": false,
+            "description": "Workflow slug for tracking. Optional on non-execute endpoints.",
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug from features-service. Optional on non-execute endpoints."
+            },
+            "required": false,
+            "description": "Feature slug from features-service. Optional on non-execute endpoints.",
+            "name": "x-feature-slug",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "All dynasties",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DynastiesResponse"
                 }
               }
             }

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -1044,6 +1044,36 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
   }
 });
 
+// GET /workflows/dynasties — List all dynasties with their versioned slugs
+router.get("/workflows/dynasties", requireApiKey, async (req, res) => {
+  try {
+    const allWorkflows = await db
+      .select({ slug: workflows.slug, dynastySlug: workflows.dynastySlug, dynastyName: workflows.dynastyName })
+      .from(workflows);
+
+    const dynastyMap = new Map<string, { dynastyName: string; slugs: string[] }>();
+    for (const w of allWorkflows) {
+      const entry = dynastyMap.get(w.dynastySlug);
+      if (entry) {
+        entry.slugs.push(w.slug);
+      } else {
+        dynastyMap.set(w.dynastySlug, { dynastyName: w.dynastyName, slugs: [w.slug] });
+      }
+    }
+
+    const dynasties = [...dynastyMap.entries()].map(([dynastySlug, { dynastyName, slugs }]) => ({
+      dynastySlug,
+      dynastyName,
+      slugs,
+    }));
+
+    res.json({ dynasties });
+  } catch (err) {
+    console.error("[workflow-service] GET dynasties error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 // GET /workflows/dynasty/slugs — Resolve a dynasty slug to all versioned workflow slugs
 router.get("/workflows/dynasty/slugs", requireApiKey, async (req, res) => {
   try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -769,6 +769,20 @@ export const DynastySlugsResponseSchema = z
   })
   .openapi("DynastySlugsResponse");
 
+export const DynastyEntrySchema = z
+  .object({
+    dynastySlug: z.string().describe("Stable dynasty slug."),
+    dynastyName: z.string().describe("Human-readable dynasty name."),
+    slugs: z.array(z.string()).describe("All versioned workflow slugs in this dynasty."),
+  })
+  .openapi("DynastyEntry");
+
+export const DynastiesResponseSchema = z
+  .object({
+    dynasties: z.array(DynastyEntrySchema).describe("All dynasties with their versioned slugs."),
+  })
+  .openapi("DynastiesResponse");
+
 export const DynastyStatsResponseSchema = z
   .object({
     dynastySlug: z.string().describe("The dynasty slug."),
@@ -1286,6 +1300,28 @@ registry.registerPath({
 });
 
 // --- Dynasty endpoints ---
+
+registry.registerPath({
+  method: "get",
+  path: "/workflows/dynasties",
+  summary: "List all dynasties with their versioned slugs",
+  description:
+    "Returns all dynasties with the list of versioned workflow slugs for each. " +
+    "Useful for building a reverse map (slug → dynastySlug) to aggregate stats by dynasty.",
+  tags: ["Dynasty"],
+  security: [{ apiKey: [] }],
+  request: {
+    headers: IdentityHeaders,
+  },
+  responses: {
+    200: {
+      description: "All dynasties",
+      content: {
+        "application/json": { schema: DynastiesResponseSchema },
+      },
+    },
+  },
+});
 
 registry.registerPath({
   method: "get",

--- a/tests/integration/best-workflow.test.ts
+++ b/tests/integration/best-workflow.test.ts
@@ -678,6 +678,42 @@ describe("GET /workflows/best (hero records)", () => {
   });
 });
 
+describe("GET /workflows/dynasties", () => {
+  beforeEach(() => {
+    mockWorkflowRows.length = 0;
+  });
+
+  it("returns all dynasties grouped with their slugs", async () => {
+    mockWorkflowRows.push(
+      makeWorkflow({ id: "wf-1", slug: "cold-email-sequoia", dynastySlug: "cold-email-sequoia", dynastyName: "Cold Email Sequoia" }),
+      makeWorkflow({ id: "wf-2", slug: "cold-email-sequoia-v2", dynastySlug: "cold-email-sequoia", dynastyName: "Cold Email Sequoia" }),
+      makeWorkflow({ id: "wf-3", slug: "warm-intro", dynastySlug: "warm-intro", dynastyName: "Warm Intro" }),
+    );
+
+    const res = await request.get("/workflows/dynasties").set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.dynasties).toHaveLength(2);
+
+    const coldEmail = res.body.dynasties.find((d: { dynastySlug: string }) => d.dynastySlug === "cold-email-sequoia");
+    expect(coldEmail).toBeDefined();
+    expect(coldEmail.dynastyName).toBe("Cold Email Sequoia");
+    expect(coldEmail.slugs).toHaveLength(2);
+    expect(coldEmail.slugs).toContain("cold-email-sequoia");
+    expect(coldEmail.slugs).toContain("cold-email-sequoia-v2");
+
+    const warmIntro = res.body.dynasties.find((d: { dynastySlug: string }) => d.dynastySlug === "warm-intro");
+    expect(warmIntro).toBeDefined();
+    expect(warmIntro.slugs).toEqual(["warm-intro"]);
+  });
+
+  it("returns empty array when no workflows exist", async () => {
+    const res = await request.get("/workflows/dynasties").set(AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body.dynasties).toEqual([]);
+  });
+});
+
 describe("GET /workflows/dynasty/slugs", () => {
   beforeEach(() => {
     mockWorkflowRows.length = 0;


### PR DESCRIPTION
## Summary
- Add `GET /workflows/dynasties` — returns all dynasties with their versioned workflow slugs
- Enables clients to build a reverse map (slug → dynastySlug) for groupBy dynasty aggregation
- New Zod schemas: `DynastyEntrySchema`, `DynastiesResponseSchema`

## Test plan
- [x] 484 tests pass (2 new tests for the endpoint)
- [x] TypeScript compiles cleanly
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)