### PR TITLE
feat: deprecate stale workflows to reduce LLM upgrade costs

### DIFF
--- a/src/lib/campaign-client.ts
+++ b/src/lib/campaign-client.ts
@@ -1,0 +1,64 @@
+/**
+ * Client for campaign-service.
+ *
+ * Used to check whether workflows are currently in use by active campaigns.
+ */
+
+interface Campaign {
+  id: string;
+  workflowSlug: string;
+  status: string;
+  toResumeAt: string | null;
+}
+
+/**
+ * Fetch all campaigns from campaign-service.
+ * Requires CAMPAIGN_SERVICE_URL and CAMPAIGN_SERVICE_API_KEY env vars.
+ */
+export async function fetchAllCampaigns(): Promise<Campaign[]> {
+  const baseUrl = process.env.CAMPAIGN_SERVICE_URL?.replace(/\/$/, "");
+  const apiKey = process.env.CAMPAIGN_SERVICE_API_KEY;
+
+  if (!baseUrl || !apiKey) {
+    throw new Error(
+      "CAMPAIGN_SERVICE_URL and CAMPAIGN_SERVICE_API_KEY must be set to check active campaigns",
+    );
+  }
+
+  const res = await fetch(`${baseUrl}/campaigns/list`, {
+    method: "GET",
+    headers: {
+      "x-api-key": apiKey,
+      "x-service-name": "workflow-service",
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `campaign-service error: GET /campaigns/list -> ${res.status} ${res.statusText}: ${text}`,
+    );
+  }
+
+  const data = (await res.json()) as { campaigns: Campaign[] };
+  return data.campaigns;
+}
+
+/**
+ * Returns the set of workflow slugs that are currently "in use" by a campaign.
+ * A campaign is considered in-use if:
+ *   - status is "active", OR
+ *   - toResumeAt is non-null (periodic campaign temporarily paused, will resume)
+ */
+export async function fetchActiveWorkflowSlugs(): Promise<Set<string>> {
+  const campaigns = await fetchAllCampaigns();
+
+  const activeSlugs = new Set<string>();
+  for (const c of campaigns) {
+    if (c.status === "active" || c.toResumeAt !== null) {
+      activeSlugs.add(c.workflowSlug);
+    }
+  }
+
+  return activeSlugs;
+}

--- a/src/lib/stale-workflow-deprecator.ts
+++ b/src/lib/stale-workflow-deprecator.ts
@@ -1,0 +1,136 @@
+/**
+ * Deprecates stale active workflows to reduce LLM upgrade costs.
+ *
+ * For each feature_slug, keeps only the 3 most recently used workflows.
+ * Workflows outside the top 3 are deprecated UNLESS they are currently
+ * used by an active campaign in campaign-service.
+ */
+
+import { eq, sql, inArray } from "drizzle-orm";
+import { workflows, workflowRuns } from "../db/schema.js";
+import type { db as DbInstance } from "../db/index.js";
+import { fetchActiveWorkflowSlugs } from "./campaign-client.js";
+
+type Database = typeof DbInstance;
+
+const KEEP_TOP_N = 3;
+
+interface DeprecationResult {
+  deprecatedCount: number;
+  keptByRecency: number;
+  keptByCampaign: number;
+  skippedNoCampaignService: boolean;
+}
+
+/**
+ * Deprecate stale workflows that are not in the top N most recently used
+ * per feature_slug and are not used by any active campaign.
+ *
+ * Safe to call at startup and periodically — only deprecates, never deletes.
+ */
+export async function deprecateStaleWorkflows(
+  database: Database,
+): Promise<DeprecationResult> {
+  // 1. Fetch all active workflows
+  const activeWorkflows = await database
+    .select()
+    .from(workflows)
+    .where(eq(workflows.status, "active"));
+
+  if (activeWorkflows.length === 0) {
+    return { deprecatedCount: 0, keptByRecency: 0, keptByCampaign: 0, skippedNoCampaignService: false };
+  }
+
+  // 2. Get last run date for each active workflow
+  const lastRunRows = await database
+    .select({
+      workflowId: workflowRuns.workflowId,
+      lastRun: sql<string>`max(${workflowRuns.createdAt})`.as("last_run"),
+    })
+    .from(workflowRuns)
+    .where(inArray(workflowRuns.workflowId, activeWorkflows.map((w) => w.id)))
+    .groupBy(workflowRuns.workflowId);
+
+  const lastRunByWorkflowId = new Map(
+    lastRunRows.map((r) => [r.workflowId, new Date(r.lastRun).getTime()]),
+  );
+
+  // 3. Group by featureSlug
+  const byFeature = new Map<string, typeof activeWorkflows>();
+  for (const wf of activeWorkflows) {
+    const arr = byFeature.get(wf.featureSlug) ?? [];
+    arr.push(wf);
+    byFeature.set(wf.featureSlug, arr);
+  }
+
+  // 4. For each feature, identify workflows outside the top N
+  const candidatesForDeprecation: typeof activeWorkflows = [];
+  let keptByRecency = 0;
+
+  for (const [, featureWorkflows] of byFeature) {
+    if (featureWorkflows.length <= KEEP_TOP_N) {
+      keptByRecency += featureWorkflows.length;
+      continue;
+    }
+
+    // Sort by most recent run (descending). Workflows with no runs go last.
+    featureWorkflows.sort((a, b) => {
+      const aTime = lastRunByWorkflowId.get(a.id) ?? 0;
+      const bTime = lastRunByWorkflowId.get(b.id) ?? 0;
+      return bTime - aTime;
+    });
+
+    const kept = featureWorkflows.slice(0, KEEP_TOP_N);
+    const stale = featureWorkflows.slice(KEEP_TOP_N);
+
+    keptByRecency += kept.length;
+    candidatesForDeprecation.push(...stale);
+  }
+
+  if (candidatesForDeprecation.length === 0) {
+    return { deprecatedCount: 0, keptByRecency, keptByCampaign: 0, skippedNoCampaignService: false };
+  }
+
+  // 5. Check campaign-service for active campaigns
+  let activeSlugs: Set<string>;
+  try {
+    activeSlugs = await fetchActiveWorkflowSlugs();
+  } catch (err) {
+    console.warn(
+      "[workflow-service] Cannot check active campaigns — skipping stale workflow deprecation:",
+      err instanceof Error ? err.message : err,
+    );
+    return {
+      deprecatedCount: 0,
+      keptByRecency,
+      keptByCampaign: 0,
+      skippedNoCampaignService: true,
+    };
+  }
+
+  // 6. Deprecate candidates that are NOT used by an active campaign
+  let deprecatedCount = 0;
+  let keptByCampaign = 0;
+
+  for (const wf of candidatesForDeprecation) {
+    if (activeSlugs.has(wf.slug)) {
+      keptByCampaign++;
+      console.log(
+        `[workflow-service] Keeping stale workflow "${wf.slug}" — active campaign exists`,
+      );
+      continue;
+    }
+
+    await database
+      .update(workflows)
+      .set({ status: "deprecated", updatedAt: new Date() })
+      .where(eq(workflows.id, wf.id));
+
+    deprecatedCount++;
+    console.log(
+      `[workflow-service] Deprecated stale workflow "${wf.slug}" (feature: ${wf.featureSlug}) — not in top ${KEEP_TOP_N} and no active campaign`,
+    );
+  }
+
+  return { deprecatedCount, keptByRecency, keptByCampaign, skippedNoCampaignService: false };
+}

--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -15,6 +15,7 @@ import { pickSignatureName } from "./signature-words.js";
 import type { WindmillClient } from "./windmill-client.js";
 import { fetchPlatformAnthropicKey } from "./key-service-client.js";
 import { createPlatformRun, closePlatformRun } from "./runs-client.js";
+import { deprecateStaleWorkflows } from "./stale-workflow-deprecator.js";
 
 type Database = typeof DbInstance;
 
@@ -40,6 +41,24 @@ export async function validateAndUpgradeWorkflows(
   deps: StartupValidatorDeps,
 ): Promise<void> {
   const { db: database, windmillClient } = deps;
+
+  // 0. Deprecate stale workflows BEFORE validation — avoids paying for LLM upgrades on unused workflows
+  try {
+    const result = await deprecateStaleWorkflows(database);
+    if (result.deprecatedCount > 0) {
+      console.log(
+        `[workflow-service] Stale deprecation: ${result.deprecatedCount} deprecated, ${result.keptByRecency} kept by recency, ${result.keptByCampaign} kept by active campaign`,
+      );
+    }
+    if (result.skippedNoCampaignService) {
+      console.warn("[workflow-service] Stale deprecation skipped — campaign-service unreachable");
+    }
+  } catch (err) {
+    console.warn(
+      "[workflow-service] Stale workflow deprecation failed (non-blocking):",
+      err instanceof Error ? err.message : err,
+    );
+  }
 
   // 1. Fetch all active workflows
   const activeWorkflows = await database

--- a/tests/unit/campaign-client.test.ts
+++ b/tests/unit/campaign-client.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Must set env vars before import
+const ORIGINAL_ENV = { ...process.env };
+
+describe("campaign-client", () => {
+  beforeEach(() => {
+    process.env.CAMPAIGN_SERVICE_URL = "http://localhost:5000";
+    process.env.CAMPAIGN_SERVICE_API_KEY = "test-key";
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  describe("fetchAllCampaigns", () => {
+    it("throws when env vars are missing", async () => {
+      delete process.env.CAMPAIGN_SERVICE_URL;
+      delete process.env.CAMPAIGN_SERVICE_API_KEY;
+
+      const { fetchAllCampaigns } = await import("../../src/lib/campaign-client.js");
+      await expect(fetchAllCampaigns()).rejects.toThrow(
+        "CAMPAIGN_SERVICE_URL and CAMPAIGN_SERVICE_API_KEY must be set",
+      );
+    });
+
+    it("fetches campaigns from campaign-service", async () => {
+      const campaigns = [
+        { id: "c1", workflowSlug: "wf-1", status: "active", toResumeAt: null },
+        { id: "c2", workflowSlug: "wf-2", status: "stopped", toResumeAt: null },
+      ];
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify({ campaigns }), { status: 200 }),
+      );
+
+      const { fetchAllCampaigns } = await import("../../src/lib/campaign-client.js");
+      const result = await fetchAllCampaigns();
+
+      expect(result).toEqual(campaigns);
+      expect(fetch).toHaveBeenCalledWith(
+        "http://localhost:5000/campaigns/list",
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("throws on non-200 response", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response("Internal Server Error", { status: 500, statusText: "Internal Server Error" }),
+      );
+
+      const { fetchAllCampaigns } = await import("../../src/lib/campaign-client.js");
+      await expect(fetchAllCampaigns()).rejects.toThrow("campaign-service error");
+    });
+  });
+
+  describe("fetchActiveWorkflowSlugs", () => {
+    it("returns slugs for active campaigns and campaigns with toResumeAt", async () => {
+      const campaigns = [
+        { id: "c1", workflowSlug: "wf-active", status: "active", toResumeAt: null },
+        { id: "c2", workflowSlug: "wf-stopped", status: "stopped", toResumeAt: null },
+        { id: "c3", workflowSlug: "wf-paused", status: "paused", toResumeAt: "2026-04-01T00:00:00Z" },
+        { id: "c4", workflowSlug: "wf-completed", status: "completed", toResumeAt: null },
+      ];
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify({ campaigns }), { status: 200 }),
+      );
+
+      const { fetchActiveWorkflowSlugs } = await import("../../src/lib/campaign-client.js");
+      const result = await fetchActiveWorkflowSlugs();
+
+      expect(result).toEqual(new Set(["wf-active", "wf-paused"]));
+      expect(result.has("wf-stopped")).toBe(false);
+      expect(result.has("wf-completed")).toBe(false);
+    });
+  });
+});

--- a/tests/unit/stale-workflow-deprecator.test.ts
+++ b/tests/unit/stale-workflow-deprecator.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock campaign client
+const mockFetchActiveWorkflowSlugs = vi.fn();
+vi.mock("../../src/lib/campaign-client.js", () => ({
+  fetchActiveWorkflowSlugs: (...args: unknown[]) => mockFetchActiveWorkflowSlugs(...args),
+}));
+
+// Mock DB
+vi.mock("../../src/db/index.js", () => ({
+  db: "mock-db",
+}));
+
+import { deprecateStaleWorkflows } from "../../src/lib/stale-workflow-deprecator.js";
+
+function makeWorkflow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: overrides.id ?? `wf-${Math.random().toString(36).slice(2, 8)}`,
+    slug: overrides.slug ?? `workflow-${Math.random().toString(36).slice(2, 8)}`,
+    name: overrides.name ?? "Test Workflow",
+    featureSlug: overrides.featureSlug ?? "sales-cold-email",
+    status: "active",
+    orgId: "org-1",
+    ...overrides,
+  };
+}
+
+function createMockDb(activeWorkflows: unknown[], lastRuns: { workflowId: string; lastRun: string }[]) {
+  let selectCallCount = 0;
+
+  const updateWhereMock = vi.fn().mockResolvedValue(undefined);
+  const updateSetMock = vi.fn().mockReturnValue({ where: updateWhereMock });
+  const updateMock = vi.fn().mockReturnValue({ set: updateSetMock });
+
+  const mockDb = {
+    select: vi.fn().mockImplementation(() => {
+      selectCallCount++;
+      const callNum = selectCallCount;
+      return {
+        from: vi.fn().mockImplementation(() => {
+          if (callNum === 1) {
+            // First select: active workflows
+            return { where: vi.fn().mockResolvedValue(activeWorkflows) };
+          }
+          // Second select: last run dates
+          return {
+            where: vi.fn().mockReturnValue({
+              groupBy: vi.fn().mockResolvedValue(
+                lastRuns.map((r) => ({ workflowId: r.workflowId, lastRun: r.lastRun })),
+              ),
+            }),
+          };
+        }),
+      };
+    }),
+    update: updateMock,
+    _updateMock: updateMock,
+    _updateWhereMock: updateWhereMock,
+  };
+
+  return mockDb;
+}
+
+describe("deprecateStaleWorkflows", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockFetchActiveWorkflowSlugs.mockReset();
+  });
+
+  it("returns early with no deprecations when there are no active workflows", async () => {
+    const mockDb = createMockDb([], []);
+    const result = await deprecateStaleWorkflows(mockDb as any);
+
+    expect(result.deprecatedCount).toBe(0);
+    expect(mockFetchActiveWorkflowSlugs).not.toHaveBeenCalled();
+  });
+
+  it("does not deprecate when a feature has <= 3 active workflows", async () => {
+    const wfs = [
+      makeWorkflow({ id: "wf-1", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-2", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-3", featureSlug: "feat-a" }),
+    ];
+    const mockDb = createMockDb(wfs, []);
+    const result = await deprecateStaleWorkflows(mockDb as any);
+
+    expect(result.deprecatedCount).toBe(0);
+    expect(result.keptByRecency).toBe(3);
+    expect(mockFetchActiveWorkflowSlugs).not.toHaveBeenCalled();
+  });
+
+  it("deprecates workflows outside top 3 by recency when no active campaigns", async () => {
+    const wfs = [
+      makeWorkflow({ id: "wf-1", slug: "wf-slug-1", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-2", slug: "wf-slug-2", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-3", slug: "wf-slug-3", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-4", slug: "wf-slug-4", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-5", slug: "wf-slug-5", featureSlug: "feat-a" }),
+    ];
+
+    const lastRuns = [
+      { workflowId: "wf-1", lastRun: "2026-03-30T10:00:00Z" },
+      { workflowId: "wf-2", lastRun: "2026-03-29T10:00:00Z" },
+      { workflowId: "wf-3", lastRun: "2026-03-28T10:00:00Z" },
+      { workflowId: "wf-4", lastRun: "2026-03-27T10:00:00Z" },
+      { workflowId: "wf-5", lastRun: "2026-03-26T10:00:00Z" },
+    ];
+
+    mockFetchActiveWorkflowSlugs.mockResolvedValue(new Set<string>());
+
+    const mockDb = createMockDb(wfs, lastRuns);
+    const result = await deprecateStaleWorkflows(mockDb as any);
+
+    expect(result.deprecatedCount).toBe(2);
+    expect(result.keptByRecency).toBe(3);
+    expect(result.keptByCampaign).toBe(0);
+    expect(mockDb._updateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps stale workflows that are used by active campaigns", async () => {
+    const wfs = [
+      makeWorkflow({ id: "wf-1", slug: "wf-slug-1", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-2", slug: "wf-slug-2", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-3", slug: "wf-slug-3", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-4", slug: "wf-slug-4", featureSlug: "feat-a" }),
+    ];
+
+    const lastRuns = [
+      { workflowId: "wf-1", lastRun: "2026-03-30T10:00:00Z" },
+      { workflowId: "wf-2", lastRun: "2026-03-29T10:00:00Z" },
+      { workflowId: "wf-3", lastRun: "2026-03-28T10:00:00Z" },
+      { workflowId: "wf-4", lastRun: "2026-03-27T10:00:00Z" },
+    ];
+
+    mockFetchActiveWorkflowSlugs.mockResolvedValue(new Set(["wf-slug-4"]));
+
+    const mockDb = createMockDb(wfs, lastRuns);
+    const result = await deprecateStaleWorkflows(mockDb as any);
+
+    expect(result.deprecatedCount).toBe(0);
+    expect(result.keptByCampaign).toBe(1);
+    expect(mockDb._updateMock).not.toHaveBeenCalled();
+  });
+
+  it("skips deprecation when campaign-service is unreachable", async () => {
+    const wfs = [
+      makeWorkflow({ id: "wf-1", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-2", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-3", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-4", featureSlug: "feat-a" }),
+    ];
+
+    const lastRuns = [
+      { workflowId: "wf-1", lastRun: "2026-03-30T10:00:00Z" },
+      { workflowId: "wf-2", lastRun: "2026-03-29T10:00:00Z" },
+      { workflowId: "wf-3", lastRun: "2026-03-28T10:00:00Z" },
+      { workflowId: "wf-4", lastRun: "2026-03-26T10:00:00Z" },
+    ];
+
+    mockFetchActiveWorkflowSlugs.mockRejectedValue(
+      new Error("CAMPAIGN_SERVICE_URL and CAMPAIGN_SERVICE_API_KEY must be set"),
+    );
+
+    const mockDb = createMockDb(wfs, lastRuns);
+    const result = await deprecateStaleWorkflows(mockDb as any);
+
+    expect(result.deprecatedCount).toBe(0);
+    expect(result.skippedNoCampaignService).toBe(true);
+    expect(mockDb._updateMock).not.toHaveBeenCalled();
+  });
+
+  it("handles multiple features independently", async () => {
+    const wfs = [
+      makeWorkflow({ id: "wf-a1", slug: "slug-a1", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-a2", slug: "slug-a2", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-a3", slug: "slug-a3", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-a4", slug: "slug-a4", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-b1", slug: "slug-b1", featureSlug: "feat-b" }),
+      makeWorkflow({ id: "wf-b2", slug: "slug-b2", featureSlug: "feat-b" }),
+    ];
+
+    const lastRuns = [
+      { workflowId: "wf-a1", lastRun: "2026-03-30T10:00:00Z" },
+      { workflowId: "wf-a2", lastRun: "2026-03-29T10:00:00Z" },
+      { workflowId: "wf-a3", lastRun: "2026-03-28T10:00:00Z" },
+      { workflowId: "wf-a4", lastRun: "2026-03-27T10:00:00Z" },
+      { workflowId: "wf-b1", lastRun: "2026-03-30T10:00:00Z" },
+      { workflowId: "wf-b2", lastRun: "2026-03-29T10:00:00Z" },
+    ];
+
+    mockFetchActiveWorkflowSlugs.mockResolvedValue(new Set<string>());
+
+    const mockDb = createMockDb(wfs, lastRuns);
+    const result = await deprecateStaleWorkflows(mockDb as any);
+
+    // Only 1 deprecated (wf-a4 from feat-a). feat-b has only 2
+    expect(result.deprecatedCount).toBe(1);
+    expect(result.keptByRecency).toBe(5); // 3 from feat-a + 2 from feat-b
+  });
+
+  it("workflows with no runs are considered least recent", async () => {
+    const wfs = [
+      makeWorkflow({ id: "wf-1", slug: "slug-1", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-2", slug: "slug-2", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-3", slug: "slug-3", featureSlug: "feat-a" }),
+      makeWorkflow({ id: "wf-no-runs", slug: "slug-no-runs", featureSlug: "feat-a" }),
+    ];
+
+    const lastRuns = [
+      { workflowId: "wf-1", lastRun: "2026-03-30T10:00:00Z" },
+      { workflowId: "wf-2", lastRun: "2026-03-29T10:00:00Z" },
+      { workflowId: "wf-3", lastRun: "2026-03-28T10:00:00Z" },
+    ];
+
+    mockFetchActiveWorkflowSlugs.mockResolvedValue(new Set<string>());
+
+    const mockDb = createMockDb(wfs, lastRuns);
+    const result = await deprecateStaleWorkflows(mockDb as any);
+
+    expect(result.deprecatedCount).toBe(1); // wf-no-runs deprecated
+  });
+});


### PR DESCRIPTION
## Summary
- Before running LLM-powered upgrades, deprecates active workflows that are outside the top 3 most recently used per `feature_slug`
- Workflows used by an active campaign (status=active or toResumeAt non-null) are always kept, regardless of recency
- If campaign-service is unreachable, deprecation is skipped (non-blocking)
- Runs at the start of `validateAndUpgradeWorkflows`, so both startup and SpecWatcher benefit

## New files
- `src/lib/campaign-client.ts` — fetches campaign list from campaign-service to check active workflow usage
- `src/lib/stale-workflow-deprecator.ts` — core deprecation logic (top 3 per feature + campaign check)

## Test plan
- [x] Unit tests for campaign-client (env var validation, fetch, active slug filtering)
- [x] Unit tests for stale-workflow-deprecator (7 cases: empty, ≤3, top-N deprecation, campaign protection, campaign-service down, multi-feature, no-runs)
- [x] Full unit suite passes (365 tests)
- [ ] Requires `CAMPAIGN_SERVICE_URL` and `CAMPAIGN_SERVICE_API_KEY` env vars in Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)