### PR TITLE
feat: source-based dynamic scoring for non-email features

### DIFF
--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -169,6 +169,7 @@ export async function fetchFeatureOutputs(
 export interface StatsRegistryEntry {
   type: string;
   label: string;
+  source?: string;
 }
 
 /**

--- a/src/lib/source-stats-client.ts
+++ b/src/lib/source-stats-client.ts
@@ -1,0 +1,174 @@
+/**
+ * Fetches stats from source services (lead, journalists, outlets) grouped by workflow slug.
+ * Each source returns metrics in its own format — this module normalizes them into
+ * a uniform Map<workflowSlug, Record<statsKey, number>>.
+ *
+ * The `source` field from the features-service stats registry determines which
+ * service to call: "email-gateway", "leads", "journalists", "outlets".
+ * Email-gateway stats are handled separately in stats-client.ts.
+ */
+
+import type { IdentityHeaders } from "./key-service-client.js";
+
+function getServiceConfig(envPrefix: string): { baseUrl: string; apiKey: string } {
+  const baseUrl = process.env[`${envPrefix}_SERVICE_URL`];
+  const apiKey = process.env[`${envPrefix}_SERVICE_API_KEY`];
+  if (!baseUrl || !apiKey) {
+    throw new Error(
+      `${envPrefix}_SERVICE_URL and ${envPrefix}_SERVICE_API_KEY must be set`
+    );
+  }
+  return { baseUrl: baseUrl.replace(/\/$/, ""), apiKey };
+}
+
+/** Uniform return type: map of workflowSlug → { statsKey: count } */
+export type SourceStatsMap = Map<string, Record<string, number>>;
+
+// --- Lead service ---
+
+export async function fetchLeadStats(
+  workflowSlugs: string[],
+  identity: IdentityHeaders,
+): Promise<SourceStatsMap> {
+  if (workflowSlugs.length === 0) return new Map();
+  const { baseUrl, apiKey } = getServiceConfig("LEAD");
+  const params = new URLSearchParams({
+    groupBy: "workflowSlug",
+    workflowSlugs: workflowSlugs.join(","),
+  });
+
+  const res = await fetch(`${baseUrl}/stats?${params}`, {
+    headers: {
+      "x-api-key": apiKey,
+      "x-org-id": identity.orgId,
+      "x-user-id": identity.userId,
+      "x-run-id": identity.runId,
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`lead-service error: GET /stats -> ${res.status} ${res.statusText}: ${text}`);
+  }
+
+  const body = (await res.json()) as {
+    groups: Array<{ key: string; served: number; contacted: number; buffered: number; skipped: number }>;
+  };
+
+  const result: SourceStatsMap = new Map();
+  for (const g of body.groups) {
+    result.set(g.key, {
+      leadsServed: g.served,
+      leadsContacted: g.contacted,
+    });
+  }
+  return result;
+}
+
+// --- Journalists service ---
+
+export async function fetchJournalistStats(
+  workflowSlugs: string[],
+  identity: IdentityHeaders,
+): Promise<SourceStatsMap> {
+  if (workflowSlugs.length === 0) return new Map();
+  const { baseUrl, apiKey } = getServiceConfig("JOURNALISTS");
+  const params = new URLSearchParams({ groupBy: "workflowSlug" });
+
+  const res = await fetch(`${baseUrl}/stats?${params}`, {
+    headers: {
+      "x-api-key": apiKey,
+      "x-org-id": identity.orgId,
+      "x-user-id": identity.userId,
+      "x-run-id": identity.runId,
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`journalists-service error: GET /stats -> ${res.status} ${res.statusText}: ${text}`);
+  }
+
+  const body = (await res.json()) as {
+    groupedBy?: Record<string, { totalJournalists: number; byStatus: Record<string, number> }>;
+  };
+
+  const result: SourceStatsMap = new Map();
+  if (body.groupedBy) {
+    for (const [slug, stats] of Object.entries(body.groupedBy)) {
+      if (!workflowSlugs.includes(slug)) continue;
+      result.set(slug, {
+        journalistsFound: stats.totalJournalists,
+        journalistsContacted: stats.byStatus?.contacted ?? 0,
+      });
+    }
+  }
+  return result;
+}
+
+// --- Outlets service ---
+
+export async function fetchOutletStats(
+  workflowSlugs: string[],
+  identity: IdentityHeaders,
+): Promise<SourceStatsMap> {
+  if (workflowSlugs.length === 0) return new Map();
+  const { baseUrl, apiKey } = getServiceConfig("OUTLETS");
+  const params = new URLSearchParams({ groupBy: "workflowSlug" });
+
+  const res = await fetch(`${baseUrl}/outlets/stats?${params}`, {
+    headers: {
+      "x-api-key": apiKey,
+      "x-org-id": identity.orgId,
+      "x-user-id": identity.userId,
+      "x-run-id": identity.runId,
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`outlets-service error: GET /outlets/stats -> ${res.status} ${res.statusText}: ${text}`);
+  }
+
+  const body = (await res.json()) as {
+    groups: Array<{ key: string; outletsDiscovered: number; avgRelevanceScore: number; searchQueriesUsed: number }>;
+  };
+
+  const result: SourceStatsMap = new Map();
+  for (const g of body.groups) {
+    if (!workflowSlugs.includes(g.key)) continue;
+    result.set(g.key, {
+      outletsDiscovered: g.outletsDiscovered,
+      searchQueriesUsed: g.searchQueriesUsed,
+    });
+  }
+  return result;
+}
+
+// --- Dispatcher ---
+
+/**
+ * Fetches stats from the appropriate source service based on the registry `source` field.
+ * Returns a map of workflowSlug → Record<statsKey, count>.
+ *
+ * Sources "email-gateway" and "runs" are handled by stats-client.ts — this module
+ * handles "leads", "journalists", and "outlets".
+ */
+export async function fetchSourceStats(
+  source: string,
+  workflowSlugs: string[],
+  identity: IdentityHeaders,
+): Promise<SourceStatsMap> {
+  switch (source) {
+    case "leads":
+      return fetchLeadStats(workflowSlugs, identity);
+    case "journalists":
+      return fetchJournalistStats(workflowSlugs, identity);
+    case "outlets":
+      return fetchOutletStats(workflowSlugs, identity);
+    default:
+      throw new Error(
+        `[workflow-service] Unknown stats source: "${source}". Known sources: leads, journalists, outlets (email-gateway and runs are handled separately)`
+      );
+  }
+}

--- a/src/lib/workflow-scoring.ts
+++ b/src/lib/workflow-scoring.ts
@@ -2,7 +2,9 @@ import { eq, and, inArray } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { workflows, workflowRuns } from "../db/schema.js";
 import { fetchRunCostsAuth, fetchRunCostsPublic, fetchEmailStatsAuth, fetchEmailStatsPublic } from "./stats-client.js";
+import { fetchSourceStats, type SourceStatsMap } from "./source-stats-client.js";
 import type { IdentityHeaders } from "./key-service-client.js";
+import type { StatsRegistryEntry } from "./features-client.js";
 
 export const EMPTY_EMAIL_STATS = {
   sent: 0, delivered: 0, opened: 0, clicked: 0,
@@ -10,10 +12,10 @@ export const EMPTY_EMAIL_STATS = {
 };
 
 /**
- * Maps stats registry keys (from features-service) to email stats field names.
- * These are the count-type metrics that can be used as ranking objectives.
+ * Maps email-gateway stats keys to internal email stats field names.
+ * Used to populate sourceMetrics from email stats data.
  */
-const STATS_KEY_TO_EMAIL_FIELD: Record<string, keyof typeof EMPTY_EMAIL_STATS> = {
+const EMAIL_KEY_TO_FIELD: Record<string, keyof typeof EMPTY_EMAIL_STATS> = {
   emailsSent: "sent",
   emailsDelivered: "delivered",
   emailsOpened: "opened",
@@ -35,20 +37,20 @@ export function resolveObjective(objective: string): string {
 }
 
 /**
- * Extracts the outcome count for a given stats key from aggregated email stats.
- * Sums transactional + broadcast counts. Throws if the key is unknown.
+ * Extracts the outcome count for a given stats key from a workflow's source metrics.
+ * Throws if the key is not found in the metrics map.
  */
 export function extractOutcomeCount(
   statsKey: string,
-  emailStats: { transactional: typeof EMPTY_EMAIL_STATS; broadcast: typeof EMPTY_EMAIL_STATS },
+  sourceMetrics: Record<string, number>,
 ): number {
-  const field = STATS_KEY_TO_EMAIL_FIELD[statsKey];
-  if (!field) {
+  const value = sourceMetrics[statsKey];
+  if (value === undefined) {
     throw new Error(
-      `Unknown objective metric: "${statsKey}". Known email stats keys: ${Object.keys(STATS_KEY_TO_EMAIL_FIELD).join(", ")}`
+      `Metric "${statsKey}" not found in source metrics. Available: [${Object.keys(sourceMetrics).join(", ")}]`
     );
   }
-  return emailStats.transactional[field] + emailStats.broadcast[field];
+  return value;
 }
 
 /**
@@ -58,13 +60,27 @@ export function extractOutcomeCount(
 export function rescoreForObjective(scores: WorkflowScore[], objective: string): WorkflowScore[] {
   const resolved = resolveObjective(objective);
   return scores.map((s) => {
-    const outcomes = extractOutcomeCount(resolved, s.emailStats);
+    const outcomes = extractOutcomeCount(resolved, s.sourceMetrics);
     return {
       ...s,
       totalOutcomes: outcomes,
       costPerOutcome: outcomes > 0 ? s.totalCost / outcomes : null,
     };
   });
+}
+
+/**
+ * Builds sourceMetrics from email stats by mapping email-gateway keys to counts.
+ */
+function emailStatsToMetrics(
+  transactional: typeof EMPTY_EMAIL_STATS,
+  broadcast: typeof EMPTY_EMAIL_STATS,
+): Record<string, number> {
+  const metrics: Record<string, number> = {};
+  for (const [statsKey, field] of Object.entries(EMAIL_KEY_TO_FIELD)) {
+    metrics[statsKey] = transactional[field] + broadcast[field];
+  }
+  return metrics;
 }
 
 export interface WorkflowScore {
@@ -74,6 +90,8 @@ export interface WorkflowScore {
   costPerOutcome: number | null;
   completedRuns: number;
   emailStats: { transactional: typeof EMPTY_EMAIL_STATS; broadcast: typeof EMPTY_EMAIL_STATS };
+  /** All metric values keyed by stats registry key (e.g. emailsReplied, leadsServed, outletsDiscovered). */
+  sourceMetrics: Record<string, number>;
 }
 
 export function getUpgradeChainIds(
@@ -124,6 +142,8 @@ export async function computeWorkflowScores(
   deprecatedWorkflows: (typeof workflows.$inferSelect)[],
   objective: string,
   mode: ScoreMode,
+  /** Stats registry entries for the objectives — used to fetch from the right source services. */
+  registry?: Record<string, StatsRegistryEntry>,
 ): Promise<ScoreResult> {
   // 1. Build dynasty chains: for each active workflow, collect all workflow names in its upgrade chain
   const chainWorkflowsById: Record<string, (typeof workflows.$inferSelect)[]> = {};
@@ -159,7 +179,33 @@ export async function computeWorkflowScores(
 
   const emailBySlug = new Map(emailGroups.map((g) => [g.workflowSlug, g]));
 
-  // 5. For each active workflow, aggregate costs + email stats across dynasty chain + build brand map
+  // 5. Fetch stats from additional source services (leads, journalists, outlets)
+  //    based on registry sources — only for auth mode (source services require identity)
+  const additionalSourceMaps: SourceStatsMap[] = [];
+  if (registry && mode.kind === "auth") {
+    const sourcesToFetch = new Set<string>();
+    for (const entry of Object.values(registry)) {
+      if (entry.source && entry.source !== "email-gateway" && entry.source !== "runs" && entry.source !== "campaign") {
+        sourcesToFetch.add(entry.source);
+      }
+    }
+    const sourcePromises = [...sourcesToFetch].map((source) =>
+      fetchSourceStats(source, allChainNames, mode.identity)
+    );
+    additionalSourceMaps.push(...await Promise.all(sourcePromises));
+  }
+
+  // Build a combined map: workflowSlug → Record<statsKey, number> from additional sources
+  const additionalMetricsBySlug = new Map<string, Record<string, number>>();
+  for (const sourceMap of additionalSourceMaps) {
+    for (const [slug, metrics] of sourceMap) {
+      const existing = additionalMetricsBySlug.get(slug) ?? {};
+      Object.assign(existing, metrics);
+      additionalMetricsBySlug.set(slug, existing);
+    }
+  }
+
+  // 6. For each active workflow, aggregate costs + all metrics across dynasty chain + build brand map
   const workflowRunsByWfId: Record<string, string[]> = {};
   const runBrandMap = new Map<string, string>();
   const scores: WorkflowScore[] = [];
@@ -187,6 +233,16 @@ export async function computeWorkflowScores(
       }
     }
 
+    // Source metrics: combine email stats + additional source stats
+    const sourceMetrics = emailStatsToMetrics(transactional, broadcast);
+    for (const name of chainNames) {
+      const additional = additionalMetricsBySlug.get(name);
+      if (!additional) continue;
+      for (const [key, value] of Object.entries(additional)) {
+        sourceMetrics[key] = (sourceMetrics[key] ?? 0) + value;
+      }
+    }
+
     // Run IDs + brand map: still from local workflow_runs table (needed for brand grouping)
     const runs = chainIds.length === 1
       ? await db.select().from(workflowRuns).where(
@@ -200,7 +256,7 @@ export async function computeWorkflowScores(
     workflowRunsByWfId[wf.id] = runIds;
 
     const resolvedObjective = resolveObjective(objective);
-    const outcomes = extractOutcomeCount(resolvedObjective, { transactional, broadcast });
+    const outcomes = extractOutcomeCount(resolvedObjective, sourceMetrics);
 
     const costPerOutcome = outcomes > 0 ? totalCost / outcomes : null;
 
@@ -211,6 +267,7 @@ export async function computeWorkflowScores(
       costPerOutcome,
       completedRuns: runIds.length,
       emailStats: { transactional, broadcast },
+      sourceMetrics,
     });
   }
 
@@ -300,7 +357,13 @@ export function handleExternalServiceError(err: unknown, res: import("express").
     err instanceof Error &&
     (err.message.includes("RUNS_SERVICE_URL") ||
       err.message.includes("EMAIL_GATEWAY_SERVICE_URL") ||
-      err.message.startsWith("email-gateway-service error:"))
+      err.message.includes("LEAD_SERVICE_URL") ||
+      err.message.includes("JOURNALISTS_SERVICE_URL") ||
+      err.message.includes("OUTLETS_SERVICE_URL") ||
+      err.message.startsWith("email-gateway-service error:") ||
+      err.message.startsWith("lead-service error:") ||
+      err.message.startsWith("journalists-service error:") ||
+      err.message.startsWith("outlets-service error:"))
   ) {
     console.error(`[workflow-service] ${label}: external service error:`, err.message);
     res.status(502).json({ error: err.message });

--- a/src/routes/public-workflows.ts
+++ b/src/routes/public-workflows.ts
@@ -22,8 +22,8 @@ const router = Router();
 async function resolveObjectives(
   objective: string | undefined,
   featureSlug: string | undefined,
-): Promise<string[]> {
-  if (objective) return [objective];
+): Promise<{ objectives: string[]; registry?: Record<string, import("../lib/features-client.js").StatsRegistryEntry> }> {
+  if (objective) return { objectives: [objective] };
 
   if (!featureSlug) {
     throw new Error(
@@ -46,7 +46,7 @@ async function resolveObjectives(
       `Feature "${featureSlug}" has no count-type output metrics. Outputs: [${outputs.map((o) => o.key).join(", ")}]`
     );
   }
-  return countMetrics;
+  return { objectives: countMetrics, registry };
 }
 
 // GET /public/workflows/ranked — Public ranked workflows (no auth, no DAG)
@@ -83,7 +83,7 @@ router.get("/public/workflows/ranked", async (req, res) => {
       return;
     }
 
-    const objectives = await resolveObjectives(objective, featureSlug);
+    const { objectives } = await resolveObjectives(objective, featureSlug);
     const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objectives[0], { kind: "public" as const, brandId, orgId });
 
     function rankForObjectives(inputScores: WorkflowScore[]) {
@@ -198,7 +198,7 @@ router.get("/public/workflows/best", async (req, res) => {
       return;
     }
 
-    const objectives = await resolveObjectives(undefined, featureSlug);
+    const { objectives } = await resolveObjectives(undefined, featureSlug);
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -54,8 +54,8 @@ const router = Router();
 async function resolveObjectives(
   objective: string | undefined,
   featureSlug: string | undefined,
-): Promise<string[]> {
-  if (objective) return [objective];
+): Promise<{ objectives: string[]; registry?: Record<string, import("../lib/features-client.js").StatsRegistryEntry> }> {
+  if (objective) return { objectives: [objective] };
 
   if (!featureSlug) {
     throw new Error(
@@ -78,7 +78,7 @@ async function resolveObjectives(
       `Feature "${featureSlug}" has no count-type output metrics. Outputs: [${outputs.map((o) => o.key).join(", ")}]`
     );
   }
-  return countMetrics;
+  return { objectives: countMetrics, registry };
 }
 
 function formatWorkflow(w: typeof workflows.$inferSelect) {
@@ -864,10 +864,10 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
     }
 
     // Resolve which metrics to rank by (from feature outputs or explicit objective)
-    const objectives = await resolveObjectives(objective, featureSlug);
+    const { objectives, registry } = await resolveObjectives(objective, featureSlug);
 
     // Fetch base scores once — objective only affects outcome computation, which we re-score per metric
-    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objectives[0], { kind: "auth", identity });
+    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objectives[0], { kind: "auth", identity }, registry);
 
     // Helper: produce rankings for a given set of scores across all objectives
     function rankForObjectives(inputScores: WorkflowScore[]) {
@@ -995,7 +995,7 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
     };
 
     // Resolve which metrics to compute best records for
-    const objectives = await resolveObjectives(undefined, featureSlug);
+    const { objectives, registry } = await resolveObjectives(undefined, featureSlug);
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
@@ -1019,7 +1019,7 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
     }
 
     // Slug-level stats only — no dynasty chain aggregation
-    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objectives[0], { kind: "auth", identity });
+    const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objectives[0], { kind: "auth", identity }, registry);
 
     if (by === "brand") {
       // Aggregate by brandId from runs

--- a/tests/unit/workflow-scoring.test.ts
+++ b/tests/unit/workflow-scoring.test.ts
@@ -12,12 +12,40 @@ const makeEmailStats = (overrides: Partial<typeof EMPTY_EMAIL_STATS> = {}) => ({
   ...overrides,
 });
 
+/**
+ * Builds sourceMetrics from email stats, mirroring the production emailStatsToMetrics helper.
+ */
+function buildSourceMetrics(
+  transactional: typeof EMPTY_EMAIL_STATS,
+  broadcast: typeof EMPTY_EMAIL_STATS,
+  extra?: Record<string, number>,
+): Record<string, number> {
+  const EMAIL_KEY_TO_FIELD: Record<string, keyof typeof EMPTY_EMAIL_STATS> = {
+    emailsSent: "sent",
+    emailsDelivered: "delivered",
+    emailsOpened: "opened",
+    emailsClicked: "clicked",
+    emailsReplied: "replied",
+    emailsBounced: "bounced",
+    recipients: "recipients",
+  };
+  const metrics: Record<string, number> = {};
+  for (const [statsKey, field] of Object.entries(EMAIL_KEY_TO_FIELD)) {
+    metrics[statsKey] = transactional[field] + broadcast[field];
+  }
+  if (extra) Object.assign(metrics, extra);
+  return metrics;
+}
+
 function makeScore(opts: {
   totalCost: number;
   completedRuns: number;
   transactional?: Partial<typeof EMPTY_EMAIL_STATS>;
   broadcast?: Partial<typeof EMPTY_EMAIL_STATS>;
+  extraMetrics?: Record<string, number>;
 }): WorkflowScore {
+  const transactional = makeEmailStats(opts.transactional);
+  const broadcast = makeEmailStats(opts.broadcast);
   return {
     workflow: {
       id: "wf-1",
@@ -35,10 +63,8 @@ function makeScore(opts: {
     totalOutcomes: 0,
     costPerOutcome: null,
     completedRuns: opts.completedRuns,
-    emailStats: {
-      transactional: makeEmailStats(opts.transactional),
-      broadcast: makeEmailStats(opts.broadcast),
-    },
+    emailStats: { transactional, broadcast },
+    sourceMetrics: buildSourceMetrics(transactional, broadcast, opts.extraMetrics),
   };
 }
 
@@ -59,53 +85,56 @@ describe("resolveObjective", () => {
 });
 
 describe("extractOutcomeCount", () => {
-  it("extracts emailsReplied from transactional + broadcast", () => {
-    const stats = {
-      transactional: makeEmailStats({ replied: 5 }),
-      broadcast: makeEmailStats({ replied: 3 }),
-    };
-    expect(extractOutcomeCount("emailsReplied", stats)).toBe(8);
+  it("extracts emailsReplied from sourceMetrics", () => {
+    const metrics = buildSourceMetrics(
+      makeEmailStats({ replied: 5 }),
+      makeEmailStats({ replied: 3 }),
+    );
+    expect(extractOutcomeCount("emailsReplied", metrics)).toBe(8);
   });
 
-  it("extracts emailsClicked from transactional + broadcast", () => {
-    const stats = {
-      transactional: makeEmailStats({ clicked: 10 }),
-      broadcast: makeEmailStats({ clicked: 7 }),
-    };
-    expect(extractOutcomeCount("emailsClicked", stats)).toBe(17);
+  it("extracts emailsClicked from sourceMetrics", () => {
+    const metrics = buildSourceMetrics(
+      makeEmailStats({ clicked: 10 }),
+      makeEmailStats({ clicked: 7 }),
+    );
+    expect(extractOutcomeCount("emailsClicked", metrics)).toBe(17);
   });
 
   it("extracts emailsOpened", () => {
-    const stats = {
-      transactional: makeEmailStats({ opened: 20 }),
-      broadcast: makeEmailStats({ opened: 15 }),
-    };
-    expect(extractOutcomeCount("emailsOpened", stats)).toBe(35);
+    const metrics = buildSourceMetrics(
+      makeEmailStats({ opened: 20 }),
+      makeEmailStats({ opened: 15 }),
+    );
+    expect(extractOutcomeCount("emailsOpened", metrics)).toBe(35);
   });
 
   it("extracts emailsSent", () => {
-    const stats = {
-      transactional: makeEmailStats({ sent: 100 }),
-      broadcast: makeEmailStats({ sent: 50 }),
-    };
-    expect(extractOutcomeCount("emailsSent", stats)).toBe(150);
+    const metrics = buildSourceMetrics(
+      makeEmailStats({ sent: 100 }),
+      makeEmailStats({ sent: 50 }),
+    );
+    expect(extractOutcomeCount("emailsSent", metrics)).toBe(150);
   });
 
   it("extracts emailsDelivered", () => {
-    const stats = {
-      transactional: makeEmailStats({ delivered: 90 }),
-      broadcast: makeEmailStats({ delivered: 45 }),
-    };
-    expect(extractOutcomeCount("emailsDelivered", stats)).toBe(135);
+    const metrics = buildSourceMetrics(
+      makeEmailStats({ delivered: 90 }),
+      makeEmailStats({ delivered: 45 }),
+    );
+    expect(extractOutcomeCount("emailsDelivered", metrics)).toBe(135);
+  });
+
+  it("extracts non-email metrics (leadsServed, outletsDiscovered)", () => {
+    const metrics = { leadsServed: 42, outletsDiscovered: 7 };
+    expect(extractOutcomeCount("leadsServed", metrics)).toBe(42);
+    expect(extractOutcomeCount("outletsDiscovered", metrics)).toBe(7);
   });
 
   it("throws for unknown stats key", () => {
-    const stats = {
-      transactional: makeEmailStats(),
-      broadcast: makeEmailStats(),
-    };
-    expect(() => extractOutcomeCount("unknownMetric", stats)).toThrow(
-      'Unknown objective metric: "unknownMetric"'
+    const metrics = buildSourceMetrics(makeEmailStats(), makeEmailStats());
+    expect(() => extractOutcomeCount("unknownMetric", metrics)).toThrow(
+      'Metric "unknownMetric" not found in source metrics'
     );
   });
 });
@@ -193,5 +222,17 @@ describe("rescoreForObjective", () => {
     const byClicks = rescoreForObjective([scoreA, scoreB], "emailsClicked");
     expect(byClicks[0].costPerOutcome).toBe(100); // A
     expect(byClicks[1].costPerOutcome).toBe(10); // B
+  });
+
+  it("works with non-email source metrics (leadsServed)", () => {
+    const score = makeScore({
+      totalCost: 2000,
+      completedRuns: 10,
+      extraMetrics: { leadsServed: 40, leadsContacted: 20 },
+    });
+
+    const rescored = rescoreForObjective([score], "leadsServed");
+    expect(rescored[0].totalOutcomes).toBe(40);
+    expect(rescored[0].costPerOutcome).toBe(50); // 2000 / 40
   });
 });


### PR DESCRIPTION
## Summary
- Ranking and best endpoints now fetch metrics from lead, journalists, and outlets services based on the stats registry `source` field — not just email-gateway
- New `source-stats-client.ts` with uniform `SourceStatsMap` return type for all source services
- `WorkflowScore` now carries a generic `sourceMetrics: Record<string, number>` map populated from all sources, enabling `rescoreForObjective` to work with any metric (leadsServed, outletsDiscovered, journalistsFound, etc.)
- `extractOutcomeCount` reads from the generic metrics map instead of hardcoded email stats fields
- Auth mode passes the registry to `computeWorkflowScores` which routes to the appropriate source services; public mode still works without additional sources (no identity available)

## Test plan
- [x] All 375 unit tests pass (33 test files)
- [x] TypeScript compiles cleanly
- [x] New test: `extractOutcomeCount` works with non-email metrics (leadsServed, outletsDiscovered)
- [x] New test: `rescoreForObjective` works with non-email source metrics
- [x] Existing tests updated for new `sourceMetrics`-based API without breaking backward compat
- [ ] Integration: verify ranked/best endpoints return correct data for lead-discovery and PR-outreach features in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)