### PR TITLE
feat: accept featureDynastySlug on ranked/best endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3680,20 +3680,20 @@
           {
             "schema": {
               "type": "string",
-              "description": "Exact match on the versioned feature slug."
+              "description": "Exact match on the versioned feature slug. Either featureSlug or featureDynastySlug is required."
             },
             "required": false,
-            "description": "Exact match on the versioned feature slug.",
+            "description": "Exact match on the versioned feature slug. Either featureSlug or featureDynastySlug is required.",
             "name": "featureSlug",
             "in": "query"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage."
+              "description": "Feature dynasty slug — resolves to all versioned feature slugs in the lineage. Can be used instead of featureSlug."
             },
             "required": false,
-            "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage.",
+            "description": "Feature dynasty slug — resolves to all versioned feature slugs in the lineage. Can be used instead of featureSlug.",
             "name": "featureDynastySlug",
             "in": "query"
           },
@@ -4326,20 +4326,20 @@
           {
             "schema": {
               "type": "string",
-              "description": "Exact match on the versioned feature slug."
+              "description": "Exact match on the versioned feature slug. Either featureSlug or featureDynastySlug is required."
             },
             "required": false,
-            "description": "Exact match on the versioned feature slug.",
+            "description": "Exact match on the versioned feature slug. Either featureSlug or featureDynastySlug is required.",
             "name": "featureSlug",
             "in": "query"
           },
           {
             "schema": {
               "type": "string",
-              "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage."
+              "description": "Feature dynasty slug — resolves to all versioned feature slugs in the lineage. Can be used instead of featureSlug."
             },
             "required": false,
-            "description": "Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage.",
+            "description": "Feature dynasty slug — resolves to all versioned feature slugs in the lineage. Can be used instead of featureSlug.",
             "name": "featureDynastySlug",
             "in": "query"
           },

