### PR TITLE
feat: switch workflow generation to Google Pro model

### DIFF
--- a/src/lib/chat-service-client.ts
+++ b/src/lib/chat-service-client.ts
@@ -1,10 +1,14 @@
+export type ChatProvider = "anthropic" | "google";
+export type ChatModel = "haiku" | "sonnet" | "opus" | "flash-lite" | "flash" | "pro";
+
 export interface ChatServiceCompleteRequest {
   message: string;
   systemPrompt: string;
   responseFormat?: "json";
   temperature?: number;
   maxTokens?: number;
-  model?: "claude-sonnet-4-6" | "claude-haiku-4-5";
+  provider: ChatProvider;
+  model: ChatModel;
 }
 
 export interface ChatServiceCompleteResponse {

--- a/src/lib/workflow-generator.ts
+++ b/src/lib/workflow-generator.ts
@@ -115,7 +115,8 @@ export async function generateWorkflow(
         systemPrompt,
         responseFormat: "json",
         maxTokens: 16384,
-        model: "claude-sonnet-4-6",
+        provider: "google",
+        model: "pro",
       },
       downstreamHeaders,
     );

--- a/src/lib/workflow-upgrader.ts
+++ b/src/lib/workflow-upgrader.ts
@@ -101,7 +101,8 @@ export async function upgradeWorkflow(
         systemPrompt,
         responseFormat: "json",
         maxTokens: 16384,
-        model: "claude-sonnet-4-6",
+        provider: "google",
+        model: "pro",
       },
       chatHeaders,
     );

--- a/tests/unit/workflow-generator.test.ts
+++ b/tests/unit/workflow-generator.test.ts
@@ -340,13 +340,14 @@ describe("generateWorkflow", () => {
     expect(call.responseFormat).toBe("json");
   });
 
-  it("uses claude-sonnet-4-6 model", async () => {
+  it("uses google pro model", async () => {
     mockComplete.mockResolvedValueOnce(createMockResponse(VALID_LINEAR_DAG));
 
     await generateWorkflow({ description: "test workflow" }, TEST_IDENTITY);
 
     const call = mockComplete.mock.calls[0][0] as ChatServiceCompleteRequest;
-    expect(call.model).toBe("claude-sonnet-4-6");
+    expect(call.provider).toBe("google");
+    expect(call.model).toBe("pro");
   });
 
   it("uses 16384 maxTokens", async () => {

--- a/tests/unit/workflow-upgrader.test.ts
+++ b/tests/unit/workflow-upgrader.test.ts
@@ -123,7 +123,7 @@ describe("upgradeWorkflow", () => {
     expect(call.systemPrompt).toContain("FIX a broken workflow");
   });
 
-  it("uses claude-sonnet-4-6 and responseFormat json", async () => {
+  it("uses google pro model and responseFormat json", async () => {
     const mockComplete = vi.fn().mockResolvedValue(createMockResponse(FIXED_DAG));
     setUpgradeChatServiceClient(mockComplete);
 
@@ -136,7 +136,8 @@ describe("upgradeWorkflow", () => {
     );
 
     const call = mockComplete.mock.calls[0][0] as ChatServiceCompleteRequest;
-    expect(call.model).toBe("claude-sonnet-4-6");
+    expect(call.provider).toBe("google");
+    expect(call.model).toBe("pro");
     expect(call.responseFormat).toBe("json");
   });
 


### PR DESCRIPTION
## Summary
- Updates chat-service client to use the new `provider` + `model` (version-free alias) API format instead of the old versioned model IDs
- Switches both `workflow-generator` and `workflow-upgrader` LLM calls from `claude-sonnet-4-6` to `google`/`pro` — the most powerful Google model for complex reasoning tasks like DAG generation

## Test plan
- [x] All 477 existing tests pass
- [x] Updated model assertion tests in both `workflow-generator.test.ts` and `workflow-upgrader.test.ts`
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)