### PR TITLE
fix: dynamic ranking metrics from feature outputs

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1429,12 +1429,7 @@
       },
       "RankedWorkflowObjective": {
         "type": "string",
-        "enum": [
-          "replies",
-          "clicks"
-        ],
-        "default": "replies",
-        "description": "Which metric to optimize for. Defaults to 'replies'."
+        "description": "Stats key to optimize for. When omitted with featureSlug, auto-resolves from the feature's declared output metrics. When omitted without featureSlug, defaults to 'replies' (emailsReplied) for backward compatibility."
       },
       "RankedWorkflowGroupBy": {
         "type": "string",
@@ -1477,29 +1472,21 @@
           "workflowName",
           "createdForBrandId",
           "value"
-        ],
-        "description": "Workflow with the lowest cost per email open. Null if no data."
+        ]
       },
       "BestWorkflowResponse": {
         "type": "object",
         "properties": {
-          "bestCostPerOpen": {
-            "$ref": "#/components/schemas/BestWorkflowRecord"
-          },
-          "bestCostPerReply": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BestWorkflowRecord"
-              },
-              {
-                "description": "Workflow with the lowest cost per reply. Null if no data."
-              }
-            ]
+          "best": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/BestWorkflowRecord"
+            },
+            "description": "Best records keyed by stats metric (e.g. 'emailsReplied', 'emailsOpened'). Each value is the workflow with the lowest cost per that metric, or null if no data."
           }
         },
         "required": [
-          "bestCostPerOpen",
-          "bestCostPerReply"
+          "best"
         ]
       },
       "BestWorkflowBy": {
@@ -3402,7 +3389,7 @@
               "$ref": "#/components/schemas/RankedWorkflowObjective"
             },
             "required": false,
-            "description": "Which metric to optimize for. Defaults to 'replies'.",
+            "description": "Stats key to optimize for. When omitted with featureSlug, auto-resolves from the feature's declared output metrics. When omitted without featureSlug, defaults to 'replies' (emailsReplied) for backward compatibility.",
             "name": "objective",
             "in": "query"
           },
@@ -3564,6 +3551,16 @@
             "required": false,
             "description": "Filter workflows by brand ID.",
             "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature slug and use its declared output metrics for best-record computation."
+            },
+            "required": false,
+            "description": "Filter by feature slug and use its declared output metrics for best-record computation.",
+            "name": "featureSlug",
             "in": "query"
           },
           {
@@ -3921,10 +3918,17 @@
           },
           {
             "schema": {
-              "$ref": "#/components/schemas/RankedWorkflowObjective"
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/RankedWorkflowObjective"
+                },
+                {
+                  "description": "Stats key to optimize for. Defaults to 'replies' (emailsReplied) when omitted."
+                }
+              ]
             },
             "required": false,
-            "description": "Which metric to optimize for. Defaults to 'replies'.",
+            "description": "Stats key to optimize for. Defaults to 'replies' (emailsReplied) when omitted.",
             "name": "objective",
             "in": "query"
           },
@@ -4086,7 +4090,7 @@
               "$ref": "#/components/schemas/RankedWorkflowObjective"
             },
             "required": false,
-            "description": "Which metric to optimize for. Defaults to 'replies'.",
+            "description": "Stats key to optimize for. When omitted with featureSlug, auto-resolves from the feature's declared output metrics. When omitted without featureSlug, defaults to 'replies' (emailsReplied) for backward compatibility.",
             "name": "objective",
             "in": "query"
           },
@@ -4173,6 +4177,16 @@
             "required": false,
             "description": "Filter workflows by brand ID.",
             "name": "brandId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature slug and use its declared output metrics for best-record computation."
