### PR TITLE
fix: no silent fallback in ranking endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3923,12 +3923,12 @@
                   "$ref": "#/components/schemas/RankedWorkflowObjective"
                 },
                 {
-                  "description": "Stats key to optimize for. Defaults to 'replies' (emailsReplied) when omitted."
+                  "description": "Stats key to optimize for (e.g. 'emailsReplied', 'emailsClicked'). Required."
                 }
               ]
             },
-            "required": false,
-            "description": "Stats key to optimize for. Defaults to 'replies' (emailsReplied) when omitted.",
+            "required": true,
+            "description": "Stats key to optimize for (e.g. 'emailsReplied', 'emailsClicked'). Required.",
             "name": "objective",
             "in": "query"
           },

--- a/src/routes/public-workflows.ts
+++ b/src/routes/public-workflows.ts
@@ -19,27 +19,34 @@ import { fetchFeatureOutputs, fetchStatsRegistry } from "../lib/features-client.
 
 const router = Router();
 
-const DEFAULT_OBJECTIVES = ["emailsReplied"];
-
 async function resolveObjectives(
   objective: string | undefined,
   featureSlug: string | undefined,
 ): Promise<string[]> {
   if (objective) return [objective];
-  if (featureSlug) {
-    const [outputs, registry] = await Promise.all([
-      fetchFeatureOutputs(featureSlug),
-      fetchStatsRegistry(),
-    ]);
-    const countMetrics = outputs
-      .map((o) => o.key)
-      .filter((key) => {
-        const entry = registry[key];
-        return entry && entry.type === "count";
-      });
-    if (countMetrics.length > 0) return countMetrics;
+
+  if (!featureSlug) {
+    throw new Error(
+      "Either 'objective' or 'featureSlug' must be provided to determine ranking metrics"
+    );
   }
-  return DEFAULT_OBJECTIVES;
+
+  const [outputs, registry] = await Promise.all([
+    fetchFeatureOutputs(featureSlug),
+    fetchStatsRegistry(),
+  ]);
+  const countMetrics = outputs
+    .map((o) => o.key)
+    .filter((key) => {
+      const entry = registry[key];
+      return entry && entry.type === "count";
+    });
+  if (countMetrics.length === 0) {
+    throw new Error(
+      `Feature "${featureSlug}" has no count-type output metrics. Outputs: [${outputs.map((o) => o.key).join(", ")}]`
+    );
+  }
+  return countMetrics;
 }
 
 // GET /public/workflows/ranked — Public ranked workflows (no auth, no DAG)
@@ -51,6 +58,11 @@ router.get("/public/workflows/ranked", async (req, res) => {
       return;
     }
     const { orgId, brandId, featureSlug, objective, limit, groupBy } = query.data;
+
+    if (!objective && !featureSlug) {
+      res.status(400).json({ error: "Either 'objective' or 'featureSlug' must be provided to determine ranking metrics" });
+      return;
+    }
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
@@ -176,6 +188,11 @@ router.get("/public/workflows/best", async (req, res) => {
       return;
     }
     const { orgId, brandId, featureSlug, by } = query.data;
+
+    if (!featureSlug) {
+      res.status(400).json({ error: "'featureSlug' is required — metrics are derived from the feature's declared outputs" });
+      return;
+    }
 
     const objectives = await resolveObjectives(undefined, featureSlug);
 

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -45,14 +45,11 @@ import { resolveFeatureDynasty, fetchFeatureOutputs, fetchStatsRegistry } from "
 
 const router = Router();
 
-/** Default metrics when feature outputs can't be resolved or no featureSlug is provided. */
-const DEFAULT_OBJECTIVES = ["emailsReplied"];
-
 /**
  * Resolves which stats keys to use as ranking objectives.
  * - If explicit objective is provided, use it alone.
  * - If featureSlug is provided, fetch its outputs and filter to count-type metrics.
- * - Otherwise, fall back to DEFAULT_OBJECTIVES.
+ * - Otherwise, crash — callers must provide either objective or featureSlug.
  */
 async function resolveObjectives(
   objective: string | undefined,
@@ -60,21 +57,28 @@ async function resolveObjectives(
 ): Promise<string[]> {
   if (objective) return [objective];
 
-  if (featureSlug) {
-    const [outputs, registry] = await Promise.all([
-      fetchFeatureOutputs(featureSlug),
-      fetchStatsRegistry(),
-    ]);
-    const countMetrics = outputs
-      .map((o) => o.key)
-      .filter((key) => {
-        const entry = registry[key];
-        return entry && entry.type === "count";
-      });
-    if (countMetrics.length > 0) return countMetrics;
+  if (!featureSlug) {
+    throw new Error(
+      "Either 'objective' or 'featureSlug' must be provided to determine ranking metrics"
+    );
   }
 
-  return DEFAULT_OBJECTIVES;
+  const [outputs, registry] = await Promise.all([
+    fetchFeatureOutputs(featureSlug),
+    fetchStatsRegistry(),
+  ]);
+  const countMetrics = outputs
+    .map((o) => o.key)
+    .filter((key) => {
+      const entry = registry[key];
+      return entry && entry.type === "count";
+    });
+  if (countMetrics.length === 0) {
+    throw new Error(
+      `Feature "${featureSlug}" has no count-type output metrics. Outputs: [${outputs.map((o) => o.key).join(", ")}]`
+    );
+  }
+  return countMetrics;
 }
 
 function formatWorkflow(w: typeof workflows.$inferSelect) {
@@ -840,6 +844,12 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
       return;
     }
     const { orgId, brandId, featureSlug, objective, limit, groupBy } = query.data;
+
+    if (!objective && !featureSlug) {
+      res.status(400).json({ error: "Either 'objective' or 'featureSlug' must be provided to determine ranking metrics" });
+      return;
+    }
+
     const identity = {
       orgId: res.locals.orgId as string,
       userId: res.locals.userId as string,
@@ -980,6 +990,12 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
       return;
     }
     const { orgId, brandId, featureSlug, by } = query.data;
+
+    if (!featureSlug) {
+      res.status(400).json({ error: "'featureSlug' is required — metrics are derived from the feature's declared outputs" });
+      return;
+    }
+
     const identity = {
       orgId: res.locals.orgId as string,
       userId: res.locals.userId as string,
@@ -1161,7 +1177,11 @@ router.get("/workflows/dynasty/stats", requireApiKey, async (req, res) => {
     }
 
     const objectiveParam = req.query.objective;
-    const objective = (typeof objectiveParam === "string" && objectiveParam) ? objectiveParam : "replies";
+    if (!objectiveParam || typeof objectiveParam !== "string") {
+      res.status(400).json({ error: "Missing required query parameter: objective (stats key, e.g. 'emailsReplied')" });
+      return;
+    }
+    const objective = objectiveParam;
 
     const identity = {
       orgId: res.locals.orgId as string,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1391,7 +1391,7 @@ registry.registerPath({
     headers: IdentityHeaders,
     query: z.object({
       dynastySlug: z.string().describe("The dynasty slug to get stats for."),
-      objective: RankedWorkflowObjectiveSchema.optional().describe("Stats key to optimize for. Defaults to 'replies' (emailsReplied) when omitted."),
+      objective: RankedWorkflowObjectiveSchema.describe("Stats key to optimize for (e.g. 'emailsReplied', 'emailsClicked'). Required."),
     }),
   },
   responses: {


### PR DESCRIPTION
## Summary
- `/workflows/ranked` and `/public/workflows/ranked` return **400** if neither `objective` nor `featureSlug` is provided
- `/workflows/best` and `/public/workflows/best` return **400** if `featureSlug` is missing
- `/workflows/dynasty/stats` returns **400** if `objective` is missing
- If a feature has no count-type output metrics, the error propagates with a clear message instead of silently falling back to `emailsReplied`

Follows up on #192.

## Test plan
- [x] 379 unit tests pass
- [x] Build + OpenAPI regen succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)