--- a/src/routes/public-workflows.ts
+++ b/src/routes/public-workflows.ts
@@ -61,8 +61,16 @@ router.get("/public/workflows/ranked", async (req, res) => {
     }
     const { orgId, brandId, featureSlug, featureDynastySlug, objective, limit, groupBy } = query.data;
 
-    if (!objective && !featureSlug) {
-      res.status(400).json({ error: "Either 'objective' or 'featureSlug' must be provided to determine ranking metrics" });
+    // Resolve effective featureSlug: direct or via dynasty
+    let effectiveFeatureSlug = featureSlug;
+    let dynastyVersionedSlugs: string[] | undefined;
+    if (!effectiveFeatureSlug && featureDynastySlug) {
+      dynastyVersionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
+      effectiveFeatureSlug = dynastyVersionedSlugs[0];
+    }
+
+    if (!objective && !effectiveFeatureSlug) {
+      res.status(400).json({ error: "Either 'objective', 'featureSlug', or 'featureDynastySlug' must be provided to determine ranking metrics" });
       return;
     }
 
@@ -70,8 +78,8 @@ router.get("/public/workflows/ranked", async (req, res) => {
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
     if (featureDynastySlug) {
-      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
-      conditions.push(inArray(workflows.featureSlug, versionedSlugs));
+      dynastyVersionedSlugs ??= await resolveFeatureDynastySlugs(featureDynastySlug);
+      conditions.push(inArray(workflows.featureSlug, dynastyVersionedSlugs));
     }
 
     const allMatchingWorkflows = conditions.length > 0
@@ -85,7 +93,7 @@ router.get("/public/workflows/ranked", async (req, res) => {
       return;
     }
 
-    const { objectives } = await resolveObjectives(objective, featureSlug);
+    const { objectives } = await resolveObjectives(objective, effectiveFeatureSlug);
     const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objectives[0], { kind: "public" as const, brandId, orgId });
 
     function rankForObjectives(inputScores: WorkflowScore[]) {
@@ -195,19 +203,26 @@ router.get("/public/workflows/best", async (req, res) => {
     }
     const { orgId, brandId, featureSlug, featureDynastySlug, by } = query.data;
 
-    if (!featureSlug) {
-      res.status(400).json({ error: "'featureSlug' is required — metrics are derived from the feature's declared outputs" });
+    // Resolve effective featureSlug: direct or via dynasty
+    let effectiveFeatureSlug = featureSlug;
+    let dynastyVersionedSlugs: string[] | undefined;
+    if (!effectiveFeatureSlug && featureDynastySlug) {
+      dynastyVersionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
+      effectiveFeatureSlug = dynastyVersionedSlugs[0];
+    }
+    if (!effectiveFeatureSlug) {
+      res.status(400).json({ error: "'featureSlug' or 'featureDynastySlug' is required — metrics are derived from the feature's declared outputs" });
       return;
     }
 
-    const { objectives } = await resolveObjectives(undefined, featureSlug);
+    const { objectives } = await resolveObjectives(undefined, effectiveFeatureSlug);
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
     if (featureDynastySlug) {
-      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
-      conditions.push(inArray(workflows.featureSlug, versionedSlugs));
+      dynastyVersionedSlugs ??= await resolveFeatureDynastySlugs(featureDynastySlug);
+      conditions.push(inArray(workflows.featureSlug, dynastyVersionedSlugs));
     }
 
     const allMatchingWorkflows = conditions.length > 0

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -835,19 +835,27 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
     }
     const { orgId, brandId, featureSlug, featureDynastySlug, objective, limit, groupBy } = query.data;
 
-    if (!objective && !featureSlug) {
-      res.status(400).json({ error: "Either 'objective' or 'featureSlug' must be provided to determine ranking metrics" });
-      return;
+    const dsHeaders = extractDownstreamHeaders(req);
+
+    // Resolve effective featureSlug: direct or via dynasty
+    let effectiveFeatureSlug = featureSlug;
+    let dynastyVersionedSlugs: string[] | undefined;
+    if (!effectiveFeatureSlug && featureDynastySlug) {
+      dynastyVersionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug, dsHeaders);
+      effectiveFeatureSlug = dynastyVersionedSlugs[0];
     }
 
-    const dsHeaders = extractDownstreamHeaders(req);
+    if (!objective && !effectiveFeatureSlug) {
+      res.status(400).json({ error: "Either 'objective', 'featureSlug', or 'featureDynastySlug' must be provided to determine ranking metrics" });
+      return;
+    }
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
     if (featureDynastySlug) {
-      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug, dsHeaders);
-      conditions.push(inArray(workflows.featureSlug, versionedSlugs));
+      dynastyVersionedSlugs ??= await resolveFeatureDynastySlugs(featureDynastySlug, dsHeaders);
+      conditions.push(inArray(workflows.featureSlug, dynastyVersionedSlugs));
     }
 
     const allMatchingWorkflows = conditions.length > 0
@@ -862,7 +870,7 @@ router.get("/workflows/ranked", requireApiKey, async (req, res) => {
     }
 
     // Resolve which metrics to rank by (from feature outputs or explicit objective)
-    const { objectives, registry } = await resolveObjectives(objective, featureSlug, dsHeaders);
+    const { objectives, registry } = await resolveObjectives(objective, effectiveFeatureSlug, dsHeaders);
 
     // Fetch base scores once — objective only affects outcome computation, which we re-score per metric
     const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objectives[0], { kind: "auth", downstreamHeaders: dsHeaders }, registry);
@@ -981,22 +989,29 @@ router.get("/workflows/best", requireApiKey, async (req, res) => {
     }
     const { orgId, brandId, featureSlug, featureDynastySlug, by } = query.data;
 
-    if (!featureSlug) {
-      res.status(400).json({ error: "'featureSlug' is required — metrics are derived from the feature's declared outputs" });
+    const dsHeaders = extractDownstreamHeaders(req);
+
+    // Resolve effective featureSlug: direct or via dynasty
+    let effectiveFeatureSlug = featureSlug;
+    let dynastyVersionedSlugs: string[] | undefined;
+    if (!effectiveFeatureSlug && featureDynastySlug) {
+      dynastyVersionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug, dsHeaders);
+      effectiveFeatureSlug = dynastyVersionedSlugs[0];
+    }
+    if (!effectiveFeatureSlug) {
+      res.status(400).json({ error: "'featureSlug' or 'featureDynastySlug' is required — metrics are derived from the feature's declared outputs" });
       return;
     }
 
-    const dsHeaders = extractDownstreamHeaders(req);
-
     // Resolve which metrics to compute best records for
-    const { objectives, registry } = await resolveObjectives(undefined, featureSlug, dsHeaders);
+    const { objectives, registry } = await resolveObjectives(undefined, effectiveFeatureSlug, dsHeaders);
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
     if (featureDynastySlug) {
-      const versionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug, dsHeaders);
-      conditions.push(inArray(workflows.featureSlug, versionedSlugs));
+      dynastyVersionedSlugs ??= await resolveFeatureDynastySlugs(featureDynastySlug, dsHeaders);
+      conditions.push(inArray(workflows.featureSlug, dynastyVersionedSlugs));
     }
 
     const allMatchingWorkflows = conditions.length > 0

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -723,8 +723,8 @@ export const BestWorkflowQuerySchema = z
   .object({
     orgId: z.string().optional().describe("Organization ID. When omitted, searches across all orgs."),
     brandId: z.string().optional().describe("Filter workflows by brand ID."),
-    featureSlug: z.string().optional().describe("Exact match on the versioned feature slug."),
-    featureDynastySlug: z.string().optional().describe("Filter by feature dynasty slug — resolves to all versioned feature slugs in the lineage."),
+    featureSlug: z.string().optional().describe("Exact match on the versioned feature slug. Either featureSlug or featureDynastySlug is required."),
+    featureDynastySlug: z.string().optional().describe("Feature dynasty slug — resolves to all versioned feature slugs in the lineage. Can be used instead of featureSlug."),
     by: BestWorkflowBySchema.default("workflow").describe("Granularity: best workflow or best brand. Defaults to 'workflow'."),
   })
   .openapi("BestWorkflowQuery");

--- a/tests/integration/best-workflow.test.ts
+++ b/tests/integration/best-workflow.test.ts
@@ -121,6 +121,25 @@ vi.mock("../../src/lib/key-service-client.js", () => ({
   fetchProviderRequirements: vi.fn(),
 }));
 
+// --- Mock features-client ---
+const mockResolveFeatureDynastySlugs = vi.fn();
+const mockFetchFeatureOutputs = vi.fn();
+const mockFetchStatsRegistry = vi.fn();
+
+vi.mock("../../src/lib/features-client.js", () => ({
+  resolveFeatureDynasty: vi.fn().mockImplementation((featureSlug: string) => {
+    const dynastySlug = featureSlug.replace(/-v\d+$/, "");
+    const dynastyName = dynastySlug
+      .split("-")
+      .map((w: string) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(" ");
+    return Promise.resolve({ featureDynastyName: dynastyName, featureDynastySlug: dynastySlug });
+  }),
+  resolveFeatureDynastySlugs: (...args: unknown[]) => mockResolveFeatureDynastySlugs(...args),
+  fetchFeatureOutputs: (...args: unknown[]) => mockFetchFeatureOutputs(...args),
+  fetchStatsRegistry: (...args: unknown[]) => mockFetchStatsRegistry(...args),
+}));
+
 import supertest from "supertest";
 import app from "../../src/index.js";
 
@@ -227,6 +246,9 @@ describe("GET /workflows/ranked", () => {
     mockWorkflowRunRows.length = 0;
     mockFetchRunCostsAuth.mockReset();
     mockFetchEmailStatsAuth.mockReset();
+    mockResolveFeatureDynastySlugs.mockReset();
+    mockFetchFeatureOutputs.mockReset();
+    mockFetchStatsRegistry.mockReset();
   });
 
   it("returns ranked workflows with stats", async () => {
@@ -252,12 +274,12 @@ describe("GET /workflows/ranked", () => {
     expect(best.stats.email.broadcast).toEqual(EMPTY_STATS);
     // Verify workflowNames filter is passed to both endpoints
     expect(mockFetchRunCostsAuth).toHaveBeenCalledWith(
-      expect.objectContaining({ orgId: "org-1" }),
+      expect.objectContaining({ "x-org-id": "org-1" }),
       [DEFAULT_WF_SLUG],
     );
     expect(mockFetchEmailStatsAuth).toHaveBeenCalledWith(
       [DEFAULT_WF_SLUG],
-      expect.objectContaining({ orgId: "org-1" }),
+      expect.objectContaining({ "x-org-id": "org-1" }),
     );
   });
 
@@ -507,6 +529,36 @@ describe("GET /workflows/ranked", () => {
     expect(feature.stats.email).toBeDefined();
     expect(feature.workflows).toHaveLength(2);
   });
+
+  it("accepts featureDynastySlug as alternative to featureSlug for objective resolution", async () => {
+    const wf = makeWorkflow({ id: "wf-dynasty-ranked" });
+    mockWorkflowRows.push(wf);
+    mockWorkflowRunRows.push(makeRun("wf-dynasty-ranked", "ext-run-dr1"));
+
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 200, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { replied: 8 } } });
+
+    // Mock dynasty resolution → returns the matching featureSlug
+    mockResolveFeatureDynastySlugs.mockResolvedValue(["sales-cold-email-outreach", "sales-cold-email-outreach-v2"]);
+    // Mock feature outputs → emailsReplied is a count metric
+    mockFetchFeatureOutputs.mockResolvedValue([{ key: "emailsReplied", displayOrder: 0 }]);
+    mockFetchStatsRegistry.mockResolvedValue({ emailsReplied: { type: "count", label: "Replies" } });
+
+    const res = await request.get("/workflows/ranked").query({
+      orgId: "org1",
+      featureDynastySlug: "sales-cold-email-outreach",
+    }).set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(1);
+    expect(res.body.results[0].stats.totalOutcomes).toBe(8);
+  });
+
+  it("returns 400 when neither objective, featureSlug, nor featureDynastySlug is provided", async () => {
+    const res = await request.get("/workflows/ranked").query({ orgId: "org1" }).set(AUTH);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/objective.*featureSlug.*featureDynastySlug/);
+  });
 });
 
 // ==================== GET /workflows/best (hero records) ====================
@@ -517,54 +569,79 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRunRows.length = 0;
     mockFetchRunCostsAuth.mockReset();
     mockFetchEmailStatsAuth.mockReset();
+    mockResolveFeatureDynastySlugs.mockReset();
+    mockFetchFeatureOutputs.mockReset();
+    mockFetchStatsRegistry.mockReset();
   });
 
