### PR TITLE
fix: use /internal/platform-complete for startup upgrades

### DIFF
--- a/src/lib/chat-service-client.ts
+++ b/src/lib/chat-service-client.ts
@@ -59,3 +59,31 @@ export async function chatServiceComplete(
 
   return res.json() as Promise<ChatServiceCompleteResponse>;
 }
+
+/**
+ * Platform-level LLM call — no org/user/run context, no billing.
+ * Uses POST /internal/platform-complete (x-api-key auth only).
+ */
+export async function chatServicePlatformComplete(
+  request: ChatServiceCompleteRequest,
+): Promise<ChatServiceCompleteResponse> {
+  const { baseUrl, apiKey } = getChatServiceConfig();
+
+  const res = await fetch(`${baseUrl}/internal/platform-complete`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `chat-service error: POST /internal/platform-complete -> ${res.status} ${res.statusText}: ${text}`
+    );
+  }
+
+  return res.json() as Promise<ChatServiceCompleteResponse>;
+}

--- a/src/lib/workflow-upgrader.ts
+++ b/src/lib/workflow-upgrader.ts
@@ -12,13 +12,14 @@ import type { DownstreamHeaders } from "./downstream-headers.js";
 import type { InvalidEndpoint, FieldValidationIssue } from "./validate-workflow-endpoints.js";
 import {
   chatServiceComplete,
+  chatServicePlatformComplete,
   type ChatServiceCompleteRequest,
   type ChatServiceCompleteResponse,
 } from "./chat-service-client.js";
 
 const MAX_RETRIES = 2;
 
-let overrideCompleteFn: ((req: ChatServiceCompleteRequest, h: DownstreamHeaders) => Promise<ChatServiceCompleteResponse>) | null = null;
+let overrideCompleteFn: ((req: ChatServiceCompleteRequest, h?: DownstreamHeaders) => Promise<ChatServiceCompleteResponse>) | null = null;
 
 /** Exported for testing — allows injecting a mock chat-service client */
 export function setUpgradeChatServiceClient(fn: typeof overrideCompleteFn): void {
@@ -27,10 +28,11 @@ export function setUpgradeChatServiceClient(fn: typeof overrideCompleteFn): void
 
 async function callComplete(
   request: ChatServiceCompleteRequest,
-  downstreamHeaders: DownstreamHeaders,
+  downstreamHeaders?: DownstreamHeaders,
 ): Promise<ChatServiceCompleteResponse> {
   if (overrideCompleteFn) return overrideCompleteFn(request, downstreamHeaders);
-  return chatServiceComplete(request, downstreamHeaders);
+  if (downstreamHeaders) return chatServiceComplete(request, downstreamHeaders);
+  return chatServicePlatformComplete(request);
 }
 
 async function fetchServiceContext(
@@ -89,9 +91,6 @@ export async function upgradeWorkflow(
     serviceContext,
   });
 
-  const chatHeaders: DownstreamHeaders = downstreamHeaders
-    ?? { "x-org-id": "platform", "x-user-id": "workflow-service", "x-run-id": "startup-upgrade" };
-
   let userMessage = `Fix this workflow. The category is "${metadata.category}", channel is "${metadata.channel}", audienceType is "${metadata.audienceType}". Description: "${metadata.description}". Fix the broken endpoints and field errors listed above.`;
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -104,7 +103,7 @@ export async function upgradeWorkflow(
         provider: "google",
         model: "pro",
       },
-      chatHeaders,
+      downstreamHeaders,
     );
 
     if (!response.json) {

--- a/tests/unit/workflow-upgrader.test.ts
+++ b/tests/unit/workflow-upgrader.test.ts
@@ -182,7 +182,7 @@ describe("upgradeWorkflow", () => {
     ).rejects.toThrow(UpgradeValidationError);
   });
 
-  it("uses platform identity when no identity is provided", async () => {
+  it("passes undefined headers for platform-level calls (no identity)", async () => {
     const mockComplete = vi.fn().mockResolvedValue(createMockResponse(FIXED_DAG));
     setUpgradeChatServiceClient(mockComplete);
 
@@ -194,8 +194,9 @@ describe("upgradeWorkflow", () => {
       METADATA,
     );
 
-    const headers = mockComplete.mock.calls[0][1] as DownstreamHeaders;
-    expect(headers["x-org-id"]).toBe("platform");
-    expect(headers["x-user-id"]).toBe("workflow-service");
+    // When no downstreamHeaders, callComplete receives undefined
+    // which routes to chatServicePlatformComplete (no org/user/run headers)
+    const headers = mockComplete.mock.calls[0][1];
+    expect(headers).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Startup workflow upgrades passed `x-org-id: "platform"` to chat-service `POST /complete`, causing billing to reject with 400 ("not a valid UUID")
- Added `chatServicePlatformComplete()` that hits `POST /internal/platform-complete` (x-api-key only, no billing/run tracking) — per chat-service PR #144
- `callComplete()` now routes: with downstream headers → `/complete`, without → `/internal/platform-complete`
- Removed the fake `"platform"` header fallback from workflow-upgrader

## Test plan
- [x] Updated test: platform-level calls pass `undefined` headers (not fake "platform" org)
- [x] All 367 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)