### PR TITLE
feat: 1-hour timeout on all workflow nodes

### DIFF
--- a/src/lib/dag-to-openflow.ts
+++ b/src/lib/dag-to-openflow.ts
@@ -2,6 +2,9 @@ import type { DAG, DAGNode, DAGEdge } from "./dag-validator.js";
 import { getScriptPath, isNativeNode } from "./node-type-registry.js";
 import { buildInputTransforms } from "./input-mapping.js";
 
+/** Global timeout applied to every script module (in seconds). 1 hour. */
+const NODE_TIMEOUT_SECONDS = 3600;
+
 export interface FlowModule {
   id: string;
   summary?: string;
@@ -11,6 +14,7 @@ export interface FlowModule {
     | BranchOneModule
     | ForloopFlowModule;
   sleep?: { type: "javascript"; expr: string } | { type: "static"; value: number };
+  timeout?: { type: "static"; value: number };
   retry?: { constant?: { attempts: number; seconds: number } };
   stop_after_if?: { expr: string; skip_if_stopped?: boolean };
   skip_if?: { expr: string };
@@ -421,6 +425,7 @@ function nodeToModule(node: DAGNode, dag: DAG): FlowModule | null {
       path: scriptPath,
       input_transforms: inputTransforms,
     },
+    timeout: { type: "static", value: NODE_TIMEOUT_SECONDS },
     retry: retries > 0
       ? { constant: { attempts: retries, seconds: 5 } }
       : { constant: { attempts: 0, seconds: 0 } },

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -622,4 +622,26 @@ describe("dagToOpenFlow", () => {
       expect(transforms.body).toBeUndefined();
     }
   });
+
+  it("sets a 1-hour timeout on every script module", () => {
+    const result = dagToOpenFlow(VALID_LINEAR_DAG, "Timeout Flow");
+
+    for (const mod of result.value.modules) {
+      if (mod.value.type === "script") {
+        expect(mod.timeout).toEqual({ type: "static", value: 3600 });
+      }
+    }
+  });
+
+  it("sets timeout on http.call modules", () => {
+    const result = dagToOpenFlow(DAG_WITH_HTTP_CALL, "HTTP Timeout");
+    const mod = result.value.modules[0];
+    expect(mod.timeout).toEqual({ type: "static", value: 3600 });
+  });
+
+  it("does not set timeout on wait modules", () => {
+    const result = dagToOpenFlow(DAG_WITH_WAIT, "Wait Timeout");
+    const waitMod = result.value.modules.find((m) => m.id === "pause");
+    expect(waitMod!.timeout).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `timeout: { type: "static", value: 3600 }` to every script module in the OpenFlow translation
- Fixes `TimeoutError` on nodes like `fetch_lead` that make multiple sequential downstream calls (google-service, outlets-service, journalists-service, brand-service, articles-service)
- No DB changes, no schema changes — pure OpenFlow generation change

## Test plan
- [x] 3 new unit tests: timeout on script modules, http.call modules, and no timeout on wait modules
- [x] Full suite: 481 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)