-  it("returns bestCostPerOpen and bestCostPerReply", async () => {
+  // Helper: set up features mocks for best endpoint (which requires featureSlug or featureDynastySlug)
+  function setupFeaturesMock(outputs: Array<{ key: string; displayOrder: number }> = [{ key: "emailsReplied", displayOrder: 0 }]) {
+    mockFetchFeatureOutputs.mockResolvedValue(outputs);
+    mockFetchStatsRegistry.mockResolvedValue(
+      Object.fromEntries(outputs.map((o) => [o.key, { type: "count", label: o.key }]))
+    );
+  }
+
+  const BEST_QUERY = { featureSlug: "sales-cold-email-outreach" };
+
+  it("returns best record keyed by metric", async () => {
     const wf = makeWorkflow({ id: "wf-hero", createdForBrandId: "brand-abc" });
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-hero", "ext-run-hero"));
 
     setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { opened: 10, replied: 5 } } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { replied: 5 } } });
+    setupFeaturesMock([{ key: "emailsReplied", displayOrder: 0 }]);
 
     const res = await request
       .get("/workflows/best")
+      .query(BEST_QUERY)
       .set(AUTH);
 
     expect(res.status).toBe(200);
-    expect(res.body.bestCostPerOpen).toBeDefined();
-    expect(res.body.bestCostPerOpen.workflowId).toBe("wf-hero");
-    expect(res.body.bestCostPerOpen.createdForBrandId).toBe("brand-abc");
-    expect(res.body.bestCostPerOpen.value).toBe(10); // 100 / 10 opens
-    expect(res.body.bestCostPerReply).toBeDefined();
-    expect(res.body.bestCostPerReply.workflowId).toBe("wf-hero");
-    expect(res.body.bestCostPerReply.value).toBe(20); // 100 / 5 replies
+    expect(res.body.best.emailsReplied).toBeDefined();
+    expect(res.body.best.emailsReplied.workflowId).toBe("wf-hero");
+    expect(res.body.best.emailsReplied.createdForBrandId).toBe("brand-abc");
+    expect(res.body.best.emailsReplied.value).toBe(20); // 100 / 5 replies
   });
 
