### PR TITLE
feat: use workflowSlugs filter on outlets-service stats

### DIFF
--- a/src/lib/source-stats-client.ts
+++ b/src/lib/source-stats-client.ts
@@ -114,7 +114,10 @@ export async function fetchOutletStats(
 ): Promise<SourceStatsMap> {
   if (workflowSlugs.length === 0) return new Map();
   const { baseUrl, apiKey } = getServiceConfig("OUTLETS");
-  const params = new URLSearchParams({ groupBy: "workflowSlug" });
+  const params = new URLSearchParams({
+    groupBy: "workflowSlug",
+    workflowSlugs: workflowSlugs.join(","),
+  });
 
   const res = await fetch(`${baseUrl}/outlets/stats?${params}`, {
     headers: {
@@ -136,7 +139,6 @@ export async function fetchOutletStats(
 
   const result: SourceStatsMap = new Map();
   for (const g of body.groups) {
-    if (!workflowSlugs.includes(g.key)) continue;
     result.set(g.key, {
       outletsDiscovered: g.outletsDiscovered,
       searchQueriesUsed: g.searchQueriesUsed,


### PR DESCRIPTION
## Summary
- Pass `workflowSlugs` query param to outlets-service `GET /outlets/stats` now that PR #32 added support for it
- Removes client-side filtering — server returns only requested slugs
- Reduces payload size for ranking computations

## Test plan
- [x] 375 unit tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)