### PR TITLE
feat: add dynasty slug filters to list endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1829,11 +1829,41 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter workflows by feature slug."
+              "description": "Exact match on the versioned feature slug stored in the workflow."
             },
             "required": false,
-            "description": "Filter workflows by feature slug.",
+            "description": "Exact match on the versioned feature slug stored in the workflow.",
             "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage via features-service."
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage via features-service.",
+            "name": "featureDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Exact match on the versioned workflow slug."
+            },
+            "required": false,
+            "description": "Exact match on the versioned workflow slug.",
+            "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow dynasty slug — matches all workflows in the dynasty (all versions)."
+            },
+            "required": false,
+            "description": "Filter by workflow dynasty slug — matches all workflows in the dynasty (all versions).",
+            "name": "workflowDynastySlug",
             "in": "query"
           },
           {
@@ -2996,11 +3026,41 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter runs by feature slug."
+              "description": "Exact match on the versioned feature slug stored in the run."
             },
             "required": false,
-            "description": "Filter runs by feature slug.",
+            "description": "Exact match on the versioned feature slug stored in the run.",
             "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage via features-service."
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage via features-service.",
+            "name": "featureDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Exact match on the versioned workflow slug stored in the run."
+            },
+            "required": false,
+            "description": "Exact match on the versioned workflow slug stored in the run.",
+            "name": "workflowSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by workflow dynasty slug — finds all workflows in the dynasty, then matches runs by workflow ID."
+            },
+            "required": false,
+            "description": "Filter by workflow dynasty slug — finds all workflows in the dynasty, then matches runs by workflow ID.",
+            "name": "workflowDynastySlug",
             "in": "query"
           },
           {
@@ -3377,11 +3437,21 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter workflows by feature slug."
+              "description": "Exact match on the versioned feature slug."
             },
             "required": false,
-            "description": "Filter workflows by feature slug.",
+            "description": "Exact match on the versioned feature slug.",
             "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage."
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage.",
+            "name": "featureDynastySlug",
             "in": "query"
           },
           {
@@ -3556,11 +3626,21 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter by feature slug and use its declared output metrics for best-record computation."
+              "description": "Exact match on the versioned feature slug."
             },
             "required": false,
-            "description": "Filter by feature slug and use its declared output metrics for best-record computation.",
+            "description": "Exact match on the versioned feature slug.",
             "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage."
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage.",
+            "name": "featureDynastySlug",
             "in": "query"
           },
           {
@@ -4078,11 +4158,21 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter workflows by feature slug."
+              "description": "Exact match on the versioned feature slug."
             },
             "required": false,