-  it("returns null when no opens or replies exist", async () => {
+  it("returns null when no outcomes exist", async () => {
     const wf = makeWorkflow({ id: "wf-no-outcomes" });
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-no-outcomes", "ext-run-no"));
 
     setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 } });
     setupEmailMock({ [DEFAULT_WF_SLUG]: {} });
+    setupFeaturesMock([{ key: "emailsReplied", displayOrder: 0 }]);
 
     const res = await request
       .get("/workflows/best")
+      .query(BEST_QUERY)
       .set(AUTH);
 
     expect(res.status).toBe(200);
-    expect(res.body.bestCostPerOpen).toBeNull();
-    expect(res.body.bestCostPerReply).toBeNull();
+    expect(res.body.best.emailsReplied).toBeNull();
   });
 
   it("returns 200 with null records when no active workflows exist", async () => {
+    setupFeaturesMock([{ key: "emailsReplied", displayOrder: 0 }]);
+
+    const res = await request
+      .get("/workflows/best")
+      .query(BEST_QUERY)
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.best.emailsReplied).toBeNull();
+  });
+
+  it("returns 400 when neither featureSlug nor featureDynastySlug is provided", async () => {
     const res = await request
       .get("/workflows/best")
       .set(AUTH);
 
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ bestCostPerOpen: null, bestCostPerReply: null });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/featureSlug.*featureDynastySlug/);
   });
 
   it("requires authentication", async () => {
@@ -581,15 +658,16 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRunRows.push(makeRun("wf-dn-hero", "ext-run-dn"));
 
     setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { opened: 10, replied: 5 } } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { replied: 5 } } });
+    setupFeaturesMock([{ key: "emailsReplied", displayOrder: 0 }]);
 
     const res = await request
       .get("/workflows/best")
+      .query(BEST_QUERY)
       .set(AUTH);
 
     expect(res.status).toBe(200);
