### PR TITLE
feat: use workflowSlugs filter on journalists-service stats

### DIFF
--- a/src/lib/source-stats-client.ts
+++ b/src/lib/source-stats-client.ts
@@ -73,7 +73,10 @@ export async function fetchJournalistStats(
 ): Promise<SourceStatsMap> {
   if (workflowSlugs.length === 0) return new Map();
   const { baseUrl, apiKey } = getServiceConfig("JOURNALISTS");
-  const params = new URLSearchParams({ groupBy: "workflowSlug" });
+  const params = new URLSearchParams({
+    groupBy: "workflowSlug",
+    workflowSlugs: workflowSlugs.join(","),
+  });
 
   const res = await fetch(`${baseUrl}/stats?${params}`, {
     headers: {
@@ -96,7 +99,6 @@ export async function fetchJournalistStats(
   const result: SourceStatsMap = new Map();
   if (body.groupedBy) {
     for (const [slug, stats] of Object.entries(body.groupedBy)) {
-      if (!workflowSlugs.includes(slug)) continue;
       result.set(slug, {
         journalistsFound: stats.totalJournalists,
         journalistsContacted: stats.byStatus?.contacted ?? 0,


### PR DESCRIPTION
## Summary
- Pass `workflowSlugs` query param to journalists-service `GET /stats` now that PR #35 added support for it
- Removes client-side filtering — server returns only requested slugs
- Reduces payload size for ranking computations

## Test plan
- [x] 375 unit tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)