+            },
+            "required": false,
+            "description": "Filter by feature slug and use its declared output metrics for best-record computation.",
+            "name": "featureSlug",
             "in": "query"
           },
           {

--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -84,3 +84,81 @@ function deriveFromSlug(featureSlug: string): FeatureDynasty {
 
   return { featureDynastyName: dynastyName, featureDynastySlug: dynastySlug };
 }
+
+// --- Feature outputs (for dynamic ranking metrics) ---
+
+export interface FeatureOutput {
+  key: string;
+  displayOrder: number;
+  defaultSort?: boolean;
+  sortDirection?: "asc" | "desc";
+}
+
+/**
+ * Fetch the outputs array for a feature from features-service.
+ * Throws if features-service is not configured or returns an error.
+ */
+export async function fetchFeatureOutputs(
+  featureSlug: string,
+): Promise<FeatureOutput[]> {
+  const config = getFeaturesServiceConfig();
+  if (!config) {
+    throw new Error(
+      "FEATURES_SERVICE_URL and FEATURES_SERVICE_API_KEY must be set to resolve feature outputs"
+    );
+  }
+
+  const res = await fetch(
+    `${config.baseUrl}/features/${encodeURIComponent(featureSlug)}`,
+    {
+      method: "GET",
+      headers: { "x-api-key": config.apiKey },
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `features-service error: GET /features/${featureSlug} -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  const data = (await res.json()) as { feature: { outputs: FeatureOutput[] } };
+  return data.feature.outputs;
+}
+
+// --- Stats registry ---
+
+export interface StatsRegistryEntry {
+  type: string;
+  label: string;
+}
+
+/**
+ * Fetch the stats key registry from features-service.
+ * Returns a map of stats key → { type, label }.
+ * Throws if features-service is not configured or returns an error.
+ */
+export async function fetchStatsRegistry(): Promise<Record<string, StatsRegistryEntry>> {
+  const config = getFeaturesServiceConfig();
+  if (!config) {
+    throw new Error(
+      "FEATURES_SERVICE_URL and FEATURES_SERVICE_API_KEY must be set to fetch stats registry"
+    );
+  }
+
+  const res = await fetch(`${config.baseUrl}/stats/registry`, {
+    method: "GET",
+    headers: { "x-api-key": config.apiKey },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `features-service error: GET /stats/registry -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  const data = (await res.json()) as { registry: Record<string, StatsRegistryEntry> };
+  return data.registry;
+}

--- a/src/lib/workflow-scoring.ts
+++ b/src/lib/workflow-scoring.ts
@@ -9,6 +9,64 @@ export const EMPTY_EMAIL_STATS = {
   replied: 0, bounced: 0, unsubscribed: 0, recipients: 0,
 };
 
+/**
+ * Maps stats registry keys (from features-service) to email stats field names.
+ * These are the count-type metrics that can be used as ranking objectives.
+ */
+const STATS_KEY_TO_EMAIL_FIELD: Record<string, keyof typeof EMPTY_EMAIL_STATS> = {
+  emailsSent: "sent",
+  emailsDelivered: "delivered",
+  emailsOpened: "opened",
+  emailsClicked: "clicked",
+  emailsReplied: "replied",
+  emailsBounced: "bounced",
+  recipients: "recipients",
+};
+
+/** Backward-compat aliases for the legacy "replies" | "clicks" objective values. */
+const OBJECTIVE_ALIASES: Record<string, string> = {
+  replies: "emailsReplied",
+  clicks: "emailsClicked",
+};
+
+/** Resolves a legacy alias to its stats key, or returns the key unchanged. */
+export function resolveObjective(objective: string): string {
+  return OBJECTIVE_ALIASES[objective] ?? objective;
+}
+
+/**
+ * Extracts the outcome count for a given stats key from aggregated email stats.
+ * Sums transactional + broadcast counts. Throws if the key is unknown.
+ */
+export function extractOutcomeCount(
+  statsKey: string,
+  emailStats: { transactional: typeof EMPTY_EMAIL_STATS; broadcast: typeof EMPTY_EMAIL_STATS },
+): number {
+  const field = STATS_KEY_TO_EMAIL_FIELD[statsKey];
+  if (!field) {
+    throw new Error(
+      `Unknown objective metric: "${statsKey}". Known email stats keys: ${Object.keys(STATS_KEY_TO_EMAIL_FIELD).join(", ")}`
+    );
+  }
+  return emailStats.transactional[field] + emailStats.broadcast[field];
+}
+
+/**
+ * Re-computes outcomes and costPerOutcome for a different objective without re-fetching data.
+ * Use this to produce per-metric rankings from a single computeWorkflowScores call.
+ */
+export function rescoreForObjective(scores: WorkflowScore[], objective: string): WorkflowScore[] {
+  const resolved = resolveObjective(objective);
+  return scores.map((s) => {
+    const outcomes = extractOutcomeCount(resolved, s.emailStats);
+    return {
+      ...s,
+      totalOutcomes: outcomes,
+      costPerOutcome: outcomes > 0 ? s.totalCost / outcomes : null,
+    };
+  });
+}
+
 export interface WorkflowScore {
   workflow: typeof workflows.$inferSelect;
   totalCost: number;
@@ -64,7 +122,7 @@ export interface ScoreResult {
 export async function computeWorkflowScores(
   activeWorkflows: (typeof workflows.$inferSelect)[],
   deprecatedWorkflows: (typeof workflows.$inferSelect)[],
-  objective: "replies" | "clicks",
+  objective: string,
   mode: ScoreMode,
 ): Promise<ScoreResult> {
   // 1. Build dynasty chains: for each active workflow, collect all workflow names in its upgrade chain
@@ -141,10 +199,8 @@ export async function computeWorkflowScores(
     }
     workflowRunsByWfId[wf.id] = runIds;
 
-    const outcomes =
-      objective === "replies"
-        ? transactional.replied + broadcast.replied
-        : transactional.clicked + broadcast.clicked;
+    const resolvedObjective = resolveObjective(objective);
+    const outcomes = extractOutcomeCount(resolvedObjective, { transactional, broadcast });
 
     const costPerOutcome = outcomes > 0 ? totalCost / outcomes : null;
 

--- a/src/routes/public-workflows.ts
+++ b/src/routes/public-workflows.ts
@@ -9,13 +9,38 @@ import {
 import {
   computeWorkflowScores,
   rankScores,
+  rescoreForObjective,
   formatPublicScoreItem,
   aggregateSectionStats,
   handleExternalServiceError,
   type WorkflowScore,
 } from "../lib/workflow-scoring.js";
+import { fetchFeatureOutputs, fetchStatsRegistry } from "../lib/features-client.js";
 
 const router = Router();
+
+const DEFAULT_OBJECTIVES = ["emailsReplied"];
+
+async function resolveObjectives(
+  objective: string | undefined,
+  featureSlug: string | undefined,
+): Promise<string[]> {
+  if (objective) return [objective];
+  if (featureSlug) {
+    const [outputs, registry] = await Promise.all([
+      fetchFeatureOutputs(featureSlug),
+      fetchStatsRegistry(),
+    ]);
+    const countMetrics = outputs
+      .map((o) => o.key)
+      .filter((key) => {
+        const entry = registry[key];
+        return entry && entry.type === "count";
+      });
+    if (countMetrics.length > 0) return countMetrics;
+  }
+  return DEFAULT_OBJECTIVES;
+}
 
 // GET /public/workflows/ranked — Public ranked workflows (no auth, no DAG)
 router.get("/public/workflows/ranked", async (req, res) => {
@@ -42,8 +67,21 @@ router.get("/public/workflows/ranked", async (req, res) => {
       return;
     }
 
-    // Slug-level stats only — no dynasty chain aggregation
-    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objective, { kind: "public" as const, brandId, orgId });
+    const objectives = await resolveObjectives(objective, featureSlug);
+    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objectives[0], { kind: "public" as const, brandId, orgId });
+
+    function rankForObjectives(inputScores: WorkflowScore[]) {
+      if (objectives.length === 1) {
+        const rescored = rescoreForObjective(inputScores, objectives[0]);
+        return rankScores(rescored).slice(0, limit).map(formatPublicScoreItem);
+      }
+      const rankings: Record<string, ReturnType<typeof formatPublicScoreItem>[]> = {};
+      for (const obj of objectives) {
+        const rescored = rescoreForObjective(inputScores, obj);
+        rankings[obj] = rankScores(rescored).slice(0, limit).map(formatPublicScoreItem);
+      }
+      return rankings;
+    }
 
     if (groupBy === "feature") {
       const featureMap = new Map<string, WorkflowScore[]>();
@@ -54,18 +92,14 @@ router.get("/public/workflows/ranked", async (req, res) => {
         featureMap.set(key, arr);
       }
 
-      const features = [...featureMap.entries()].map(([featureSlug, featureScores]) => {
-        const ranked = rankScores(featureScores).slice(0, limit);
-        return {
-          featureSlug,
-          stats: aggregateSectionStats(featureScores),
-          workflows: ranked.map(formatPublicScoreItem),
-        };
-      });
+      const features = [...featureMap.entries()].map(([featureSlug, featureScores]) => ({
+        featureSlug,
+        stats: aggregateSectionStats(featureScores),
+        workflows: rankForObjectives(featureScores),
+      }));
 
       res.json({ features });
     } else if (groupBy === "brand") {
-      // Group by brandId from runs
       const brandRunIds = new Map<string, Set<string>>();
       const brandWorkflowIds = new Map<string, Set<string>>();
 
@@ -91,13 +125,12 @@ router.get("/public/workflows/ranked", async (req, res) => {
         return {
           brandId: bId,
           stats: aggregateSectionStats(brandScores),
-          workflows: rankScores(brandScores).slice(0, limit).map(formatPublicScoreItem),
+          workflows: rankForObjectives(brandScores),
         };
       });
 
       res.json({ brands });
     } else {
-      // If brandId filter is set, only include workflows that have runs for that brand
       let filteredScores = scores;
       if (brandId) {
         const wfIdsForBrand = new Set<string>();
@@ -112,8 +145,19 @@ router.get("/public/workflows/ranked", async (req, res) => {
         }
         filteredScores = scores.filter((s) => wfIdsForBrand.has(s.workflow.id));
       }
-      const ranked = rankScores(filteredScores).slice(0, limit);
-      res.json({ results: ranked.map(formatPublicScoreItem) });
+
+      if (objectives.length === 1) {
+        const rescored = rescoreForObjective(filteredScores, objectives[0]);
+        const ranked = rankScores(rescored).slice(0, limit);
+        res.json({ results: ranked.map(formatPublicScoreItem) });
+      } else {
+        const rankings: Record<string, ReturnType<typeof formatPublicScoreItem>[]> = {};
+        for (const obj of objectives) {
+          const rescored = rescoreForObjective(filteredScores, obj);
+          rankings[obj] = rankScores(rescored).slice(0, limit).map(formatPublicScoreItem);
+        }
+        res.json({ rankings });
+      }
     }
   } catch (err: unknown) {
     if (!handleExternalServiceError(err, res, "public/ranked")) {
@@ -123,7 +167,7 @@ router.get("/public/workflows/ranked", async (req, res) => {
   }
 });
 
-// GET /public/workflows/best — Public hero records (no auth, no DAG)
+// GET /public/workflows/best — Public hero records: best cost-per-metric
 router.get("/public/workflows/best", async (req, res) => {
   try {
     const query = BestWorkflowQuerySchema.safeParse(req.query);
@@ -131,10 +175,13 @@ router.get("/public/workflows/best", async (req, res) => {
       res.status(400).json({ error: "Validation error", details: query.error });
       return;
     }
-    const { orgId, brandId, by } = query.data;
+    const { orgId, brandId, featureSlug, by } = query.data;
+
+    const objectives = await resolveObjectives(undefined, featureSlug);
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
+    if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
 
     const allMatchingWorkflows = conditions.length > 0
       ? await db.select().from(workflows).where(and(...conditions))
@@ -143,15 +190,15 @@ router.get("/public/workflows/best", async (req, res) => {
     const activeWorkflows = allMatchingWorkflows.filter((w) => w.status === "active");
 
     if (activeWorkflows.length === 0) {
-      res.json({ bestCostPerOpen: null, bestCostPerReply: null });
+      const best: Record<string, null> = {};
+      for (const obj of objectives) best[obj] = null;
+      res.json({ best });
       return;
     }
 
-    // Slug-level stats only — no dynasty chain aggregation
-    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], "replies", { kind: "public" as const, brandId, orgId });
+    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objectives[0], { kind: "public" as const, brandId, orgId });
 
     if (by === "brand") {
-      // Aggregate by brandId from runs
       const brandScoresMap = new Map<string, WorkflowScore[]>();
       for (const s of scores) {
         const runIds = workflowRunIds[s.workflow.id] ?? [];
@@ -170,78 +217,53 @@ router.get("/public/workflows/best", async (req, res) => {
         ? [...brandScoresMap.entries()].filter(([bId]) => bId === brandId)
         : [...brandScoresMap.entries()];
 
-      let bestCostPerOpen: { brandId: string; workflowCount: number; value: number } | null = null;
-      let bestCostPerReply: { brandId: string; workflowCount: number; value: number } | null = null;
-
-      for (const [bId, brandScores] of brandEntries) {
-        const totalCost = brandScores.reduce((s, e) => s + e.totalCost, 0);
-        const hasRuns = brandScores.some((s) => s.completedRuns > 0);
-        if (!hasRuns) continue;
-
-        const totalOpened = brandScores.reduce(
-          (s, e) => s + e.emailStats.transactional.opened + e.emailStats.broadcast.opened,
-          0,
-        );
-        if (totalOpened > 0) {
-          const costPerOpen = totalCost / totalOpened;
-          if (!bestCostPerOpen || costPerOpen < bestCostPerOpen.value) {
-            bestCostPerOpen = { brandId: bId, workflowCount: brandScores.length, value: Math.round(costPerOpen * 100) / 100 };
+      const best: Record<string, { brandId: string; workflowCount: number; value: number } | null> = {};
+      for (const obj of objectives) {
+        let bestForMetric: { brandId: string; workflowCount: number; value: number } | null = null;
+        for (const [bId, brandScores] of brandEntries) {
+          const totalCost = brandScores.reduce((s, e) => s + e.totalCost, 0);
+          const hasRuns = brandScores.some((s) => s.completedRuns > 0);
+          if (!hasRuns) continue;
+          const rescored = rescoreForObjective(brandScores, obj);
+          const totalOutcomes = rescored.reduce((s, e) => s + e.totalOutcomes, 0);
+          if (totalOutcomes > 0) {
+            const costPer = totalCost / totalOutcomes;
+            if (!bestForMetric || costPer < bestForMetric.value) {
+              bestForMetric = { brandId: bId, workflowCount: brandScores.length, value: Math.round(costPer * 100) / 100 };
+            }
           }
         }
-
-        const totalReplied = brandScores.reduce(
-          (s, e) => s + e.emailStats.transactional.replied + e.emailStats.broadcast.replied,
-          0,
-        );
-        if (totalReplied > 0) {
-          const costPerReply = totalCost / totalReplied;
-          if (!bestCostPerReply || costPerReply < bestCostPerReply.value) {
-            bestCostPerReply = { brandId: bId, workflowCount: brandScores.length, value: Math.round(costPerReply * 100) / 100 };
-          }
-        }
+        best[obj] = bestForMetric;
       }
 
-      res.json({ bestCostPerOpen, bestCostPerReply });
+      res.json({ best });
     } else {
-      // by=workflow (default)
-      let bestCostPerOpen: { score: WorkflowScore; value: number } | null = null;
-      let bestCostPerReply: { score: WorkflowScore; value: number } | null = null;
+      const best: Record<string, { workflowId: string; workflowSlug: string; workflowName: string; createdForBrandId: string | null; value: number } | null> = {};
 
-      for (const s of scores) {
-        if (s.completedRuns === 0) continue;
-
-        const totalOpened = s.emailStats.transactional.opened + s.emailStats.broadcast.opened;
-        if (totalOpened > 0) {
-          const costPerOpen = s.totalCost / totalOpened;
-          if (!bestCostPerOpen || costPerOpen < bestCostPerOpen.value) {
-            bestCostPerOpen = { score: s, value: costPerOpen };
+      for (const obj of objectives) {
+        let bestForMetric: { score: WorkflowScore; value: number } | null = null;
+        const rescored = rescoreForObjective(scores, obj);
+        for (const s of rescored) {
+          if (s.completedRuns === 0) continue;
+          if (s.totalOutcomes > 0) {
+            const costPer = s.totalCost / s.totalOutcomes;
+            if (!bestForMetric || costPer < bestForMetric.value) {
+              bestForMetric = { score: s, value: costPer };
+            }
           }
         }
-
-        const totalReplied = s.emailStats.transactional.replied + s.emailStats.broadcast.replied;
-        if (totalReplied > 0) {
-          const costPerReply = s.totalCost / totalReplied;
-          if (!bestCostPerReply || costPerReply < bestCostPerReply.value) {
-            bestCostPerReply = { score: s, value: costPerReply };
-          }
-        }
+        best[obj] = bestForMetric
+          ? {
+              workflowId: bestForMetric.score.workflow.id,
+              workflowSlug: bestForMetric.score.workflow.slug,
+              workflowName: bestForMetric.score.workflow.name,
+              createdForBrandId: bestForMetric.score.workflow.createdForBrandId,
+              value: Math.round(bestForMetric.value * 100) / 100,
+            }
+          : null;
       }
 
-      function formatRecord(entry: { score: WorkflowScore; value: number } | null) {
-        if (!entry) return null;
-        return {
-          workflowId: entry.score.workflow.id,
-          workflowSlug: entry.score.workflow.slug,
-          workflowName: entry.score.workflow.name,
-          createdForBrandId: entry.score.workflow.createdForBrandId,
-          value: Math.round(entry.value * 100) / 100,
-        };
-      }
-
-      res.json({
-        bestCostPerOpen: formatRecord(bestCostPerOpen),
-        bestCostPerReply: formatRecord(bestCostPerReply),
-      });
+      res.json({ best });
     }
   } catch (err: unknown) {
     if (!handleExternalServiceError(err, res, "public/best")) {

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -35,14 +35,47 @@ import {
   getUpgradeChainIds,
   computeWorkflowScores,
   rankScores,
+  rescoreForObjective,
   formatScoreItem,
   aggregateSectionStats,
   handleExternalServiceError,
   type WorkflowScore,
 } from "../lib/workflow-scoring.js";
-import { resolveFeatureDynasty } from "../lib/features-client.js";
+import { resolveFeatureDynasty, fetchFeatureOutputs, fetchStatsRegistry } from "../lib/features-client.js";
 
 const router = Router();
+
+/** Default metrics when feature outputs can't be resolved or no featureSlug is provided. */
+const DEFAULT_OBJECTIVES = ["emailsReplied"];
+
+/**
+ * Resolves which stats keys to use as ranking objectives.
+ * - If explicit objective is provided, use it alone.
+ * - If featureSlug is provided, fetch its outputs and filter to count-type metrics.
+ * - Otherwise, fall back to DEFAULT_OBJECTIVES.
+ */
+async function resolveObjectives(
+  objective: string | undefined,
+  featureSlug: string | undefined,
+): Promise<string[]> {
+  if (objective) return [objective];
+
+  if (featureSlug) {
+    const [outputs, registry] = await Promise.all([
+      fetchFeatureOutputs(featureSlug),
+      fetchStatsRegistry(),
+    ]);
+    const countMetrics = outputs
+      .map((o) => o.key)
+      .filter((key) => {
+        const entry = registry[key];
+        return entry && entry.type === "count";
+      });
+    if (countMetrics.length > 0) return countMetrics;
+  }
+
+  return DEFAULT_OBJECTIVES;
+}
 
 function formatWorkflow(w: typeof workflows.$inferSelect) {
   return {
@@ -828,8 +861,27 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
       return;
     }
 
-    // Slug-level stats only — no dynasty chain aggregation
-    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objective, { kind: "auth", identity });
+    // Resolve which metrics to rank by (from feature outputs or explicit objective)
+    const objectives = await resolveObjectives(objective, featureSlug);
+
+    // Fetch base scores once — objective only affects outcome computation, which we re-score per metric
+    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objectives[0], { kind: "auth", identity });
+
+    // Helper: produce rankings for a given set of scores across all objectives
+    function rankForObjectives(inputScores: WorkflowScore[]) {
+      if (objectives.length === 1) {
+        // Single objective — re-score if needed, return flat ranked list
+        const rescored = rescoreForObjective(inputScores, objectives[0]);
+        return rankScores(rescored).slice(0, limit).map(formatScoreItem);
+      }
+      // Multiple objectives — return per-metric rankings
+      const rankings: Record<string, ReturnType<typeof formatScoreItem>[]> = {};
+      for (const obj of objectives) {
+        const rescored = rescoreForObjective(inputScores, obj);
+        rankings[obj] = rankScores(rescored).slice(0, limit).map(formatScoreItem);
+      }
+      return rankings;
+    }
 
     if (groupBy === "feature") {
       // Group by featureSlug
@@ -841,14 +893,11 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
         featureMap.set(key, arr);
       }
 
-      const features = [...featureMap.entries()].map(([featureSlug, featureScores]) => {
-        const ranked = rankScores(featureScores).slice(0, limit);
-        return {
-          featureSlug,
-          stats: aggregateSectionStats(featureScores),
-          workflows: ranked.map(formatScoreItem),
-        };
-      });
+      const features = [...featureMap.entries()].map(([featureSlug, featureScores]) => ({
+        featureSlug,
+        stats: aggregateSectionStats(featureScores),
+        workflows: rankForObjectives(featureScores),
+      }));
 
       res.json({ features });
     } else if (groupBy === "brand") {
@@ -873,13 +922,13 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
         ? [...brandRunIds.entries()].filter(([bId]) => bId === brandId)
         : [...brandRunIds.entries()];
 
-      const brands = brandEntries.map(([bId, runIdSet]) => {
+      const brands = brandEntries.map(([bId]) => {
         const wfIds = brandWorkflowIds.get(bId)!;
         const brandScores = scores.filter((s) => wfIds.has(s.workflow.id));
         return {
           brandId: bId,
           stats: aggregateSectionStats(brandScores),
-          workflows: rankScores(brandScores).slice(0, limit).map(formatScoreItem),
+          workflows: rankForObjectives(brandScores),
         };
       });
 
@@ -900,8 +949,19 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
         }
         filteredScores = scores.filter((s) => wfIdsForBrand.has(s.workflow.id));
       }
-      const ranked = rankScores(filteredScores).slice(0, limit);
-      res.json({ results: ranked.map(formatScoreItem) });
+
+      if (objectives.length === 1) {
+        const rescored = rescoreForObjective(filteredScores, objectives[0]);
+        const ranked = rankScores(rescored).slice(0, limit);
+        res.json({ results: ranked.map(formatScoreItem) });
+      } else {
+        const rankings: Record<string, ReturnType<typeof formatScoreItem>[]> = {};
+        for (const obj of objectives) {
+          const rescored = rescoreForObjective(filteredScores, obj);
+          rankings[obj] = rankScores(rescored).slice(0, limit).map(formatScoreItem);
+        }
+        res.json({ rankings });
+      }
     }
   } catch (err: unknown) {
     if (!handleExternalServiceError(err, res, "ranked")) {
@@ -911,7 +971,7 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
   }
 });
 
-// GET /workflows/best — Hero records: best cost-per-open and best cost-per-reply
+// GET /workflows/best — Hero records: best cost-per-metric for each feature output metric
 router.get("/workflows/best", requireApiKey, async (req, res) => {
   try {
     const query = BestWorkflowQuerySchema.safeParse(req.query);
@@ -919,15 +979,19 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
       res.status(400).json({ error: "Validation error", details: query.error });
       return;
     }
-    const { orgId, brandId, by } = query.data;
+    const { orgId, brandId, featureSlug, by } = query.data;
     const identity = {
       orgId: res.locals.orgId as string,
       userId: res.locals.userId as string,
       runId: res.locals.runId as string,
     };
 
+    // Resolve which metrics to compute best records for
+    const objectives = await resolveObjectives(undefined, featureSlug);
+
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
+    if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
 
     const allMatchingWorkflows = conditions.length > 0
       ? await db.select().from(workflows).where(and(...conditions))
@@ -936,15 +1000,17 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
     const activeWorkflows = allMatchingWorkflows.filter((w) => w.status === "active");
 
     if (activeWorkflows.length === 0) {
-      res.json({ bestCostPerOpen: null, bestCostPerReply: null });
+      const best: Record<string, null> = {};
+      for (const obj of objectives) best[obj] = null;
+      res.json({ best });
       return;
     }
 
     // Slug-level stats only — no dynasty chain aggregation
-    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], "replies", { kind: "auth", identity });
+    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objectives[0], { kind: "auth", identity });
 
     if (by === "brand") {
-      // Aggregate by brandId from runs, find the best brand for cost-per-open and cost-per-reply
+      // Aggregate by brandId from runs
       const brandScoresMap = new Map<string, WorkflowScore[]>();
       for (const s of scores) {
         const runIds = workflowRunIds[s.workflow.id] ?? [];
@@ -952,7 +1018,6 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
           const bId = runBrandMap.get(runId);
           if (!bId) continue;
           if (!brandScoresMap.has(bId)) brandScoresMap.set(bId, []);
-          // Add workflow to brand group (deduplicate)
           const arr = brandScoresMap.get(bId)!;
           if (!arr.some((existing) => existing.workflow.id === s.workflow.id)) {
             arr.push(s);
@@ -960,83 +1025,63 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
         }
       }
 
-      // If brandId filter is set, only consider that brand
       const brandEntries = brandId
         ? [...brandScoresMap.entries()].filter(([bId]) => bId === brandId)
         : [...brandScoresMap.entries()];
 
-      let bestCostPerOpen: { brandId: string; workflowCount: number; value: number } | null = null;
-      let bestCostPerReply: { brandId: string; workflowCount: number; value: number } | null = null;
+      const best: Record<string, { brandId: string; workflowCount: number; value: number } | null> = {};
+      for (const obj of objectives) {
+        let bestForMetric: { brandId: string; workflowCount: number; value: number } | null = null;
 
-      for (const [bId, brandScores] of brandEntries) {
-        const totalCost = brandScores.reduce((s, e) => s + e.totalCost, 0);
-        const hasRuns = brandScores.some((s) => s.completedRuns > 0);
-        if (!hasRuns) continue;
+        for (const [bId, brandScores] of brandEntries) {
+          const totalCost = brandScores.reduce((s, e) => s + e.totalCost, 0);
+          const hasRuns = brandScores.some((s) => s.completedRuns > 0);
+          if (!hasRuns) continue;
 
-        const totalOpened = brandScores.reduce(
-          (s, e) => s + e.emailStats.transactional.opened + e.emailStats.broadcast.opened,
-          0,
-        );
-        if (totalOpened > 0) {
-          const costPerOpen = totalCost / totalOpened;
-          if (!bestCostPerOpen || costPerOpen < bestCostPerOpen.value) {
-            bestCostPerOpen = { brandId: bId, workflowCount: brandScores.length, value: Math.round(costPerOpen * 100) / 100 };
+          const rescored = rescoreForObjective(brandScores, obj);
+          const totalOutcomes = rescored.reduce((s, e) => s + e.totalOutcomes, 0);
+          if (totalOutcomes > 0) {
+            const costPer = totalCost / totalOutcomes;
+            if (!bestForMetric || costPer < bestForMetric.value) {
+              bestForMetric = { brandId: bId, workflowCount: brandScores.length, value: Math.round(costPer * 100) / 100 };
+            }
           }
         }
 
-        const totalReplied = brandScores.reduce(
-          (s, e) => s + e.emailStats.transactional.replied + e.emailStats.broadcast.replied,
-          0,
-        );
-        if (totalReplied > 0) {
-          const costPerReply = totalCost / totalReplied;
-          if (!bestCostPerReply || costPerReply < bestCostPerReply.value) {
-            bestCostPerReply = { brandId: bId, workflowCount: brandScores.length, value: Math.round(costPerReply * 100) / 100 };
-          }
-        }
+        best[obj] = bestForMetric;
       }
 
-      res.json({ bestCostPerOpen, bestCostPerReply });
+      res.json({ best });
     } else {
-      // by=workflow (default) — existing behavior
-      let bestCostPerOpen: { score: WorkflowScore; value: number } | null = null;
-      let bestCostPerReply: { score: WorkflowScore; value: number } | null = null;
+      // by=workflow (default)
+      const best: Record<string, { workflowId: string; workflowSlug: string; workflowName: string; createdForBrandId: string | null; value: number } | null> = {};
 
-      for (const s of scores) {
-        if (s.completedRuns === 0) continue;
+      for (const obj of objectives) {
+        let bestForMetric: { score: WorkflowScore; value: number } | null = null;
+        const rescored = rescoreForObjective(scores, obj);
 
-        const totalOpened = s.emailStats.transactional.opened + s.emailStats.broadcast.opened;
-        if (totalOpened > 0) {
-          const costPerOpen = s.totalCost / totalOpened;
-          if (!bestCostPerOpen || costPerOpen < bestCostPerOpen.value) {
-            bestCostPerOpen = { score: s, value: costPerOpen };
+        for (const s of rescored) {
+          if (s.completedRuns === 0) continue;
+          if (s.totalOutcomes > 0) {
+            const costPer = s.totalCost / s.totalOutcomes;
+            if (!bestForMetric || costPer < bestForMetric.value) {
+              bestForMetric = { score: s, value: costPer };
+            }
           }
         }
 
-        const totalReplied = s.emailStats.transactional.replied + s.emailStats.broadcast.replied;
-        if (totalReplied > 0) {
-          const costPerReply = s.totalCost / totalReplied;
-          if (!bestCostPerReply || costPerReply < bestCostPerReply.value) {
-            bestCostPerReply = { score: s, value: costPerReply };
-          }
-        }
+        best[obj] = bestForMetric
+          ? {
+              workflowId: bestForMetric.score.workflow.id,
+              workflowSlug: bestForMetric.score.workflow.slug,
+              workflowName: bestForMetric.score.workflow.name,
+              createdForBrandId: bestForMetric.score.workflow.createdForBrandId,
+              value: Math.round(bestForMetric.value * 100) / 100,
+            }
+          : null;
       }
 
-      function formatRecord(entry: { score: WorkflowScore; value: number } | null) {
-        if (!entry) return null;
-        return {
-          workflowId: entry.score.workflow.id,
-          workflowSlug: entry.score.workflow.slug,
-          workflowName: entry.score.workflow.name,
-          createdForBrandId: entry.score.workflow.createdForBrandId,
-          value: Math.round(entry.value * 100) / 100,
-        };
-      }
-
-      res.json({
-        bestCostPerOpen: formatRecord(bestCostPerOpen),
-        bestCostPerReply: formatRecord(bestCostPerReply),
-      });
+      res.json({ best });
     }
   } catch (err: unknown) {
     if (!handleExternalServiceError(err, res, "best")) {
@@ -1116,8 +1161,7 @@ router.get("/workflows/dynasty/stats", requireApiKey, async (req, res) => {
     }
 
     const objectiveParam = req.query.objective;
-    const objectiveResult = RankedWorkflowObjectiveSchema.safeParse(objectiveParam ?? "replies");
-    const objective = objectiveResult.success ? objectiveResult.data : "replies" as const;
+    const objective = (typeof objectiveParam === "string" && objectiveParam) ? objectiveParam : "replies";
 
     const identity = {
       orgId: res.locals.orgId as string,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -597,9 +597,11 @@ export const WorkflowMetadataSchema = z
 // --- Ranked Workflow schemas ---
 
 export const RankedWorkflowObjectiveSchema = z
-  .enum(["replies", "clicks"])
+  .string()
   .describe(
-    'Optimization objective. "replies" sorts by lowest cost per reply; "clicks" sorts by lowest cost per click.'
+    'Stats key to optimize for (e.g. "emailsReplied", "emailsClicked", "emailsOpened"). ' +
+    'Legacy values "replies" and "clicks" are still supported as aliases. ' +
+    'When featureSlug is provided and objective is omitted, the feature\'s declared output metrics are used automatically.'
   )
   .openapi("RankedWorkflowObjective");
 
@@ -617,7 +619,10 @@ export const RankedWorkflowQuerySchema = z
     orgId: z.string().optional().describe("Organization ID. When omitted, searches across all orgs."),
     brandId: z.string().optional().describe("Filter workflows by brand ID."),
     featureSlug: z.string().optional().describe("Filter workflows by feature slug."),
-    objective: RankedWorkflowObjectiveSchema.default("replies").describe("Which metric to optimize for. Defaults to 'replies'."),
+    objective: RankedWorkflowObjectiveSchema.optional().describe(
+      "Stats key to optimize for. When omitted with featureSlug, auto-resolves from the feature's declared output metrics. " +
+      "When omitted without featureSlug, defaults to 'replies' (emailsReplied) for backward compatibility."
+    ),
     limit: z.coerce.number().int().min(1).max(100).default(10).describe("Max workflows per group (when groupBy is set) or total (when flat). Defaults to 10."),
     groupBy: RankedWorkflowGroupBySchema.optional().describe("Group results by section or brand. When omitted, returns a flat ranked list."),
   })
@@ -705,6 +710,7 @@ export const BestWorkflowQuerySchema = z
   .object({
     orgId: z.string().optional().describe("Organization ID. When omitted, searches across all orgs."),
     brandId: z.string().optional().describe("Filter workflows by brand ID."),
+    featureSlug: z.string().optional().describe("Filter by feature slug and use its declared output metrics for best-record computation."),
     by: BestWorkflowBySchema.default("workflow").describe("Granularity: best workflow or best brand. Defaults to 'workflow'."),
   })
   .openapi("BestWorkflowQuery");
@@ -729,15 +735,21 @@ export const BestBrandRecordSchema = z
 
 export const BestWorkflowResponseSchema = z
   .object({
-    bestCostPerOpen: BestWorkflowRecordSchema.nullable().describe("Workflow with the lowest cost per email open. Null if no data."),
-    bestCostPerReply: BestWorkflowRecordSchema.nullable().describe("Workflow with the lowest cost per reply. Null if no data."),
+    best: z.record(z.string(), BestWorkflowRecordSchema.nullable())
+      .describe(
+        "Best records keyed by stats metric (e.g. 'emailsReplied', 'emailsOpened'). " +
+        "Each value is the workflow with the lowest cost per that metric, or null if no data."
+      ),
   })
   .openapi("BestWorkflowResponse");
 
 export const BestBrandResponseSchema = z
   .object({
-    bestCostPerOpen: BestBrandRecordSchema.nullable().describe("Brand with the lowest cost per email open. Null if no data."),
-    bestCostPerReply: BestBrandRecordSchema.nullable().describe("Brand with the lowest cost per reply. Null if no data."),
+    best: z.record(z.string(), BestBrandRecordSchema.nullable())
+      .describe(
+        "Best records keyed by stats metric (e.g. 'emailsReplied', 'emailsOpened'). " +
+        "Each value is the brand with the lowest cost per that metric, or null if no data."
+      ),
   })
   .openapi("BestBrandResponse");
 
@@ -1379,7 +1391,7 @@ registry.registerPath({
     headers: IdentityHeaders,
     query: z.object({
       dynastySlug: z.string().describe("The dynasty slug to get stats for."),
-      objective: RankedWorkflowObjectiveSchema.default("replies").describe("Which metric to optimize for. Defaults to 'replies'."),
+      objective: RankedWorkflowObjectiveSchema.optional().describe("Stats key to optimize for. Defaults to 'replies' (emailsReplied) when omitted."),
     }),
   },
   responses: {

--- a/tests/unit/workflow-scoring.test.ts
+++ b/tests/unit/workflow-scoring.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveObjective,
+  extractOutcomeCount,
+  rescoreForObjective,
+  EMPTY_EMAIL_STATS,
+  type WorkflowScore,
+} from "../../src/lib/workflow-scoring.js";
+
+const makeEmailStats = (overrides: Partial<typeof EMPTY_EMAIL_STATS> = {}) => ({
+  ...EMPTY_EMAIL_STATS,
+  ...overrides,
+});
+
+function makeScore(opts: {
+  totalCost: number;
+  completedRuns: number;
+  transactional?: Partial<typeof EMPTY_EMAIL_STATS>;
+  broadcast?: Partial<typeof EMPTY_EMAIL_STATS>;
+}): WorkflowScore {
+  return {
+    workflow: {
+      id: "wf-1",
+      slug: "test-wf",
+      name: "Test Workflow",
+      dynastyName: "Test",
+      dynastySlug: "test",
+      version: 1,
+      createdForBrandId: null,
+      featureSlug: "feature-a",
+      signature: "abc",
+      signatureName: "alpha",
+    } as WorkflowScore["workflow"],
+    totalCost: opts.totalCost,
+    totalOutcomes: 0,
+    costPerOutcome: null,
+    completedRuns: opts.completedRuns,
+    emailStats: {
+      transactional: makeEmailStats(opts.transactional),
+      broadcast: makeEmailStats(opts.broadcast),
+    },
+  };
+}
+
+describe("resolveObjective", () => {
+  it("resolves 'replies' alias to 'emailsReplied'", () => {
+    expect(resolveObjective("replies")).toBe("emailsReplied");
+  });
+
+  it("resolves 'clicks' alias to 'emailsClicked'", () => {
+    expect(resolveObjective("clicks")).toBe("emailsClicked");
+  });
+
+  it("passes through native stats keys unchanged", () => {
+    expect(resolveObjective("emailsOpened")).toBe("emailsOpened");
+    expect(resolveObjective("emailsSent")).toBe("emailsSent");
+    expect(resolveObjective("recipients")).toBe("recipients");
+  });
+});
+
+describe("extractOutcomeCount", () => {
+  it("extracts emailsReplied from transactional + broadcast", () => {
+    const stats = {
+      transactional: makeEmailStats({ replied: 5 }),
+      broadcast: makeEmailStats({ replied: 3 }),
+    };
+    expect(extractOutcomeCount("emailsReplied", stats)).toBe(8);
+  });
+
+  it("extracts emailsClicked from transactional + broadcast", () => {
+    const stats = {
+      transactional: makeEmailStats({ clicked: 10 }),
+      broadcast: makeEmailStats({ clicked: 7 }),
+    };
+    expect(extractOutcomeCount("emailsClicked", stats)).toBe(17);
+  });
+
+  it("extracts emailsOpened", () => {
+    const stats = {
+      transactional: makeEmailStats({ opened: 20 }),
+      broadcast: makeEmailStats({ opened: 15 }),
+    };
+    expect(extractOutcomeCount("emailsOpened", stats)).toBe(35);
+  });
+
+  it("extracts emailsSent", () => {
+    const stats = {
+      transactional: makeEmailStats({ sent: 100 }),
+      broadcast: makeEmailStats({ sent: 50 }),
+    };
+    expect(extractOutcomeCount("emailsSent", stats)).toBe(150);
+  });
+
+  it("extracts emailsDelivered", () => {
+    const stats = {
+      transactional: makeEmailStats({ delivered: 90 }),
+      broadcast: makeEmailStats({ delivered: 45 }),
+    };
+    expect(extractOutcomeCount("emailsDelivered", stats)).toBe(135);
+  });
+
+  it("throws for unknown stats key", () => {
+    const stats = {
+      transactional: makeEmailStats(),
+      broadcast: makeEmailStats(),
+    };
+    expect(() => extractOutcomeCount("unknownMetric", stats)).toThrow(
+      'Unknown objective metric: "unknownMetric"'
+    );
+  });
+});
+
+describe("rescoreForObjective", () => {
+  it("re-computes outcomes and costPerOutcome for a different metric", () => {
+    const score = makeScore({
+      totalCost: 1000,
+      completedRuns: 5,
+      transactional: { replied: 2, clicked: 10 },
+      broadcast: { replied: 3, clicked: 5 },
+    });
+
+    const rescoredReplies = rescoreForObjective([score], "emailsReplied");
+    expect(rescoredReplies[0].totalOutcomes).toBe(5); // 2 + 3
+    expect(rescoredReplies[0].costPerOutcome).toBe(200); // 1000 / 5
+
+    const rescoredClicks = rescoreForObjective([score], "emailsClicked");
+    expect(rescoredClicks[0].totalOutcomes).toBe(15); // 10 + 5
+    expect(rescoredClicks[0].costPerOutcome).toBeCloseTo(66.67, 1); // 1000 / 15
+  });
+
+  it("resolves legacy aliases", () => {
+    const score = makeScore({
+      totalCost: 500,
+      completedRuns: 3,
+      transactional: { replied: 5 },
+      broadcast: { replied: 5 },
+    });
+
+    const rescored = rescoreForObjective([score], "replies");
+    expect(rescored[0].totalOutcomes).toBe(10);
+    expect(rescored[0].costPerOutcome).toBe(50);
+  });
+
+  it("returns null costPerOutcome when no outcomes", () => {
+    const score = makeScore({
+      totalCost: 1000,
+      completedRuns: 5,
+      transactional: { opened: 0 },
+      broadcast: { opened: 0 },
+    });
+
+    const rescored = rescoreForObjective([score], "emailsOpened");
+    expect(rescored[0].totalOutcomes).toBe(0);
+    expect(rescored[0].costPerOutcome).toBeNull();
+  });
+
+  it("does not mutate the original scores", () => {
+    const score = makeScore({
+      totalCost: 1000,
+      completedRuns: 5,
+      transactional: { replied: 10 },
+    });
+    score.totalOutcomes = 99;
+    score.costPerOutcome = 99;
+
+    rescoreForObjective([score], "emailsReplied");
+
+    expect(score.totalOutcomes).toBe(99);
+    expect(score.costPerOutcome).toBe(99);
+  });
+
+  it("ranks differently depending on metric", () => {
+    const scoreA = makeScore({
+      totalCost: 100,
+      completedRuns: 5,
+      transactional: { replied: 10, clicked: 1 },
+    });
+    scoreA.workflow = { ...scoreA.workflow, id: "wf-a", slug: "wf-a" } as WorkflowScore["workflow"];
+
+    const scoreB = makeScore({
+      totalCost: 100,
+      completedRuns: 5,
+      transactional: { replied: 1, clicked: 10 },
+    });
+    scoreB.workflow = { ...scoreB.workflow, id: "wf-b", slug: "wf-b" } as WorkflowScore["workflow"];
+
+    // By replies: A is better (cost 10 vs 100)
+    const byReplies = rescoreForObjective([scoreA, scoreB], "emailsReplied");
+    expect(byReplies[0].costPerOutcome).toBe(10); // A
+    expect(byReplies[1].costPerOutcome).toBe(100); // B
+
+    // By clicks: B is better (cost 10 vs 100)
+    const byClicks = rescoreForObjective([scoreA, scoreB], "emailsClicked");
+    expect(byClicks[0].costPerOutcome).toBe(100); // A
+    expect(byClicks[1].costPerOutcome).toBe(10); // B
+  });
+});


### PR DESCRIPTION
## Summary
- **`workflow-scoring.ts`**: `computeWorkflowScores` now accepts any stats key as the `objective` (not just `"replies" | "clicks"`). Added `resolveObjective()` for backward-compat aliases, `extractOutcomeCount()` to map stats keys to email stats fields, and `rescoreForObjective()` to re-rank by different metrics without re-fetching data.
- **`features-client.ts`**: Added `fetchFeatureOutputs()` and `fetchStatsRegistry()` to fetch the feature's declared output metrics and the stats key registry from features-service.
- **`schemas.ts`**: `RankedWorkflowObjectiveSchema` changed from `z.enum(["replies", "clicks"])` to `z.string()`. `objective` is now optional in query schemas — when omitted with a `featureSlug`, auto-resolves from the feature's outputs. `BestWorkflowResponseSchema` changed to `{ best: Record<metricKey, record> }`.
- **Routes (`workflows.ts`, `public-workflows.ts`)**: Both `/ranked` and `/best` (auth + public) now resolve objectives from feature outputs via features-service, rank per-metric independently, and return per-metric rankings when multiple metrics are detected.
- **Tests**: 14 new unit tests covering `resolveObjective`, `extractOutcomeCount`, and `rescoreForObjective`.

## Breaking changes
- `/workflows/best` and `/public/workflows/best` response shape changes from `{ bestCostPerOpen, bestCostPerReply }` to `{ best: { [metricKey]: record | null } }`.
- `objective` query param no longer has a default — when omitted, it's auto-resolved from feature outputs (or falls back to `emailsReplied`).

## Test plan
- [x] All 379 unit tests pass
- [x] TypeScript compilation + OpenAPI spec regeneration succeeds
- [ ] Verify api-service and front-end consumers handle the new `/best` response shape
- [ ] Verify features-service returns expected `outputs[].key` and `stats/registry` data

🤖 Generated with [Claude Code](https://claude.com/claude-code)