-    expect(res.body.bestCostPerOpen.workflowName).toBe("Sales Email Cold Outreach Jasmine");
-    expect(res.body.bestCostPerReply.workflowName).toBe("Sales Email Cold Outreach Jasmine");
+    expect(res.body.best.emailsReplied.workflowName).toBe("Sales Email Cold Outreach Jasmine");
   });
 
   it("filters by brandId", async () => {
@@ -600,17 +678,18 @@ describe("GET /workflows/best (hero records)", () => {
 
     setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 }, "sales-email-cold-outreach-other": { cost: 200, runCount: 1 } });
     setupEmailMock({
-      [DEFAULT_WF_SLUG]: { transactional: { opened: 10, replied: 5 } },
-      "sales-email-cold-outreach-other": { transactional: { opened: 10, replied: 5 } },
+      [DEFAULT_WF_SLUG]: { transactional: { replied: 5 } },
+      "sales-email-cold-outreach-other": { transactional: { replied: 5 } },
     });
+    setupFeaturesMock([{ key: "emailsReplied", displayOrder: 0 }]);
 
     const res = await request
       .get("/workflows/best")
-      .query({ brandId: "brand-target" })
+      .query({ ...BEST_QUERY, brandId: "brand-target" })
       .set(AUTH);
 
     expect(res.status).toBe(200);
-    expect(res.body.bestCostPerOpen.createdForBrandId).toBe("brand-target");
+    expect(res.body.best.emailsReplied.createdForBrandId).toBe("brand-target");
   });
 
   it("returns best brand with by=brand", async () => {
@@ -619,19 +698,18 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRunRows.push(makeRun("wf-1", "ext-run-a", "brand-A"), makeRun("wf-1", "ext-run-b", "brand-A"));
 
     setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 600, runCount: 2 } });
-    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { opened: 20, replied: 10 } } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { replied: 10 } } });
+    setupFeaturesMock([{ key: "emailsReplied", displayOrder: 0 }]);
 
     const res = await request
       .get("/workflows/best")
-      .query({ by: "brand" })
+      .query({ ...BEST_QUERY, by: "brand" })
       .set(AUTH);
 
     expect(res.status).toBe(200);
-    expect(res.body.bestCostPerOpen).toBeDefined();
-    expect(res.body.bestCostPerOpen.workflowCount).toBe(1);
-    expect(res.body.bestCostPerOpen.value).toBe(30); // 600 / 20
-    expect(res.body.bestCostPerReply).toBeDefined();
-    expect(res.body.bestCostPerReply.value).toBe(60); // 600 / 10
+    expect(res.body.best.emailsReplied).toBeDefined();
+    expect(res.body.best.emailsReplied.workflowCount).toBe(1);
+    expect(res.body.best.emailsReplied.value).toBe(60); // 600 / 10
   });
 
   it("returns null for by=brand when no branded workflows have outcomes", async () => {
@@ -640,16 +718,16 @@ describe("GET /workflows/best (hero records)", () => {
     mockWorkflowRunRows.push(makeRun("wf-no-brand", "ext-run-nb"));
 
     setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 100, runCount: 1 } });
-    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { opened: 10, replied: 5 } } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { replied: 5 } } });
+    setupFeaturesMock([{ key: "emailsReplied", displayOrder: 0 }]);
 
     const res = await request
       .get("/workflows/best")
-      .query({ by: "brand" })
+      .query({ ...BEST_QUERY, by: "brand" })
       .set(AUTH);
 
     expect(res.status).toBe(200);