-            "description": "Filter workflows by feature slug.",
+            "description": "Exact match on the versioned feature slug.",
             "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage."
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage.",
+            "name": "featureDynastySlug",
             "in": "query"
           },
           {
@@ -4182,11 +4272,21 @@
           {
             "schema": {
               "type": "string",
-              "description": "Filter by feature slug and use its declared output metrics for best-record computation."
+              "description": "Exact match on the versioned feature slug."
             },
             "required": false,
-            "description": "Filter by feature slug and use its declared output metrics for best-record computation.",
+            "description": "Exact match on the versioned feature slug.",
             "name": "featureSlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage."
+            },
+            "required": false,
+            "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage.",
+            "name": "featureDynastySlug",
             "in": "query"
           },
           {

--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -85,6 +85,43 @@ function deriveFromSlug(featureSlug: string): FeatureDynasty {
   return { featureDynastyName: dynastyName, featureDynastySlug: dynastySlug };
 }
 
+/**
+ * Resolve all versioned feature slugs belonging to a dynasty.
+ *
+ * Calls features-service GET /features/dynasty/slugs?dynastySlug=... which returns
+ * { slugs: ['feature-slug', 'feature-slug-v2', ...] }.
+ *
+ * Throws if features-service is not configured or returns an error.
+ */
+export async function resolveFeatureDynastySlugs(
+  dynastySlug: string,
+): Promise<string[]> {
+  const config = getFeaturesServiceConfig();
+  if (!config) {
+    throw new Error(
+      "FEATURES_SERVICE_URL and FEATURES_SERVICE_API_KEY must be set to resolve dynasty slugs"
+    );
+  }
+
+  const res = await fetch(
+    `${config.baseUrl}/features/dynasty/slugs?dynastySlug=${encodeURIComponent(dynastySlug)}`,
+    {
+      method: "GET",
+      headers: { "x-api-key": config.apiKey },
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `features-service error: GET /features/dynasty/slugs?dynastySlug=${dynastySlug} -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  const data = (await res.json()) as { slugs: string[] };
+  return data.slugs;
+}
+
 // --- Feature outputs (for dynamic ranking metrics) ---
 
 export interface FeatureOutput {

--- a/src/routes/public-workflows.ts
+++ b/src/routes/public-workflows.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { workflows } from "../db/schema.js";
 import {
@@ -15,7 +15,7 @@ import {
   handleExternalServiceError,
   type WorkflowScore,
 } from "../lib/workflow-scoring.js";
-import { fetchFeatureOutputs, fetchStatsRegistry } from "../lib/features-client.js";
+import { fetchFeatureOutputs, fetchStatsRegistry, resolveFeatureDynastySlugs } from "../lib/features-client.js";
 
 const router = Router();
 
@@ -57,7 +57,7 @@ router.get("/public/workflows/ranked", async (req, res) => {
       res.status(400).json({ error: "Validation error", details: query.error });
       return;
     }
-    const { orgId, brandId, featureSlug, objective, limit, groupBy } = query.data;
+    const { orgId, brandId, featureSlug, featureDynastySlug, objective, limit, groupBy } = query.data;
 
     if (!objective && !featureSlug) {
       res.status(400).json({ error: "Either 'objective' or 'featureSlug' must be provided to determine ranking metrics" });
@@ -67,6 +67,10 @@ router.get("/public/workflows/ranked", async (req, res) => {
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
+    if (featureDynastySlug) {
+      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
+      conditions.push(inArray(workflows.featureSlug, versionedSlugs));
+    }
 
     const allMatchingWorkflows = conditions.length > 0
       ? await db.select().from(workflows).where(and(...conditions))
@@ -187,7 +191,7 @@ router.get("/public/workflows/best", async (req, res) => {
       res.status(400).json({ error: "Validation error", details: query.error });
       return;
     }
-    const { orgId, brandId, featureSlug, by } = query.data;
+    const { orgId, brandId, featureSlug, featureDynastySlug, by } = query.data;
 
     if (!featureSlug) {
       res.status(400).json({ error: "'featureSlug' is required — metrics are derived from the feature's declared outputs" });
@@ -199,6 +203,10 @@ router.get("/public/workflows/best", async (req, res) => {
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
+    if (featureDynastySlug) {
+      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
+      conditions.push(inArray(workflows.featureSlug, versionedSlugs));
+    }
 
     const allMatchingWorkflows = conditions.length > 0
       ? await db.select().from(workflows).where(and(...conditions))

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 import { db } from "../db/index.js";
@@ -11,6 +11,7 @@ import { collectServiceEnvs } from "../lib/service-envs.js";
 import { createRun } from "../lib/runs-client.js";
 import { ExecuteWorkflowSchema, ExecuteByNameSchema } from "../schemas.js";
 import { parseWindmillError } from "../lib/error-parser.js";
+import { resolveFeatureDynastySlugs } from "../lib/features-client.js";
 
 const router = Router();
 
@@ -400,7 +401,7 @@ router.get("/workflow-runs/:id", requireApiKey, async (req, res) => {
 // GET /workflow-runs — List runs
 router.get("/workflow-runs", requireApiKey, async (req, res) => {
   try {
-    const { workflowId, orgId, campaignId, featureSlug, status } = req.query;
+    const { workflowId, orgId, campaignId, featureSlug, featureDynastySlug, workflowSlug, workflowDynastySlug, status } = req.query;
 
     const conditions = [];
 
@@ -415,6 +416,26 @@ router.get("/workflow-runs", requireApiKey, async (req, res) => {
     }
     if (featureSlug && typeof featureSlug === "string") {
       conditions.push(eq(workflowRuns.featureSlug, featureSlug));
+    }
+    if (featureDynastySlug && typeof featureDynastySlug === "string") {
+      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
+      conditions.push(inArray(workflowRuns.featureSlug, versionedSlugs));
+    }
+    if (workflowSlug && typeof workflowSlug === "string") {
+      conditions.push(eq(workflowRuns.workflowSlug, workflowSlug));
+    }
+    if (workflowDynastySlug && typeof workflowDynastySlug === "string") {
+      // Resolve via subquery: find all workflow IDs with this dynasty slug
+      const dynastyWorkflows = await db
+        .select({ id: workflows.id })
+        .from(workflows)
+        .where(eq(workflows.dynastySlug, workflowDynastySlug));
+      const wfIds = dynastyWorkflows.map((w) => w.id);
+      if (wfIds.length === 0) {
+        res.json({ workflowRuns: [] });
+        return;
+      }
+      conditions.push(inArray(workflowRuns.workflowId, wfIds));
     }
     if (status && typeof status === "string") {
       conditions.push(eq(workflowRuns.status, status));

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { eq, and, sql } from "drizzle-orm";
+import { eq, and, sql, inArray } from "drizzle-orm";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 import { db } from "../db/index.js";
@@ -41,7 +41,7 @@ import {
   handleExternalServiceError,
   type WorkflowScore,
 } from "../lib/workflow-scoring.js";
-import { resolveFeatureDynasty, fetchFeatureOutputs, fetchStatsRegistry } from "../lib/features-client.js";
+import { resolveFeatureDynasty, resolveFeatureDynastySlugs, fetchFeatureOutputs, fetchStatsRegistry } from "../lib/features-client.js";
 
 const router = Router();
 
@@ -843,7 +843,7 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
       res.status(400).json({ error: "Validation error", details: query.error });
       return;
     }
-    const { orgId, brandId, featureSlug, objective, limit, groupBy } = query.data;
+    const { orgId, brandId, featureSlug, featureDynastySlug, objective, limit, groupBy } = query.data;
 
     if (!objective && !featureSlug) {
       res.status(400).json({ error: "Either 'objective' or 'featureSlug' must be provided to determine ranking metrics" });
@@ -859,6 +859,10 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
+    if (featureDynastySlug) {
+      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
+      conditions.push(inArray(workflows.featureSlug, versionedSlugs));
+    }
 
     const allMatchingWorkflows = conditions.length > 0
       ? await db.select().from(workflows).where(and(...conditions))
@@ -989,7 +993,7 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
       res.status(400).json({ error: "Validation error", details: query.error });
       return;
     }
-    const { orgId, brandId, featureSlug, by } = query.data;
+    const { orgId, brandId, featureSlug, featureDynastySlug, by } = query.data;
 
     if (!featureSlug) {
       res.status(400).json({ error: "'featureSlug' is required — metrics are derived from the feature's declared outputs" });
@@ -1008,6 +1012,10 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
+    if (featureDynastySlug) {
+      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
+      conditions.push(inArray(workflows.featureSlug, versionedSlugs));
+    }
 
     const allMatchingWorkflows = conditions.length > 0
       ? await db.select().from(workflows).where(and(...conditions))
@@ -1241,7 +1249,7 @@ router.get("/workflows/dynasty/stats", requireApiKey, async (req, res) => {
 // GET /workflows — List workflows (defaults to active only; ?status=all for all)
 router.get("/workflows", requireApiKey, async (req, res) => {
   try {
-    const { orgId, brandId, humanId, campaignId, featureSlug, tag, status } = req.query;
+    const { orgId, brandId, humanId, campaignId, featureSlug, featureDynastySlug, workflowSlug, workflowDynastySlug, tag, status } = req.query;
 
     const conditions: ReturnType<typeof eq>[] = [];
 
@@ -1264,6 +1272,16 @@ router.get("/workflows", requireApiKey, async (req, res) => {
     }
     if (featureSlug && typeof featureSlug === "string") {
       conditions.push(eq(workflows.featureSlug, featureSlug));
+    }
+    if (featureDynastySlug && typeof featureDynastySlug === "string") {
+      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
+      conditions.push(inArray(workflows.featureSlug, versionedSlugs));
+    }
+    if (workflowSlug && typeof workflowSlug === "string") {
+      conditions.push(eq(workflows.slug, workflowSlug));
+    }
+    if (workflowDynastySlug && typeof workflowDynastySlug === "string") {
+      conditions.push(eq(workflows.dynastySlug, workflowDynastySlug));
     }
     if (tag && typeof tag === "string") {
       conditions.push(sql`${workflows.tags} @> ${JSON.stringify([tag])}::jsonb`);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -618,7 +618,8 @@ export const RankedWorkflowQuerySchema = z
   .object({
     orgId: z.string().optional().describe("Organization ID. When omitted, searches across all orgs."),
     brandId: z.string().optional().describe("Filter workflows by brand ID."),
-    featureSlug: z.string().optional().describe("Filter workflows by feature slug."),
+    featureSlug: z.string().optional().describe("Exact match on the versioned feature slug."),
+    featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage."),
     objective: RankedWorkflowObjectiveSchema.optional().describe(
       "Stats key to optimize for. When omitted with featureSlug, auto-resolves from the feature's declared output metrics. " +
       "When omitted without featureSlug, defaults to 'replies' (emailsReplied) for backward compatibility."
@@ -710,7 +711,8 @@ export const BestWorkflowQuerySchema = z
   .object({
     orgId: z.string().optional().describe("Organization ID. When omitted, searches across all orgs."),
     brandId: z.string().optional().describe("Filter workflows by brand ID."),
-    featureSlug: z.string().optional().describe("Filter by feature slug and use its declared output metrics for best-record computation."),
+    featureSlug: z.string().optional().describe("Exact match on the versioned feature slug."),
+    featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage."),
     by: BestWorkflowBySchema.default("workflow").describe("Granularity: best workflow or best brand. Defaults to 'workflow'."),
   })
   .openapi("BestWorkflowQuery");
@@ -922,7 +924,10 @@ registry.registerPath({
       brandId: z.string().optional(),
       humanId: z.string().optional(),
       campaignId: z.string().optional(),
-      featureSlug: z.string().optional().describe("Filter workflows by feature slug."),
+      featureSlug: z.string().optional().describe("Exact match on the versioned feature slug stored in the workflow."),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage via features-service."),
+      workflowSlug: z.string().optional().describe("Exact match on the versioned workflow slug."),
+      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug — matches all workflows in the dynasty (all versions)."),
       category: WorkflowCategorySchema.optional(),
       channel: WorkflowChannelSchema.optional(),
       audienceType: WorkflowAudienceTypeSchema.optional(),
@@ -1183,7 +1188,10 @@ registry.registerPath({
       workflowId: z.string().uuid().optional(),
       orgId: z.string().optional(),
       campaignId: z.string().optional(),
-      featureSlug: z.string().optional().describe("Filter runs by feature slug."),
+      featureSlug: z.string().optional().describe("Exact match on the versioned feature slug stored in the run."),
+      featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage via features-service."),
+      workflowSlug: z.string().optional().describe("Exact match on the versioned workflow slug stored in the run."),
+      workflowDynastySlug: z.string().optional().describe("Filter by workflow dynasty slug — finds all workflows in the dynasty, then matches runs by workflow ID."),
       status: z.string().optional(),
     }),
   },

--- a/tests/integration/public-workflows.test.ts
+++ b/tests/integration/public-workflows.test.ts
@@ -87,6 +87,23 @@ vi.mock("../../src/lib/key-service-client.js", () => ({
   fetchAnthropicKey: vi.fn(),
 }));
 
+// --- Mock features-client ---
+vi.mock("../../src/lib/features-client.js", () => ({
+  resolveFeatureDynasty: vi.fn().mockImplementation((featureSlug: string) => {
+    const dynastySlug = featureSlug.replace(/-v\d+$/, "");
+    const dynastyName = dynastySlug
+      .split("-")
+      .map((w: string) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(" ");
+    return Promise.resolve({ featureDynastyName: dynastyName, featureDynastySlug: dynastySlug });
+  }),
+  resolveFeatureDynastySlugs: vi.fn().mockImplementation((dynastySlug: string) => {
+    return Promise.resolve([dynastySlug, `${dynastySlug}-v2`, `${dynastySlug}-v3`]);
+  }),
+  fetchFeatureOutputs: vi.fn().mockRejectedValue(new Error("not configured")),
+  fetchStatsRegistry: vi.fn().mockRejectedValue(new Error("not configured")),
+}));
+
 import supertest from "supertest";
 import app from "../../src/index.js";
 

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -96,6 +96,13 @@ vi.mock("../../src/lib/runs-client.js", () => ({
   createRun: (...args: unknown[]) => mockCreateRun(...args),
 }));
 
+// Mock features-client (for dynasty slug resolution)
+vi.mock("../../src/lib/features-client.js", () => ({
+  resolveFeatureDynastySlugs: vi.fn().mockImplementation((dynastySlug: string) => {
+    return Promise.resolve([dynastySlug, `${dynastySlug}-v2`, `${dynastySlug}-v3`]);
+  }),
+}));
+
 import supertest from "supertest";
 import app from "../../src/index.js";
 

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -83,6 +83,10 @@ vi.mock("../../src/lib/features-client.js", () => ({
       .join(" ");
     return Promise.resolve({ featureDynastyName: dynastyName, featureDynastySlug: dynastySlug });
   }),
+  resolveFeatureDynastySlugs: vi.fn().mockImplementation((dynastySlug: string) => {
+    // Simulate: dynasty slug resolves to itself + versioned variants
+    return Promise.resolve([dynastySlug, `${dynastySlug}-v2`, `${dynastySlug}-v3`]);
+  }),
 }));
 
 // Mock Windmill client
@@ -293,6 +297,79 @@ describe("GET /workflows", () => {
     expect(res.status).toBe(200);
     expect(res.body.workflows).toBeDefined();
     expect(res.body.workflows[0].featureSlug).toBe("outlet-database-discovery");
+  });
+
+  it("filters workflows by featureDynastySlug via features-service resolution", async () => {
+    mockDbRows.push({
+      id: WF_FEATURE_ID,
+      orgId: "org-1",
+      slug: "outlet-database-discovery-sequoia",
+      name: "Outlet Database Discovery Sequoia",
+      dynastyName: "Outlet Database Discovery Sequoia",
+      version: 1,
+      featureSlug: "outlet-database-discovery",
+      status: "active",
+      dag: VALID_LINEAR_DAG,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const res = await request
+      .get("/workflows")
+      .query({ featureDynastySlug: "outlet-database-discovery" })
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.workflows).toBeDefined();
+  });
+
+  it("filters workflows by workflowDynastySlug", async () => {
+    mockDbRows.push({
+      id: WF_FEATURE_ID,
+      orgId: "org-1",
+      slug: "sales-cold-email-outreach-sequoia-v2",
+      name: "Sales Cold Email Outreach Sequoia v2",
+      dynastyName: "Sales Cold Email Outreach Sequoia",
+      dynastySlug: "sales-cold-email-outreach-sequoia",
+      version: 2,
+      featureSlug: "sales-cold-email-outreach",
+      status: "active",
+      dag: VALID_LINEAR_DAG,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const res = await request
+      .get("/workflows")
+      .query({ workflowDynastySlug: "sales-cold-email-outreach-sequoia" })
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.workflows).toBeDefined();
+  });
+
+  it("filters workflows by workflowSlug", async () => {
+    mockDbRows.push({
+      id: WF_FEATURE_ID,
+      orgId: "org-1",
+      slug: "sales-cold-email-outreach-sequoia",
+      name: "Sales Cold Email Outreach Sequoia",
+      dynastyName: "Sales Cold Email Outreach Sequoia",
+      version: 1,
+      featureSlug: "sales-cold-email-outreach",
+      status: "active",
+      dag: VALID_LINEAR_DAG,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const res = await request
+      .get("/workflows")
+      .query({ workflowSlug: "sales-cold-email-outreach-sequoia" })
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.workflows).toBeDefined();
   });
 
   it("returns dimensions in response", async () => {

--- a/tests/unit/features-client.test.ts
+++ b/tests/unit/features-client.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resolveFeatureDynastySlugs } from "../../src/lib/features-client.js";
+
+describe("resolveFeatureDynastySlugs", () => {
+  const originalUrl = process.env.FEATURES_SERVICE_URL;
+  const originalKey = process.env.FEATURES_SERVICE_API_KEY;
+
+  beforeEach(() => {
+    process.env.FEATURES_SERVICE_URL = "http://localhost:4000";
+    process.env.FEATURES_SERVICE_API_KEY = "test-features-key";
+  });
+
+  afterEach(() => {
+    process.env.FEATURES_SERVICE_URL = originalUrl;
+    process.env.FEATURES_SERVICE_API_KEY = originalKey;
+    vi.restoreAllMocks();
+  });
+
+  it("calls GET /features/dynasty/slugs and returns the slugs array", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            slugs: ["sales-cold-email", "sales-cold-email-v2", "sales-cold-email-v3"],
+          }),
+      }),
+    );
+
+    const result = await resolveFeatureDynastySlugs("sales-cold-email");
+
+    expect(result).toEqual(["sales-cold-email", "sales-cold-email-v2", "sales-cold-email-v3"]);
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:4000/features/dynasty/slugs?dynastySlug=sales-cold-email",
+      expect.objectContaining({
+        method: "GET",
+        headers: { "x-api-key": "test-features-key" },
+      }),
+    );
+  });
+
+  it("throws when features-service is not configured", async () => {
+    delete process.env.FEATURES_SERVICE_URL;
+    delete process.env.FEATURES_SERVICE_API_KEY;
+
+    await expect(resolveFeatureDynastySlugs("sales-cold-email")).rejects.toThrow(
+      "FEATURES_SERVICE_URL and FEATURES_SERVICE_API_KEY must be set",
+    );
+  });
+
+  it("throws when features-service returns an error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        text: () => Promise.resolve("No features found"),
+      }),
+    );
+
+    await expect(resolveFeatureDynastySlugs("nonexistent")).rejects.toThrow(
+      "features-service error",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `featureDynastySlug` query param to `GET /workflows`, `GET /workflow-runs`, `GET /workflows/ranked`, `GET /workflows/best`, and their public equivalents. Resolves dynasty → versioned slugs at runtime via features-service `GET /features/dynasty/slugs`, then filters with `IN (...)`.
- Adds `workflowDynastySlug` query param to `GET /workflows` (direct match on `dynasty_slug` column) and `GET /workflow-runs` (subquery on workflows table).
- Adds `workflowSlug` exact-match filter to both list endpoints.
- No schema/DB migration needed — uses existing columns and runtime resolution.

## Test plan
- [x] Unit test for `resolveFeatureDynastySlugs` (success, not configured, error cases)
- [x] Integration tests for `featureDynastySlug`, `workflowDynastySlug`, and `workflowSlug` filters on `GET /workflows`
- [x] All 52 workflow tests pass, all 41 workflow-runs tests pass
- [x] Pre-existing public-workflows test failures unchanged (5 tests with stale response format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)