### PR TITLE
feat: SpecWatcher cron for OpenAPI spec change detection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { JobPoller } from "./lib/job-poller.js";
 import { requireIdentity } from "./middleware/auth.js";
 import { checkApiRegistryHealth, validateAndUpgradeWorkflows } from "./lib/startup-validator.js";
 import { deployNodes } from "./lib/deploy-nodes.js";
+import { SpecWatcher } from "./lib/spec-watcher.js";
 import healthRoutes from "./routes/health.js";
 import workflowsRoutes from "./routes/workflows.js";
 import workflowRunsRoutes from "./routes/workflow-runs.js";
@@ -88,6 +89,13 @@ if (process.env.NODE_ENV !== "test") {
           console.error("[workflow-service] Workflow validation/upgrade failed:", err);
           // Don't crash — workflows with issues are kept active and logged above
         }
+
+        // Start SpecWatcher — checks every 5 min if OpenAPI specs changed,
+        // triggers workflow upgrades only when a spec change breaks a workflow.
+        // The check itself is free (HTTP + hash comparison), LLM only on upgrade.
+        const specWatcher = new SpecWatcher({ db, windmillClient });
+        await specWatcher.check(); // Store baseline hash (no-op on first call)
+        specWatcher.start();
       }
     } catch (err) {
       console.error("Startup failed:", err);

--- a/src/lib/spec-watcher.ts
+++ b/src/lib/spec-watcher.ts
@@ -1,0 +1,168 @@
+import { createHash } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { workflows } from "../db/schema.js";
+import type { db as DbInstance } from "../db/index.js";
+import type { DAG } from "./dag-validator.js";
+import { extractHttpEndpoints } from "./extract-http-endpoints.js";
+import { fetchSpecsForServices } from "./api-registry-client.js";
+import { validateWorkflowEndpoints } from "./validate-workflow-endpoints.js";
+import { validateAndUpgradeWorkflows } from "./startup-validator.js";
+import type { WindmillClient } from "./windmill-client.js";
+
+type Database = typeof DbInstance;
+
+interface SpecWatcherDeps {
+  db: Database;
+  windmillClient: WindmillClient | null;
+}
+
+const INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Watches for OpenAPI spec changes every 5 minutes.
+ * The check itself is free (HTTP + CPU hash comparison).
+ * Only triggers LLM-powered upgrades when specs actually changed
+ * AND the change breaks an active workflow.
+ */
+export class SpecWatcher {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private lastSpecsHash: string | null = null;
+  private running = false;
+  private deps: SpecWatcherDeps;
+
+  constructor(deps: SpecWatcherDeps) {
+    this.deps = deps;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    console.log("[workflow-service] SpecWatcher started — checking every 5 minutes");
+    this.timer = setInterval(() => void this.check(), INTERVAL_MS);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+      console.log("[workflow-service] SpecWatcher stopped");
+    }
+  }
+
+  /**
+   * Run one check cycle. Safe to call manually (e.g. after startup validation).
+   * Stores the current spec hash so the first interval tick can detect drift.
+   */
+  async check(): Promise<void> {
+    if (this.running) {
+      console.log("[workflow-service] SpecWatcher: previous check still running — skipping");
+      return;
+    }
+
+    this.running = true;
+    try {
+      await this.doCheck();
+    } catch (err) {
+      console.error(
+        "[workflow-service] SpecWatcher check failed:",
+        err instanceof Error ? err.message : err,
+      );
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async doCheck(): Promise<void> {
+    // 1. Fetch all active workflows
+    const activeWorkflows = await this.deps.db
+      .select()
+      .from(workflows)
+      .where(eq(workflows.status, "active"));
+
+    if (activeWorkflows.length === 0) return;
+
+    // 2. Collect all service names referenced by active workflows
+    const serviceNames = new Set<string>();
+    for (const wf of activeWorkflows) {
+      for (const ep of extractHttpEndpoints(wf.dag as DAG)) {
+        serviceNames.add(ep.service);
+      }
+    }
+
+    if (serviceNames.size === 0) return;
+
+    // 3. Fetch current specs from API Registry
+    const specs = await fetchSpecsForServices([...serviceNames]);
+
+    // 4. Hash the specs — deterministic JSON serialization by sorting keys
+    const specsHash = hashSpecs(specs);
+
+    // First run: store baseline, no upgrade needed (startup already validated)
+    if (this.lastSpecsHash === null) {
+      this.lastSpecsHash = specsHash;
+      console.log("[workflow-service] SpecWatcher: baseline hash stored");
+      return;
+    }
+
+    // No change — nothing to do
+    if (specsHash === this.lastSpecsHash) return;
+
+    console.log("[workflow-service] SpecWatcher: spec change detected — validating workflows");
+    this.lastSpecsHash = specsHash;
+
+    // 5. Quick validation pass (free, rule-based)
+    let hasIssues = false;
+    for (const wf of activeWorkflows) {
+      const result = validateWorkflowEndpoints(wf.dag as DAG, specs);
+      if (!result.valid || result.fieldIssues.length > 0) {
+        hasIssues = true;
+        console.log(
+          `[workflow-service] SpecWatcher: workflow "${wf.slug}" has issues — triggering upgrade`,
+        );
+        break;
+      }
+    }
+
+    if (!hasIssues) {
+      console.log("[workflow-service] SpecWatcher: specs changed but all workflows still valid");
+      return;
+    }
+
+    // 6. Trigger full upgrade (may use LLM for broken workflows)
+    try {
+      await validateAndUpgradeWorkflows(this.deps);
+      console.log("[workflow-service] SpecWatcher: upgrade cycle completed");
+    } catch (err) {
+      console.error(
+        "[workflow-service] SpecWatcher: upgrade cycle failed:",
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}
+
+/**
+ * Deterministic hash of a Map of specs.
+ * Deep-sorts all object keys for stability.
+ */
+function hashSpecs(specs: Map<string, Record<string, unknown>>): string {
+  const sorted = [...specs.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, spec]) => [name, stableStringify(spec)]);
+
+  return createHash("sha256").update(JSON.stringify(sorted)).digest("hex");
+}
+
+/** JSON.stringify with sorted keys at every nesting level */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map(stableStringify).join(",") + "]";
+  }
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  const entries = keys.map(
+    (k) => JSON.stringify(k) + ":" + stableStringify((value as Record<string, unknown>)[k]),
+  );
+  return "{" + entries.join(",") + "}";
+}

--- a/tests/unit/spec-watcher.test.ts
+++ b/tests/unit/spec-watcher.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock API registry client
+const mockFetchSpecsForServices = vi.fn();
+vi.mock("../../src/lib/api-registry-client.js", () => ({
+  fetchSpecsForServices: (...args: unknown[]) => mockFetchSpecsForServices(...args),
+}));
+
+// Mock startup-validator
+const mockValidateAndUpgradeWorkflows = vi.fn();
+vi.mock("../../src/lib/startup-validator.js", () => ({
+  validateAndUpgradeWorkflows: (...args: unknown[]) => mockValidateAndUpgradeWorkflows(...args),
+}));
+
+import { SpecWatcher } from "../../src/lib/spec-watcher.js";
+
+// Minimal DAG with an http.call node
+function makeDag(service: string, method: string, path: string) {
+  return {
+    nodes: [
+      {
+        id: "n1",
+        type: "http.call",
+        config: { service, method, path },
+      },
+    ],
+    edges: [],
+  };
+}
+
+// Minimal OpenAPI spec where GET /leads exists
+function makeSpec(paths: Record<string, Record<string, unknown>>) {
+  return { openapi: "3.0.0", paths };
+}
+
+// Fake DB that returns active workflows
+function makeFakeDb(rows: unknown[]) {
+  const selectResult = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockResolvedValue(rows),
+  };
+  return {
+    select: vi.fn().mockReturnValue(selectResult),
+  } as unknown as Parameters<ConstructorParameters<typeof SpecWatcher>[0]["db"] extends never ? never : never>[0] & { select: ReturnType<typeof vi.fn> };
+}
+
+describe("SpecWatcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Let console.error pass through so test failures are visible
+    vi.spyOn(console, "error").mockImplementation((...args) => {
+      process.stderr.write(`[test-stderr] ${args.map(String).join(" ")}\n`);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("stores baseline hash on first check and does not trigger upgrade", async () => {
+    const dag = makeDag("lead-service", "GET", "/leads");
+    const spec = makeSpec({ "/leads": { get: { responses: { "200": {} } } } });
+
+    const fakeDb = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            { id: "w1", slug: "test-wf", dag, status: "active" },
+          ]),
+        }),
+      }),
+    };
+
+    mockFetchSpecsForServices.mockResolvedValue(new Map([["lead-service", spec]]));
+
+    const watcher = new SpecWatcher({ db: fakeDb as any, windmillClient: null });
+    await watcher.check();
+
+    // Should NOT trigger upgrade on first check (baseline)
+    expect(mockValidateAndUpgradeWorkflows).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger upgrade when specs are unchanged", async () => {
+    const dag = makeDag("lead-service", "GET", "/leads");
+    const spec = makeSpec({ "/leads": { get: { responses: { "200": {} } } } });
+
+    const fakeDb = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            { id: "w1", slug: "test-wf", dag, status: "active" },
+          ]),
+        }),
+      }),
+    };
+
+    mockFetchSpecsForServices.mockResolvedValue(new Map([["lead-service", spec]]));
+
+    const watcher = new SpecWatcher({ db: fakeDb as any, windmillClient: null });
+
+    // First check — store baseline
+    await watcher.check();
+    // Second check — same specs
+    await watcher.check();
+
+    expect(mockValidateAndUpgradeWorkflows).not.toHaveBeenCalled();
+  });
+
+  it("triggers upgrade when specs change AND workflow has issues", async () => {
+    const dag = makeDag("lead-service", "GET", "/leads");
+
+    const specV1 = makeSpec({ "/leads": { get: { responses: { "200": {} } } } });
+    // V2: /leads endpoint removed — workflow will have issues
+    const specV2 = makeSpec({ "/contacts": { get: { responses: { "200": {} } } } });
+
+    const fakeDb = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            { id: "w1", slug: "test-wf", dag, status: "active" },
+          ]),
+        }),
+      }),
+    };
+
+    mockFetchSpecsForServices
+      .mockResolvedValueOnce(new Map([["lead-service", specV1]]))
+      .mockResolvedValueOnce(new Map([["lead-service", specV2]]));
+
+    mockValidateAndUpgradeWorkflows.mockResolvedValue(undefined);
+
+    const watcher = new SpecWatcher({ db: fakeDb as any, windmillClient: null });
+
+    // First check — baseline
+    await watcher.check();
+    expect(mockValidateAndUpgradeWorkflows).not.toHaveBeenCalled();
+
+    // Second check — specs changed, /leads is gone → workflow broken → upgrade
+    await watcher.check();
+    expect(mockValidateAndUpgradeWorkflows).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not trigger upgrade when specs change but workflows are still valid", async () => {
+    const dag = makeDag("lead-service", "GET", "/leads");
+
+    const specV1 = makeSpec({ "/leads": { get: { responses: { "200": {} } } } });
+    // V2: /leads still exists, just added a new endpoint
+    const specV2 = makeSpec({
+      "/leads": { get: { responses: { "200": {} } } },
+      "/leads/search": { post: { responses: { "200": {} } } },
+    });
+
+    const fakeDb = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            { id: "w1", slug: "test-wf", dag, status: "active" },
+          ]),
+        }),
+      }),
+    };
+
+    mockFetchSpecsForServices
+      .mockResolvedValueOnce(new Map([["lead-service", specV1]]))
+      .mockResolvedValueOnce(new Map([["lead-service", specV2]]));
+
+    const watcher = new SpecWatcher({ db: fakeDb as any, windmillClient: null });
+
+    await watcher.check();
+    await watcher.check();
+
+    // Specs changed but workflow is still valid — no upgrade
+    expect(mockValidateAndUpgradeWorkflows).not.toHaveBeenCalled();
+  });
+
+  it("skips check if no active workflows", async () => {
+    const fakeDb = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    };
+
+    const watcher = new SpecWatcher({ db: fakeDb as any, windmillClient: null });
+    await watcher.check();
+
+    expect(mockFetchSpecsForServices).not.toHaveBeenCalled();
+  });
+
+  it("does not run concurrent checks", async () => {
+    const dag = makeDag("lead-service", "GET", "/leads");
+    const spec = makeSpec({ "/leads": { get: { responses: { "200": {} } } } });
+
+    // Make the fetch hang until we resolve it
+    let resolveSpecs!: (v: Map<string, unknown>) => void;
+    const hangingPromise = new Promise<Map<string, unknown>>((r) => { resolveSpecs = r; });
+
+    const fakeDb = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            { id: "w1", slug: "test-wf", dag, status: "active" },
+          ]),
+        }),
+      }),
+    };
+
+    mockFetchSpecsForServices.mockReturnValue(hangingPromise);
+
+    const watcher = new SpecWatcher({ db: fakeDb as any, windmillClient: null });
+
+    // Start first check (will hang on fetchSpecsForServices)
+    const p1 = watcher.check();
+    // Start second check — should skip
+    const p2 = watcher.check();
+
+    // Resolve the hanging fetch
+    resolveSpecs(new Map([["lead-service", spec]]));
+    await p1;
+    await p2;
+
+    // Only one call to fetchSpecsForServices (the second check was skipped)
+    expect(mockFetchSpecsForServices).toHaveBeenCalledTimes(1);
+  });
+
+  it("start() and stop() manage the interval", () => {
+    const fakeDb = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    };
+
+    const watcher = new SpecWatcher({ db: fakeDb as any, windmillClient: null });
+
+    vi.useFakeTimers();
+    watcher.start();
+    watcher.stop();
+    vi.useRealTimers();
+
+    // No error, no hanging timers
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `SpecWatcher` class that checks every 5 minutes if any OpenAPI spec (from API Registry) has changed
- The check is **free**: HTTP fetch + SHA-256 hash comparison, no LLM involved
- Only triggers the existing `validateAndUpgradeWorkflows` flow (which may use LLM) when a spec change actually breaks an active workflow
- Eliminates the need for per-repo deploy hooks or Railway watch path configuration — works automatically for any new service added to the project

## How it works
1. On startup, stores a baseline hash of all OpenAPI specs referenced by active workflows
2. Every 5 min, re-fetches specs and compares the hash
3. If hash changed → runs rule-based validation against all active workflows
4. If any workflow has broken endpoints or field mismatches → triggers the existing LLM upgrade pipeline
5. If specs changed but all workflows are still valid → logs and moves on

## Test plan
- [x] 7 unit tests covering: baseline storage, no-op on unchanged specs, upgrade trigger on breaking change, no upgrade on non-breaking change, empty workflow skip, concurrency guard, start/stop lifecycle
- [x] All 354 existing unit tests still pass
- [x] Clean TypeScript compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)