### PR TITLE
fix: don't crash startup on warning-only field issues

### DIFF
--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -112,19 +112,21 @@ export async function validateAndUpgradeWorkflows(
     const dag = wf.dag as DAG;
     const result = validateWorkflowEndpoints(dag, specs);
 
-    // Check for any issues: broken endpoints, field errors, or field warnings
-    const hasIssues = !result.valid || result.fieldIssues.length > 0;
-
-    if (!hasIssues) {
-      validCount++;
-      continue;
-    }
-
+    // Log all field issues (warnings + errors) for visibility
     if (result.fieldIssues.length > 0) {
       console.warn(
         `[workflow-service] Workflow "${wf.slug}" (${wf.id}) has ${result.fieldIssues.length} field issue(s):`,
         result.fieldIssues.map((f) => f.reason).join("; "),
       );
+    }
+
+    // Only attempt upgrade for actual errors — warnings alone don't block startup
+    const hasFieldErrors = result.fieldIssues.some((i) => i.severity === "error");
+    const needsUpgrade = !result.valid || hasFieldErrors;
+
+    if (!needsUpgrade) {
+      validCount++;
+      continue;
     }
 
     if (result.invalidEndpoints.length > 0) {

--- a/tests/unit/startup-validator.test.ts
+++ b/tests/unit/startup-validator.test.ts
@@ -493,7 +493,7 @@ describe("validateAndUpgradeWorkflows", () => {
     expect(dbInserts[0].status).toBe("active");
   });
 
-  it("upgrades workflow with warning-only field issues (unknown body fields)", async () => {
+  it("does not attempt upgrade for warning-only field issues", async () => {
     // Workflow sends "bodyHtml" but schema expects "htmlBody" — this is a warning, not an error
     const WARNING_ONLY_WORKFLOW = {
       ...VALID_WORKFLOW,
@@ -550,50 +550,102 @@ describe("validateAndUpgradeWorkflows", () => {
       new Map([["campaign", SPEC_WITH_KNOWN_FIELDS]]),
     );
 
-
-    mockCreatePlatformRun.mockResolvedValue({ runId: "warning-run-1" });
-    mockClosePlatformRun.mockResolvedValue(undefined);
-
-    const fixedDag = {
-      nodes: [
-        {
-          id: "end-run",
-          type: "http.call",
-          config: { service: "campaign", method: "POST", path: "/end-run" },
-          inputMapping: {
-            "body.campaignId": "$ref:flow_input.campaignId",
-            "body.orgId": "$ref:flow_input.orgId",
-          },
-        },
-      ],
-      edges: [],
-    };
-
-    mockUpgradeWorkflow.mockResolvedValue({
-      dag: fixedDag,
-      category: "sales",
-      channel: "email",
-      audienceType: "cold-outreach",
-      description: "Fixed workflow",
-    });
+    const warnSpy = vi.spyOn(console, "warn");
+    const logSpy = vi.spyOn(console, "log");
 
     await validateAndUpgradeWorkflows({
       db: createMockDb() as any,
       windmillClient: null,
     });
 
-    // Should attempt upgrade even though only warnings (no errors)
-    expect(mockUpgradeWorkflow).toHaveBeenCalledTimes(1);
+    // Should NOT attempt upgrade — warnings don't trigger upgrades
+    expect(mockUpgradeWorkflow).not.toHaveBeenCalled();
 
-    // upgradeWorkflow should receive the warning-level field issues
-    const callArgs = mockUpgradeWorkflow.mock.calls[0];
-    expect(callArgs[1]).toEqual([]); // no invalid endpoints
-    expect(callArgs[2]).toEqual([   // fieldIssues includes warnings
-      expect.objectContaining({ nodeId: "end-run", field: "bodyHtml", severity: "warning" }),
-    ]);
+    // Should still log the warnings for visibility
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('has 1 field issue(s)'),
+      expect.stringContaining('bodyHtml'),
+    );
 
-    // Should have inserted a new upgraded workflow
-    expect(dbInserts.length).toBe(1);
+    // Should count as valid (not failed)
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("1 valid"),
+    );
+
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it("does not crash startup when warnings exist and chat-service is down", async () => {
+    // Regression: warning-only field issues + chat-service 502 should NOT crash the service
+    const WARNING_WORKFLOW = {
+      ...VALID_WORKFLOW,
+      id: "wf-warning-crash",
+      slug: "press-kit-page-generation-cascade",
+      name: "Press Kit Page Generation Cascade",
+      dynastyName: "Press Kit Page Generation Cascade",
+      signatureName: "Cascade",
+      dag: {
+        nodes: [
+          {
+            id: "end-run",
+            type: "http.call",
+            config: { service: "campaign", method: "POST", path: "/end-run" },
+            inputMapping: {
+              "body.success": "$ref:flow_input.success",
+              "body.orgId": "$ref:flow_input.orgId",
+              "body.campaignId": "$ref:flow_input.campaignId",
+            },
+          },
+        ],
+        edges: [],
+      },
+    };
+
+    // Spec says /end-run accepts success + leadFound; orgId/campaignId are unknown → warnings only
+    const CAMPAIGN_SPEC_STRICT = {
+      paths: {
+        "/end-run": {
+          post: {
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["success"],
+                    properties: {
+                      success: { type: "boolean" },
+                      leadFound: { type: "boolean" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    dbSelectResult = [WARNING_WORKFLOW];
+    mockFetchSpecsForServices.mockResolvedValue(
+      new Map([["campaign", CAMPAIGN_SPEC_STRICT]]),
+    );
+
+    // chat-service would fail if called — but it should NOT be called
+    mockUpgradeWorkflow.mockRejectedValue(
+      new Error("chat-service error: POST /complete -> 502 Bad Gateway: Billing service unavailable"),
+    );
+
+    // Should NOT throw — warnings alone don't trigger upgrades or crash
+    await expect(
+      validateAndUpgradeWorkflows({
+        db: createMockDb() as any,
+        windmillClient: null,
+      }),
+    ).resolves.toBeUndefined();
+
+    // Should NOT have attempted upgrade
+    expect(mockUpgradeWorkflow).not.toHaveBeenCalled();
   });
 
   it("throws when upgrade fails (LLM error) and closes platform run as failed", async () => {


### PR DESCRIPTION
## Summary
- Warning-level field issues (unknown body fields like `orgId`/`campaignId` in campaign `/end-run`) were triggering LLM upgrade attempts via chat-service
- When chat-service returned 502 (billing unavailable), these upgrades failed and crashed the service at startup
- Now only severity "error" field issues and broken endpoints trigger upgrades — warnings are logged but don't block startup

## Test plan
- [x] Updated existing test: warning-only field issues no longer trigger upgrade attempts
- [x] Added regression test: warning-only issues + chat-service down → service starts normally
- [x] All 367 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)