-    expect(res.body.bestCostPerOpen).toBeNull();
-    expect(res.body.bestCostPerReply).toBeNull();
+    expect(res.body.best.emailsReplied).toBeNull();
   });
 
   it("picks the best from multiple workflows", async () => {
@@ -662,18 +740,40 @@ describe("GET /workflows/best (hero records)", () => {
 
     setupCostsMock({ [nameExp]: { cost: 500, runCount: 1 }, [nameCheap]: { cost: 500, runCount: 1 } });
     setupEmailMock({
-      [nameExp]: { transactional: { opened: 2, replied: 1 } },
-      [nameCheap]: { transactional: { opened: 100, replied: 50 } },
+      [nameExp]: { transactional: { replied: 1 } },
+      [nameCheap]: { transactional: { replied: 50 } },
     });
+    setupFeaturesMock([{ key: "emailsReplied", displayOrder: 0 }]);
 
     const res = await request
       .get("/workflows/best")
+      .query(BEST_QUERY)
       .set(AUTH);
 
     expect(res.status).toBe(200);
-    // wf-cheap has lower cost-per-open (500/100=5 vs 500/2=250) and cost-per-reply
-    expect(res.body.bestCostPerOpen.workflowId).toBe("wf-cheap");
-    expect(res.body.bestCostPerReply.workflowId).toBe("wf-cheap");
+    // wf-cheap has lower cost-per-reply (500/50=10 vs 500/1=500)
+    expect(res.body.best.emailsReplied.workflowId).toBe("wf-cheap");
+  });
+
+  it("accepts featureDynastySlug as alternative to featureSlug", async () => {
+    const wf = makeWorkflow({ id: "wf-dynasty-best" });
+    mockWorkflowRows.push(wf);
+    mockWorkflowRunRows.push(makeRun("wf-dynasty-best", "ext-run-db1"));
+
+    setupCostsMock({ [DEFAULT_WF_SLUG]: { cost: 200, runCount: 1 } });
+    setupEmailMock({ [DEFAULT_WF_SLUG]: { transactional: { replied: 10 } } });
+    setupFeaturesMock([{ key: "emailsReplied", displayOrder: 0 }]);
+    mockResolveFeatureDynastySlugs.mockResolvedValue(["sales-cold-email-outreach", "sales-cold-email-outreach-v2"]);
+
+    const res = await request
+      .get("/workflows/best")
+      .query({ featureDynastySlug: "sales-cold-email-outreach" })
+      .set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.best.emailsReplied).toBeDefined();
+    expect(res.body.best.emailsReplied.workflowId).toBe("wf-dynasty-best");
+    expect(res.body.best.emailsReplied.value).toBe(20); // 200 / 10
   });
 });
 
@@ -767,7 +867,7 @@ describe("GET /workflows/dynasty/stats", () => {
     setupCostsMock({ "cold-email-sequoia-v2": { cost: 100, runCount: 1 }, "cold-email-sequoia": { cost: 200, runCount: 1 } });
     setupEmailMock({ "cold-email-sequoia-v2": { transactional: { replied: 5 } }, "cold-email-sequoia": { transactional: { replied: 10 } } });
 
-    const res = await request.get("/workflows/dynasty/stats").query({ dynastySlug: "cold-email-sequoia" }).set(AUTH);
+    const res = await request.get("/workflows/dynasty/stats").query({ dynastySlug: "cold-email-sequoia", objective: "emailsReplied" }).set(AUTH);
 
     expect(res.status).toBe(200);
     expect(res.body.dynastySlug).toBe("cold-email-sequoia");
@@ -785,7 +885,7 @@ describe("GET /workflows/dynasty/stats", () => {
   });
 
   it("returns 404 when no workflows match", async () => {
-    const res = await request.get("/workflows/dynasty/stats").query({ dynastySlug: "nonexistent" }).set(AUTH);
+    const res = await request.get("/workflows/dynasty/stats").query({ dynastySlug: "nonexistent", objective: "emailsReplied" }).set(AUTH);
     expect(res.status).toBe(404);
   });
 });

--- a/tests/integration/public-workflows.test.ts
+++ b/tests/integration/public-workflows.test.ts
@@ -99,8 +99,8 @@ vi.mock("../../src/lib/features-client.js", () => ({
   resolveFeatureDynastySlugs: vi.fn().mockImplementation((dynastySlug: string) => {
     return Promise.resolve([dynastySlug, `${dynastySlug}-v2`, `${dynastySlug}-v3`]);
   }),
-  fetchFeatureOutputs: vi.fn().mockRejectedValue(new Error("not configured")),
-  fetchStatsRegistry: vi.fn().mockRejectedValue(new Error("not configured")),
+  fetchFeatureOutputs: vi.fn().mockResolvedValue([{ key: "emailsReplied", displayOrder: 0 }]),
+  fetchStatsRegistry: vi.fn().mockResolvedValue({ emailsReplied: { type: "count", label: "Replies" } }),
 }));
 
 import supertest from "supertest";
@@ -183,6 +183,8 @@ describe("GET /public/workflows/ranked", () => {
     mockFetchEmailStatsPublic.mockReset();
   });
 
