### PR TITLE
fix: correct dynasty backfill and name constraint

### DIFF
--- a/drizzle/0023_fix_dynasty_backfill.sql
+++ b/drizzle/0023_fix_dynasty_backfill.sql
@@ -1,0 +1,50 @@
+-- Fix dynasty backfill: correct dynasty_name, dynasty_slug, version, name.
+-- The original 0021/0022 migrations used INITCAP(feature_slug) which produces
+-- wrong capitalization (e.g. "Pr" instead of "PR") and set all versions to 1.
+-- This migration fixes the data using features-service dynasty names and
+-- computes proper version numbers from the upgrade chain.
+-- Idempotent: safe to re-run (overwrites all dynasty columns).
+
+-- 1. Fix name unique constraint: global → active-only (deprecated workflows can share names across converged dynasties)
+DROP INDEX IF EXISTS "idx_workflows_name_unique";
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_workflows_name_active_unique" ON "workflows" ("name") WHERE "status" = 'active';
+--> statement-breakpoint
+
+-- 2. Compute correct version numbers from upgrade chains
+WITH RECURSIVE chain AS (
+  SELECT w.id, w.upgraded_to, 1 as computed_version
+  FROM "workflows" w
+  WHERE NOT EXISTS (SELECT 1 FROM "workflows" w2 WHERE w2.upgraded_to = w.id)
+  UNION ALL
+  SELECT w.id, w.upgraded_to, c.computed_version + 1
+  FROM "workflows" w
+  JOIN chain c ON c.upgraded_to = w.id
+)
+UPDATE "workflows" SET "version" = chain.computed_version
+FROM chain WHERE "workflows".id = chain.id;
+--> statement-breakpoint
+
+-- 3. Fix dynasty_name using correct feature dynasty names
+UPDATE "workflows" SET "dynasty_name" = CASE
+  WHEN "feature_slug" = 'pr-cold-email-outreach' THEN 'PR Cold Email Outreach ' || INITCAP("signature_name")
+  WHEN "feature_slug" = 'sales-cold-email-outreach' THEN 'Sales Cold Email Outreach ' || INITCAP("signature_name")
+  WHEN "feature_slug" = 'press-kit-page-generation' THEN 'Press Kit Page Generation ' || INITCAP("signature_name")
+  ELSE INITCAP(REPLACE("feature_slug", '-', ' ')) || ' ' || INITCAP("signature_name")
+END;
+--> statement-breakpoint
+
+-- 4. Fix dynasty_slug: feature_dynasty_slug + "-" + signature_name
+UPDATE "workflows" SET "dynasty_slug" = CASE
+  WHEN "feature_slug" = 'pr-cold-email-outreach' THEN 'pr-cold-email-outreach-' || "signature_name"
+  WHEN "feature_slug" = 'sales-cold-email-outreach' THEN 'sales-cold-email-outreach-' || "signature_name"
+  WHEN "feature_slug" = 'press-kit-page-generation' THEN 'press-kit-page-generation-' || "signature_name"
+  ELSE REPLACE("feature_slug", '-v\d+$', '') || '-' || "signature_name"
+END;
+--> statement-breakpoint
+
+-- 5. Fix name: dynasty_name [+ " v{N}" if N >= 2]
+UPDATE "workflows" SET "name" = CASE
+  WHEN "version" = 1 THEN "dynasty_name"
+  ELSE "dynasty_name" || ' v' || "version"
+END;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1772966706410,
       "tag": "0022_add_dynasty_slug",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1774747900000,
+      "tag": "0023_fix_dynasty_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -49,7 +49,7 @@ export const workflows = pgTable(
     index("idx_workflows_campaign").on(table.campaignId),
     index("idx_workflows_org_style").on(table.orgId, table.styleName),
     uniqueIndex("idx_workflows_slug_unique").on(table.slug),
-    uniqueIndex("idx_workflows_name_unique").on(table.name),
+    uniqueIndex("idx_workflows_name_active_unique").on(table.name).where(sql`status = 'active'`),
     index("idx_workflows_dynasty_slug").on(table.dynastySlug),
   ]
 );


### PR DESCRIPTION
## Summary
- Adds migration 0023 to fix incorrect data from the original dynasty backfill (0021/0022)
- Fixes dynasty_name capitalization (uses correct feature dynasty names from features-service)
- Computes proper version numbers by walking upgrade chains (was all set to 1)
- Fixes dynasty_slug composition (feature_dynasty_slug + signature_name)
- Fixes name composition (dynasty_name + version suffix)
- Changes name uniqueness from global to active-only (deprecated workflows can share names after lineage convergence)

## Test plan
- [x] All 484 tests pass
- [x] Migration already applied to prod DB manually — data verified correct
- [x] Migration is idempotent (safe to re-run on deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)