### PR TITLE
fix: forward identity headers to features-service

### DIFF
--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -11,6 +11,22 @@ export interface FeatureDynasty {
   featureDynastySlug: string;
 }
 
+/** Headers to forward to features-service for auth. */
+export interface ForwardHeaders {
+  "x-org-id": string;
+  "x-user-id": string;
+  "x-run-id": string;
+}
+
+/** Extract forward headers from an Express request. */
+export function extractForwardHeaders(req: { headers: Record<string, string | string[] | undefined> }): ForwardHeaders {
+  return {
+    "x-org-id": req.headers["x-org-id"] as string,
+    "x-user-id": req.headers["x-user-id"] as string,
+    "x-run-id": req.headers["x-run-id"] as string,
+  };
+}
+
 function getFeaturesServiceConfig(): { baseUrl: string; apiKey: string } | null {
   const baseUrl = process.env.FEATURES_SERVICE_URL;
   const apiKey = process.env.FEATURES_SERVICE_API_KEY;
@@ -29,6 +45,7 @@ function getFeaturesServiceConfig(): { baseUrl: string; apiKey: string } | null 
  */
 export async function resolveFeatureDynasty(
   featureSlug: string,
+  forwardHeaders?: ForwardHeaders,
 ): Promise<FeatureDynasty> {
   const config = getFeaturesServiceConfig();
 
@@ -38,7 +55,7 @@ export async function resolveFeatureDynasty(
         `${config.baseUrl}/features/dynasty?slug=${encodeURIComponent(featureSlug)}`,
         {
           method: "GET",
-          headers: { "x-api-key": config.apiKey },
+          headers: { "x-api-key": config.apiKey, ...forwardHeaders },
         },
       );
 
@@ -95,6 +112,7 @@ function deriveFromSlug(featureSlug: string): FeatureDynasty {
  */
 export async function resolveFeatureDynastySlugs(
   dynastySlug: string,
+  forwardHeaders?: ForwardHeaders,
 ): Promise<string[]> {
   const config = getFeaturesServiceConfig();
   if (!config) {
@@ -107,7 +125,7 @@ export async function resolveFeatureDynastySlugs(
     `${config.baseUrl}/features/dynasty/slugs?dynastySlug=${encodeURIComponent(dynastySlug)}`,
     {
       method: "GET",
-      headers: { "x-api-key": config.apiKey },
+      headers: { "x-api-key": config.apiKey, ...forwardHeaders },
     },
   );
 
@@ -137,6 +155,7 @@ export interface FeatureOutput {
  */
 export async function fetchFeatureOutputs(
   featureSlug: string,
+  forwardHeaders?: ForwardHeaders,
 ): Promise<FeatureOutput[]> {
   const config = getFeaturesServiceConfig();
   if (!config) {
@@ -149,7 +168,7 @@ export async function fetchFeatureOutputs(
     `${config.baseUrl}/features/${encodeURIComponent(featureSlug)}`,
     {
       method: "GET",
-      headers: { "x-api-key": config.apiKey },
+      headers: { "x-api-key": config.apiKey, ...forwardHeaders },
     },
   );
 
@@ -177,7 +196,9 @@ export interface StatsRegistryEntry {
  * Returns a map of stats key → { type, label }.
  * Throws if features-service is not configured or returns an error.
  */
-export async function fetchStatsRegistry(): Promise<Record<string, StatsRegistryEntry>> {
+export async function fetchStatsRegistry(
+  forwardHeaders?: ForwardHeaders,
+): Promise<Record<string, StatsRegistryEntry>> {
   const config = getFeaturesServiceConfig();
   if (!config) {
     throw new Error(
@@ -187,7 +208,7 @@ export async function fetchStatsRegistry(): Promise<Record<string, StatsRegistry
 
   const res = await fetch(`${config.baseUrl}/stats/registry`, {
     method: "GET",
-    headers: { "x-api-key": config.apiKey },
+    headers: { "x-api-key": config.apiKey, ...forwardHeaders },
   });
 
   if (!res.ok) {

--- a/src/routes/public-workflows.ts
+++ b/src/routes/public-workflows.ts
@@ -15,13 +15,14 @@ import {
   handleExternalServiceError,
   type WorkflowScore,
 } from "../lib/workflow-scoring.js";
-import { fetchFeatureOutputs, fetchStatsRegistry, resolveFeatureDynastySlugs } from "../lib/features-client.js";
+import { fetchFeatureOutputs, fetchStatsRegistry, resolveFeatureDynastySlugs, type ForwardHeaders } from "../lib/features-client.js";
 
 const router = Router();
 
 async function resolveObjectives(
   objective: string | undefined,
   featureSlug: string | undefined,
+  forwardHeaders?: ForwardHeaders,
 ): Promise<{ objectives: string[]; registry?: Record<string, import("../lib/features-client.js").StatsRegistryEntry> }> {
   if (objective) return { objectives: [objective] };
 
@@ -32,8 +33,8 @@ async function resolveObjectives(
   }
 
   const [outputs, registry] = await Promise.all([
-    fetchFeatureOutputs(featureSlug),
-    fetchStatsRegistry(),
+    fetchFeatureOutputs(featureSlug, forwardHeaders),
+    fetchStatsRegistry(forwardHeaders),
   ]);
   const countMetrics = outputs
     .map((o) => o.key)

--- a/src/routes/workflow-runs.ts
+++ b/src/routes/workflow-runs.ts
@@ -11,7 +11,7 @@ import { collectServiceEnvs } from "../lib/service-envs.js";
 import { createRun } from "../lib/runs-client.js";
 import { ExecuteWorkflowSchema, ExecuteByNameSchema } from "../schemas.js";
 import { parseWindmillError } from "../lib/error-parser.js";
-import { resolveFeatureDynastySlugs } from "../lib/features-client.js";
+import { resolveFeatureDynastySlugs, extractForwardHeaders } from "../lib/features-client.js";
 
 const router = Router();
 
@@ -418,7 +418,7 @@ router.get("/workflow-runs", requireApiKey, async (req, res) => {
       conditions.push(eq(workflowRuns.featureSlug, featureSlug));
     }
     if (featureDynastySlug && typeof featureDynastySlug === "string") {
-      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
+      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug, extractForwardHeaders(req));
       conditions.push(inArray(workflowRuns.featureSlug, versionedSlugs));
     }
     if (workflowSlug && typeof workflowSlug === "string") {

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -41,7 +41,7 @@ import {
   handleExternalServiceError,
   type WorkflowScore,
 } from "../lib/workflow-scoring.js";
-import { resolveFeatureDynasty, resolveFeatureDynastySlugs, fetchFeatureOutputs, fetchStatsRegistry } from "../lib/features-client.js";
+import { resolveFeatureDynasty, resolveFeatureDynastySlugs, fetchFeatureOutputs, fetchStatsRegistry, extractForwardHeaders, type ForwardHeaders } from "../lib/features-client.js";
 
 const router = Router();
 
@@ -54,6 +54,7 @@ const router = Router();
 async function resolveObjectives(
   objective: string | undefined,
   featureSlug: string | undefined,
+  forwardHeaders?: ForwardHeaders,
 ): Promise<{ objectives: string[]; registry?: Record<string, import("../lib/features-client.js").StatsRegistryEntry> }> {
   if (objective) return { objectives: [objective] };
 
@@ -64,8 +65,8 @@ async function resolveObjectives(
   }
 
   const [outputs, registry] = await Promise.all([
-    fetchFeatureOutputs(featureSlug),
-    fetchStatsRegistry(),
+    fetchFeatureOutputs(featureSlug, forwardHeaders),
+    fetchStatsRegistry(forwardHeaders),
   ]);
   const countMetrics = outputs
     .map((o) => o.key)
@@ -229,7 +230,7 @@ router.post("/workflows/generate", requireApiKey, createRateLimit, async (req, r
         signatureName = pickSignatureName(signature, usedNames);
       }
 
-      const dynasty = await resolveFeatureDynasty(body.featureSlug);
+      const dynasty = await resolveFeatureDynasty(body.featureSlug, extractForwardHeaders(req));
       const dynastyName = `${dynasty.featureDynastyName} ${signatureName.charAt(0).toUpperCase() + signatureName.slice(1)}`;
       const dynastySlug = `${dynasty.featureDynastySlug}-${signatureName}`;
       const newVersion = existing ? existing.version + 1 : 1;
@@ -355,7 +356,7 @@ router.post("/workflows", requireApiKey, createRateLimit, async (req, res) => {
     const usedNames = new Set(existingWorkflows.map((w) => w.signatureName));
     const signatureName = pickSignatureName(signature, usedNames);
 
-    const dynasty = await resolveFeatureDynasty(body.featureSlug);
+    const dynasty = await resolveFeatureDynasty(body.featureSlug, extractForwardHeaders(req));
     const dynastyName = `${dynasty.featureDynastyName} ${signatureName.charAt(0).toUpperCase() + signatureName.slice(1)}`;
     const dynastySlug = `${dynasty.featureDynastySlug}-${signatureName}`;
     const slug = dynastySlug;
@@ -738,7 +739,7 @@ router.put("/workflows/upgrade", requireApiKey, async (req, res) => {
         const signatureName = pickSignatureName(signature, usedNames);
         usedNames.add(signatureName);
 
-        const dynasty = await resolveFeatureDynasty(wf.featureSlug);
+        const dynasty = await resolveFeatureDynasty(wf.featureSlug, extractForwardHeaders(req));
         const dynastyName = `${dynasty.featureDynastyName} ${signatureName.charAt(0).toUpperCase() + signatureName.slice(1)}`;
         const dynastySlug = `${dynasty.featureDynastySlug}-${signatureName}`;
         const slug = dynastySlug;
@@ -848,7 +849,7 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
     if (featureDynastySlug) {
-      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
+      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug, extractForwardHeaders(req));
       conditions.push(inArray(workflows.featureSlug, versionedSlugs));
     }
 
@@ -864,7 +865,7 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
     }
 
     // Resolve which metrics to rank by (from feature outputs or explicit objective)
-    const { objectives, registry } = await resolveObjectives(objective, featureSlug);
+    const { objectives, registry } = await resolveObjectives(objective, featureSlug, extractForwardHeaders(req));
 
     // Fetch base scores once — objective only affects outcome computation, which we re-score per metric
     const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objectives[0], { kind: "auth", identity }, registry);
@@ -995,13 +996,13 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
     };
 
     // Resolve which metrics to compute best records for
-    const { objectives, registry } = await resolveObjectives(undefined, featureSlug);
+    const { objectives, registry } = await resolveObjectives(undefined, featureSlug, extractForwardHeaders(req));
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
     if (featureDynastySlug) {
-      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
+      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug, extractForwardHeaders(req));
       conditions.push(inArray(workflows.featureSlug, versionedSlugs));
     }
 
@@ -1262,7 +1263,7 @@ router.get("/workflows", requireApiKey, async (req, res) => {
       conditions.push(eq(workflows.featureSlug, featureSlug));
     }
     if (featureDynastySlug && typeof featureDynastySlug === "string") {
-      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
+      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug, extractForwardHeaders(req));
       conditions.push(inArray(workflows.featureSlug, versionedSlugs));
     }
     if (workflowSlug && typeof workflowSlug === "string") {
@@ -1483,7 +1484,7 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
     const signatureName = pickSignatureName(newSignature, usedNames);
 
     // Resolve dynasty naming from features-service
-    const dynasty = await resolveFeatureDynasty(existing.featureSlug);
+    const dynasty = await resolveFeatureDynasty(existing.featureSlug, extractForwardHeaders(req));
     const baseDynastyName = `${dynasty.featureDynastyName} ${signatureName.charAt(0).toUpperCase() + signatureName.slice(1)}`;
     const baseDynastySlug = `${dynasty.featureDynastySlug}-${signatureName}`;
     const newSlug = baseDynastySlug; // version 1, no suffix

--- a/tests/integration/public-workflows.test.ts
+++ b/tests/integration/public-workflows.test.ts
@@ -101,6 +101,11 @@ vi.mock("../../src/lib/features-client.js", () => ({
   }),
   fetchFeatureOutputs: vi.fn().mockRejectedValue(new Error("not configured")),
   fetchStatsRegistry: vi.fn().mockRejectedValue(new Error("not configured")),
+  extractForwardHeaders: (req: { headers: Record<string, string | string[] | undefined> }) => ({
+    "x-org-id": req.headers["x-org-id"] as string,
+    "x-user-id": req.headers["x-user-id"] as string,
+    "x-run-id": req.headers["x-run-id"] as string,
+  }),
 }));
 
 import supertest from "supertest";

--- a/tests/integration/workflow-runs.test.ts
+++ b/tests/integration/workflow-runs.test.ts
@@ -101,6 +101,11 @@ vi.mock("../../src/lib/features-client.js", () => ({
   resolveFeatureDynastySlugs: vi.fn().mockImplementation((dynastySlug: string) => {
     return Promise.resolve([dynastySlug, `${dynastySlug}-v2`, `${dynastySlug}-v3`]);
   }),
+  extractForwardHeaders: (req: { headers: Record<string, string | string[] | undefined> }) => ({
+    "x-org-id": req.headers["x-org-id"] as string,
+    "x-user-id": req.headers["x-user-id"] as string,
+    "x-run-id": req.headers["x-run-id"] as string,
+  }),
 }));
 
 import supertest from "supertest";

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -87,6 +87,11 @@ vi.mock("../../src/lib/features-client.js", () => ({
     // Simulate: dynasty slug resolves to itself + versioned variants
     return Promise.resolve([dynastySlug, `${dynastySlug}-v2`, `${dynastySlug}-v3`]);
   }),
+  extractForwardHeaders: (req: { headers: Record<string, string | string[] | undefined> }) => ({
+    "x-org-id": req.headers["x-org-id"] as string,
+    "x-user-id": req.headers["x-user-id"] as string,
+    "x-run-id": req.headers["x-run-id"] as string,
+  }),
 }));
 
 // Mock Windmill client

--- a/tests/unit/features-client.test.ts
+++ b/tests/unit/features-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { resolveFeatureDynastySlugs } from "../../src/lib/features-client.js";
+import { resolveFeatureDynastySlugs, resolveFeatureDynasty, fetchFeatureOutputs, fetchStatsRegistry, extractForwardHeaders } from "../../src/lib/features-client.js";
 
 describe("resolveFeatureDynastySlugs", () => {
   const originalUrl = process.env.FEATURES_SERVICE_URL;
@@ -35,7 +35,7 @@ describe("resolveFeatureDynastySlugs", () => {
       "http://localhost:4000/features/dynasty/slugs?dynastySlug=sales-cold-email",
       expect.objectContaining({
         method: "GET",
-        headers: { "x-api-key": "test-features-key" },
+        headers: expect.objectContaining({ "x-api-key": "test-features-key" }),
       }),
     );
   });
@@ -62,6 +62,201 @@ describe("resolveFeatureDynastySlugs", () => {
 
     await expect(resolveFeatureDynastySlugs("nonexistent")).rejects.toThrow(
       "features-service error",
+    );
+  });
+
+  it("forwards x-org-id, x-user-id, x-run-id headers when provided", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ slugs: ["slug-a"] }),
+      }),
+    );
+
+    const fwdHeaders = {
+      "x-org-id": "org-123",
+      "x-user-id": "user-456",
+      "x-run-id": "run-789",
+    };
+
+    await resolveFeatureDynastySlugs("slug-a", fwdHeaders);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: {
+          "x-api-key": "test-features-key",
+          "x-org-id": "org-123",
+          "x-user-id": "user-456",
+          "x-run-id": "run-789",
+        },
+      }),
+    );
+  });
+});
+
+describe("extractForwardHeaders", () => {
+  it("extracts x-org-id, x-user-id, x-run-id from request headers", () => {
+    const req = {
+      headers: {
+        "x-org-id": "org-abc",
+        "x-user-id": "user-def",
+        "x-run-id": "run-ghi",
+        "x-api-key": "should-not-appear",
+      },
+    };
+
+    const result = extractForwardHeaders(req);
+
+    expect(result).toEqual({
+      "x-org-id": "org-abc",
+      "x-user-id": "user-def",
+      "x-run-id": "run-ghi",
+    });
+  });
+});
+
+describe("resolveFeatureDynasty forwards headers", () => {
+  const originalUrl = process.env.FEATURES_SERVICE_URL;
+  const originalKey = process.env.FEATURES_SERVICE_API_KEY;
+
+  beforeEach(() => {
+    process.env.FEATURES_SERVICE_URL = "http://localhost:4000";
+    process.env.FEATURES_SERVICE_API_KEY = "test-features-key";
+  });
+
+  afterEach(() => {
+    process.env.FEATURES_SERVICE_URL = originalUrl;
+    process.env.FEATURES_SERVICE_API_KEY = originalKey;
+    vi.restoreAllMocks();
+  });
+
+  it("forwards identity headers to features-service", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            feature_dynasty_name: "Sales Cold Email",
+            feature_dynasty_slug: "sales-cold-email",
+          }),
+      }),
+    );
+
+    const fwdHeaders = {
+      "x-org-id": "org-123",
+      "x-user-id": "user-456",
+      "x-run-id": "run-789",
+    };
+
+    await resolveFeatureDynasty("sales-cold-email-v2", fwdHeaders);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: {
+          "x-api-key": "test-features-key",
+          "x-org-id": "org-123",
+          "x-user-id": "user-456",
+          "x-run-id": "run-789",
+        },
+      }),
+    );
+  });
+});
+
+describe("fetchFeatureOutputs forwards headers", () => {
+  const originalUrl = process.env.FEATURES_SERVICE_URL;
+  const originalKey = process.env.FEATURES_SERVICE_API_KEY;
+
+  beforeEach(() => {
+    process.env.FEATURES_SERVICE_URL = "http://localhost:4000";
+    process.env.FEATURES_SERVICE_API_KEY = "test-features-key";
+  });
+
+  afterEach(() => {
+    process.env.FEATURES_SERVICE_URL = originalUrl;
+    process.env.FEATURES_SERVICE_API_KEY = originalKey;
+    vi.restoreAllMocks();
+  });
+
+  it("forwards identity headers to features-service", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ feature: { outputs: [{ key: "emails_sent", displayOrder: 1 }] } }),
+      }),
+    );
+
+    const fwdHeaders = {
+      "x-org-id": "org-123",
+      "x-user-id": "user-456",
+      "x-run-id": "run-789",
+    };
+
+    await fetchFeatureOutputs("sales-cold-email", fwdHeaders);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: {
+          "x-api-key": "test-features-key",
+          "x-org-id": "org-123",
+          "x-user-id": "user-456",
+          "x-run-id": "run-789",
+        },
+      }),
+    );
+  });
+});
+
+describe("fetchStatsRegistry forwards headers", () => {
+  const originalUrl = process.env.FEATURES_SERVICE_URL;
+  const originalKey = process.env.FEATURES_SERVICE_API_KEY;
+
+  beforeEach(() => {
+    process.env.FEATURES_SERVICE_URL = "http://localhost:4000";
+    process.env.FEATURES_SERVICE_API_KEY = "test-features-key";
+  });
+
+  afterEach(() => {
+    process.env.FEATURES_SERVICE_URL = originalUrl;
+    process.env.FEATURES_SERVICE_API_KEY = originalKey;
+    vi.restoreAllMocks();
+  });
+
+  it("forwards identity headers to features-service", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ registry: { emails_sent: { type: "count", label: "Emails Sent" } } }),
+      }),
+    );
+
+    const fwdHeaders = {
+      "x-org-id": "org-123",
+      "x-user-id": "user-456",
+      "x-run-id": "run-789",
+    };
+
+    await fetchStatsRegistry(fwdHeaders);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: {
+          "x-api-key": "test-features-key",
+          "x-org-id": "org-123",
+          "x-user-id": "user-456",
+          "x-run-id": "run-789",
+        },
+      }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- Features-service requires `x-org-id`, `x-user-id`, `x-run-id` headers on all endpoints
- The features-client was only sending `x-api-key`, causing 400 errors on dynasty slug resolution
- Added `ForwardHeaders` type and `extractForwardHeaders` helper to forward identity headers from incoming requests
- Updated all call sites in `workflows.ts`, `workflow-runs.ts`, and `public-workflows.ts`

## Test plan
- [x] Added regression tests for all 4 features-client functions verifying headers are forwarded
- [x] Added unit test for `extractForwardHeaders` helper
- [x] All previously-passing tests continue to pass (23 pre-existing failures unchanged)
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)