+  const RANKED_QUERY = { objective: "emailsReplied" };
+
   it("returns ranked workflows without auth headers", async () => {
     const wf = makeWorkflow({ id: "wf-pub" });
     mockWorkflowRows.push(wf);
@@ -197,7 +199,7 @@ describe("GET /public/workflows/ranked", () => {
 
     const res = await request
       .get("/public/workflows/ranked")
-      .query({ category: "sales", channel: "email", audienceType: "cold-outreach" });
+      .query(RANKED_QUERY);
 
     expect(res.status).toBe(200);
     expect(res.body.results).toHaveLength(1);
@@ -220,7 +222,7 @@ describe("GET /public/workflows/ranked", () => {
 
     const res = await request
       .get("/public/workflows/ranked")
-      .query({ category: "sales", channel: "email", audienceType: "cold-outreach" });
+      .query(RANKED_QUERY);
 
     expect(res.status).toBe(200);
     expect(res.body.results[0]).not.toHaveProperty("dag");
@@ -236,7 +238,7 @@ describe("GET /public/workflows/ranked", () => {
 
     await request
       .get("/public/workflows/ranked")
-      .query({ category: "sales", channel: "email", audienceType: "cold-outreach" });
+      .query(RANKED_QUERY);
 
     // Verify public functions are called
     expect(mockFetchRunCostsPublic).toHaveBeenCalled();
@@ -260,7 +262,7 @@ describe("GET /public/workflows/ranked", () => {
 
     const res = await request
       .get("/public/workflows/ranked")
-      .query({ groupBy: "feature" });
+      .query({ ...RANKED_QUERY, groupBy: "feature" });
 
     expect(res.status).toBe(200);
     expect(res.body.features).toBeDefined();
@@ -272,7 +274,7 @@ describe("GET /public/workflows/ranked", () => {
   it("returns 200 with empty results when no workflows match", async () => {
     const res = await request
       .get("/public/workflows/ranked")
-      .query({ category: "sales", channel: "email", audienceType: "cold-outreach" });
+      .query(RANKED_QUERY);
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ results: [] });
@@ -295,7 +297,7 @@ describe("GET /public/workflows/ranked", () => {
 
     const res = await request
       .get("/public/workflows/ranked")
-      .query({ groupBy: "brand" });
+      .query({ ...RANKED_QUERY, groupBy: "brand" });
 
     expect(res.status).toBe(200);
     expect(res.body.brands).toBeDefined();
@@ -319,7 +321,7 @@ describe("GET /public/workflows/ranked", () => {
 
     const res = await request
       .get("/public/workflows/ranked")
-      .query({ brandId: "brand-y" });
+      .query({ ...RANKED_QUERY, brandId: "brand-y" });
 
     expect(res.status).toBe(200);
     expect(res.body.results).toHaveLength(1);
@@ -338,6 +340,8 @@ describe("GET /public/workflows/best", () => {
     mockFetchEmailStatsPublic.mockReset();
   });
 
+  const BEST_QUERY = { featureSlug: "sales-email-cold-outreach" };
+
   it("returns hero records without auth headers", async () => {
     const wf = makeWorkflow({ id: "wf-hero-pub", createdForBrandId: "brand-abc" });
     mockWorkflowRows.push(wf);
@@ -347,22 +351,21 @@ describe("GET /public/workflows/best", () => {
       { workflowSlug: DEFAULT_WF_SLUG, totalCostInUsdCents: 100, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { opened: 10, replied: 5 } }),
+      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { replied: 5 } }),
     ]);
 
     const res = await request
-      .get("/public/workflows/best");
+      .get("/public/workflows/best")
+      .query(BEST_QUERY);
 
     expect(res.status).toBe(200);
-    expect(res.body.bestCostPerOpen).toBeDefined();
-    expect(res.body.bestCostPerOpen.workflowId).toBe("wf-hero-pub");
-    expect(res.body.bestCostPerOpen.createdForBrandId).toBe("brand-abc");
-    expect(res.body.bestCostPerOpen.value).toBe(10); // 100 / 10 opens
-    expect(res.body.bestCostPerReply.workflowId).toBe("wf-hero-pub");
-    expect(res.body.bestCostPerReply.value).toBe(20); // 100 / 5 replies
+    expect(res.body.best.emailsReplied).toBeDefined();
+    expect(res.body.best.emailsReplied.workflowId).toBe("wf-hero-pub");
+    expect(res.body.best.emailsReplied.createdForBrandId).toBe("brand-abc");
+    expect(res.body.best.emailsReplied.value).toBe(20); // 100 / 5 replies
   });
 
-  it("returns null when no opens or replies exist", async () => {
+  it("returns null when no outcomes exist", async () => {
     const wf = makeWorkflow({ id: "wf-no-out" });
     mockWorkflowRows.push(wf);
     mockWorkflowRunRows.push(makeRun("wf-no-out", "ext-run-no"));
@@ -375,19 +378,28 @@ describe("GET /public/workflows/best", () => {
     ]);
 
     const res = await request
-      .get("/public/workflows/best");
+      .get("/public/workflows/best")
+      .query(BEST_QUERY);
 
     expect(res.status).toBe(200);
-    expect(res.body.bestCostPerOpen).toBeNull();
-    expect(res.body.bestCostPerReply).toBeNull();
+    expect(res.body.best.emailsReplied).toBeNull();
   });
 
   it("returns 200 with null records when no active workflows exist", async () => {
     const res = await request
-      .get("/public/workflows/best");
+      .get("/public/workflows/best")
+      .query(BEST_QUERY);
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ bestCostPerOpen: null, bestCostPerReply: null });
+    expect(res.body.best.emailsReplied).toBeNull();
+  });
+
+  it("returns 400 when neither featureSlug nor featureDynastySlug is provided", async () => {
+    const res = await request
+      .get("/public/workflows/best");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/featureSlug.*featureDynastySlug/);
   });
 
   it("calls public fetch functions without identity", async () => {
@@ -397,10 +409,10 @@ describe("GET /public/workflows/best", () => {
 
     mockFetchRunCostsPublic.mockResolvedValue([]);
     mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { opened: 10 } }),
+      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { replied: 10 } }),
     ]);
 
-    await request.get("/public/workflows/best");
+    await request.get("/public/workflows/best").query(BEST_QUERY);
 
     expect(mockFetchRunCostsPublic).toHaveBeenCalled();
     expect(mockFetchEmailStatsPublic).toHaveBeenCalled();
@@ -420,17 +432,16 @@ describe("GET /public/workflows/best", () => {
       { workflowSlug: DEFAULT_WF_SLUG, totalCostInUsdCents: 600, runCount: 2 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { opened: 20, replied: 10 } }),
+      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { replied: 10 } }),
     ]);
 
     const res = await request
       .get("/public/workflows/best")
-      .query({ by: "brand" });
+      .query({ ...BEST_QUERY, by: "brand" });
 
     expect(res.status).toBe(200);
-    expect(res.body.bestCostPerOpen).toBeDefined();
-    expect(res.body.bestCostPerOpen.workflowCount).toBe(1);
-    expect(res.body.bestCostPerReply).toBeDefined();
+    expect(res.body.best.emailsReplied).toBeDefined();
+    expect(res.body.best.emailsReplied.workflowCount).toBe(1);
   });
 
   it("supports brandId filter", async () => {
@@ -442,14 +453,35 @@ describe("GET /public/workflows/best", () => {
       { workflowSlug: DEFAULT_WF_SLUG, totalCostInUsdCents: 100, runCount: 1 },
     ]);
     mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { opened: 10, replied: 5 } }),
+      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { replied: 5 } }),
     ]);
 
     const res = await request
       .get("/public/workflows/best")
-      .query({ brandId: "brand-z" });
+      .query({ ...BEST_QUERY, brandId: "brand-z" });
 
     expect(res.status).toBe(200);
-    expect(res.body.bestCostPerOpen.createdForBrandId).toBe("brand-z");
+    expect(res.body.best.emailsReplied.createdForBrandId).toBe("brand-z");
+  });
+
+  it("accepts featureDynastySlug as alternative to featureSlug", async () => {
+    const wf = makeWorkflow({ id: "wf-dynasty-pub" });
+    mockWorkflowRows.push(wf);
+    mockWorkflowRunRows.push(makeRun("wf-dynasty-pub", "ext-run-dp"));
+
+    mockFetchRunCostsPublic.mockResolvedValue([
+      { workflowSlug: DEFAULT_WF_SLUG, totalCostInUsdCents: 200, runCount: 1 },
+    ]);
+    mockFetchEmailStatsPublic.mockResolvedValue([
+      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { replied: 10 } }),
+    ]);
+
+    const res = await request
+      .get("/public/workflows/best")
+      .query({ featureDynastySlug: "sales-email-cold-outreach" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.best.emailsReplied).toBeDefined();
+    expect(res.body.best.emailsReplied.workflowId).toBe("wf-dynasty-pub");
   });
 });


### PR DESCRIPTION
## Summary
- `/workflows/ranked`, `/workflows/best`, `/public/workflows/ranked`, `/public/workflows/best` now accept `featureDynastySlug` as an alternative to `featureSlug`
- When `featureDynastySlug` is provided, resolves it to versioned slugs via features-service and uses the first one for metric resolution
- Fixes the 400 error reported by the front-end team (`'featureSlug' is required`) when callers only have a dynasty slug
- Updates stale tests to match the new `{ best: Record<metricKey, record> }` response format and required query params

## Test plan
- [x] 537 tests pass (38 test files)
- [x] TypeScript compiles cleanly
- [x] New test: `featureDynastySlug` accepted on auth ranked, auth best, and public best
- [x] New test: 400 when neither objective, featureSlug, nor featureDynastySlug provided
- [x] Fixed stale best/ranked tests referencing old `bestCostPerOpen`/`bestCostPerReply` format
- [x] `openapi.json` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)