### PR TITLE
revert: undo header forwarding in public endpoints (#203)

### DIFF
--- a/src/routes/public-workflows.ts
+++ b/src/routes/public-workflows.ts
@@ -16,7 +16,7 @@ import {
   type WorkflowScore,
 } from "../lib/workflow-scoring.js";
 import { fetchFeatureOutputs, fetchStatsRegistry, resolveFeatureDynastySlugs } from "../lib/features-client.js";
-import { extractDownstreamHeaders, type DownstreamHeaders } from "../lib/downstream-headers.js";
+import type { DownstreamHeaders } from "../lib/downstream-headers.js";
 
 const router = Router();
 
@@ -60,13 +60,12 @@ router.get("/public/workflows/ranked", async (req, res) => {
       return;
     }
     const { orgId, brandId, featureSlug, featureDynastySlug, objective, limit, groupBy } = query.data;
-    const downstreamHeaders = extractDownstreamHeaders(req);
 
     // Resolve effective featureSlug: direct or via dynasty
     let effectiveFeatureSlug = featureSlug;
     let dynastyVersionedSlugs: string[] | undefined;
     if (!effectiveFeatureSlug && featureDynastySlug) {
-      dynastyVersionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug, downstreamHeaders);
+      dynastyVersionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
       effectiveFeatureSlug = dynastyVersionedSlugs[0];
     }
 
@@ -79,7 +78,7 @@ router.get("/public/workflows/ranked", async (req, res) => {
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
     if (featureDynastySlug) {
-      dynastyVersionedSlugs ??= await resolveFeatureDynastySlugs(featureDynastySlug, downstreamHeaders);
+      dynastyVersionedSlugs ??= await resolveFeatureDynastySlugs(featureDynastySlug);
       conditions.push(inArray(workflows.featureSlug, dynastyVersionedSlugs));
     }
 
@@ -94,7 +93,7 @@ router.get("/public/workflows/ranked", async (req, res) => {
       return;
     }
 
-    const { objectives } = await resolveObjectives(objective, effectiveFeatureSlug, downstreamHeaders);
+    const { objectives } = await resolveObjectives(objective, effectiveFeatureSlug);
     const { scores, runBrandMap, workflowRunIds } = await computeWorkflowScores(activeWorkflows, [], objectives[0], { kind: "public" as const, brandId, orgId });
 
     function rankForObjectives(inputScores: WorkflowScore[]) {
@@ -203,13 +202,12 @@ router.get("/public/workflows/best", async (req, res) => {
       return;
     }
     const { orgId, brandId, featureSlug, featureDynastySlug, by } = query.data;
-    const downstreamHeaders = extractDownstreamHeaders(req);
 
     // Resolve effective featureSlug: direct or via dynasty
     let effectiveFeatureSlug = featureSlug;
     let dynastyVersionedSlugs: string[] | undefined;
     if (!effectiveFeatureSlug && featureDynastySlug) {
-      dynastyVersionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug, downstreamHeaders);
+      dynastyVersionedSlugs = await resolveFeatureDynastySlugs(featureDynastySlug);
       effectiveFeatureSlug = dynastyVersionedSlugs[0];
     }
     if (!effectiveFeatureSlug) {
@@ -217,13 +215,13 @@ router.get("/public/workflows/best", async (req, res) => {
       return;
     }
 
-    const { objectives } = await resolveObjectives(undefined, effectiveFeatureSlug, downstreamHeaders);
+    const { objectives } = await resolveObjectives(undefined, effectiveFeatureSlug);
 
     const conditions: ReturnType<typeof eq>[] = [];
     if (orgId) conditions.push(eq(workflows.orgId, orgId));
     if (featureSlug) conditions.push(eq(workflows.featureSlug, featureSlug));
     if (featureDynastySlug) {
-      dynastyVersionedSlugs ??= await resolveFeatureDynastySlugs(featureDynastySlug, downstreamHeaders);
+      dynastyVersionedSlugs ??= await resolveFeatureDynastySlugs(featureDynastySlug);
       conditions.push(inArray(workflows.featureSlug, dynastyVersionedSlugs));
     }
 

--- a/tests/integration/public-workflows.test.ts
+++ b/tests/integration/public-workflows.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { VALID_LINEAR_DAG } from "../helpers/fixtures.js";
 
-const mockResolveFeatureDynastySlugs = vi.fn().mockImplementation((dynastySlug: string) => {
-  return Promise.resolve([dynastySlug, `${dynastySlug}-v2`, `${dynastySlug}-v3`]);
-});
-
 // --- Mock DB with table awareness ---
 const mockWorkflowRows: Record<string, unknown>[] = [];
 const mockWorkflowRunRows: Record<string, unknown>[] = [];
@@ -100,7 +96,9 @@ vi.mock("../../src/lib/features-client.js", () => ({
       .join(" ");
     return Promise.resolve({ featureDynastyName: dynastyName, featureDynastySlug: dynastySlug });
   }),
-  resolveFeatureDynastySlugs: (...args: unknown[]) => mockResolveFeatureDynastySlugs(...args),
+  resolveFeatureDynastySlugs: vi.fn().mockImplementation((dynastySlug: string) => {
+    return Promise.resolve([dynastySlug, `${dynastySlug}-v2`, `${dynastySlug}-v3`]);
+  }),
   fetchFeatureOutputs: vi.fn().mockResolvedValue([{ key: "emailsReplied", displayOrder: 0 }]),
   fetchStatsRegistry: vi.fn().mockResolvedValue({ emailsReplied: { type: "count", label: "Replies" } }),
 }));
@@ -328,32 +326,6 @@ describe("GET /public/workflows/ranked", () => {
     expect(res.status).toBe(200);
     expect(res.body.results).toHaveLength(1);
   });
-
-  it("forwards downstream headers to resolveFeatureDynastySlugs", async () => {
-    mockResolveFeatureDynastySlugs.mockClear();
-    const wf = makeWorkflow({ id: "wf-hdr" });
-    mockWorkflowRows.push(wf);
-    mockWorkflowRunRows.push(makeRun("wf-hdr", "ext-run-hdr"));
-
-    mockFetchRunCostsPublic.mockResolvedValue([]);
-    mockFetchEmailStatsPublic.mockResolvedValue([]);
-
-    await request
-      .get("/public/workflows/ranked")
-      .set("x-org-id", "org-test")
-      .set("x-user-id", "user-test")
-      .set("x-run-id", "run-test")
-      .query({ featureDynastySlug: "sales-email-cold-outreach", objective: "emailsReplied" });
-
-    expect(mockResolveFeatureDynastySlugs).toHaveBeenCalledWith(
-      "sales-email-cold-outreach",
-      expect.objectContaining({
-        "x-org-id": "org-test",
-        "x-user-id": "user-test",
-        "x-run-id": "run-test",
-      }),
-    );
-  });
 });
 
 // ==================== GET /public/workflows/best ====================
@@ -490,36 +462,6 @@ describe("GET /public/workflows/best", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.best.emailsReplied.createdForBrandId).toBe("brand-z");
-  });
-
-  it("forwards downstream headers to resolveFeatureDynastySlugs", async () => {
-    mockResolveFeatureDynastySlugs.mockClear();
-    const wf = makeWorkflow({ id: "wf-hdr-best" });
-    mockWorkflowRows.push(wf);
-    mockWorkflowRunRows.push(makeRun("wf-hdr-best", "ext-run-hdr-best"));
-
-    mockFetchRunCostsPublic.mockResolvedValue([
-      { workflowSlug: DEFAULT_WF_SLUG, totalCostInUsdCents: 100, runCount: 1 },
-    ]);
-    mockFetchEmailStatsPublic.mockResolvedValue([
-      makeEmailGroup(DEFAULT_WF_SLUG, { transactional: { replied: 5 } }),
-    ]);
-
-    await request
-      .get("/public/workflows/best")
-      .set("x-org-id", "org-test")
-      .set("x-user-id", "user-test")
-      .set("x-run-id", "run-test")
-      .query({ featureDynastySlug: "sales-email-cold-outreach" });
-
-    expect(mockResolveFeatureDynastySlugs).toHaveBeenCalledWith(
-      "sales-email-cold-outreach",
-      expect.objectContaining({
-        "x-org-id": "org-test",
-        "x-user-id": "user-test",
-        "x-run-id": "run-test",
-      }),
-    );
   });
 
   it("accepts featureDynastySlug as alternative to featureSlug", async () => {


### PR DESCRIPTION
## Summary
- Reverts #203 — that fix was wrong
- Public endpoints (`/ranked`, `/best`) are called from the landing page with no auth context — there are no `x-org-id`/`x-user-id`/`x-run-id` headers to forward
- The real fix is for features-service to expose a public endpoint for `/features/dynasty/slugs` that doesn't require auth headers

## Test plan
- [x] All 15 existing public-workflows tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)