### PR TITLE
fix: 409 conflict response returns undefined fields

### DIFF
--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -1125,7 +1125,7 @@ router.put("/workflows/:id", requireApiKey, async (req, res) => {
 
     // Check for existing active workflow with same signature (conflict)
     const [conflicting] = await db
-      .select()
+      .select({ id: workflows.id, slug: workflows.slug })
       .from(workflows)
       .where(
         and(

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -1203,6 +1203,48 @@ describe("PUT /workflows/:id — update (metadata, same-sig DAG, or fork)", () =
     expect(res.body.version).toBe(1);
   });
 
+  it("returns 409 with existingWorkflowId and existingWorkflowSlug when DAG signature conflicts", async () => {
+    const conflictingId = "00000000-0000-4000-8000-000000000099";
+    const existingWf = {
+      id: WF_DAG_REJECT_ID,
+      orgId: "org-1",
+      slug: "sales-email-cold-outreach-pine",
+      name: "Sales Email Cold Outreach Pine",
+      dynastyName: "Sales Email Cold Outreach Pine",
+      dynastySlug: "sales-email-cold-outreach-pine",
+      featureSlug: "sales-email-cold-outreach",
+      signatureName: "pine",
+      signature: "old-sig-123",
+      version: 1,
+      description: "Original",
+      dag: VALID_LINEAR_DAG,
+      tags: [],
+      status: "active",
+      windmillWorkspace: "prod",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const conflictingWf = {
+      id: conflictingId,
+      slug: "sales-email-cold-outreach-maple",
+    };
+
+    // Queue responses: 1) existing lookup, 2) conflict check (found!)
+    mockSelectResponses.push([existingWf]); // existing workflow lookup
+    mockSelectResponses.push([conflictingWf]); // conflicting workflow with same new signature
+
+    const res = await request
+      .put(`/workflows/${WF_DAG_REJECT_ID}`)
+      .set(AUTH)
+      .send({ dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("A workflow with this DAG signature already exists");
+    expect(res.body.existingWorkflowId).toBe(conflictingId);
+    expect(res.body.existingWorkflowSlug).toBe("sales-email-cold-outreach-maple");
+  });
+
   it("returns 404 for non-existent workflow", async () => {
     const res = await request
       .put("/workflows/ffffffff-ffff-4fff-bfff-ffffffffffff")


### PR DESCRIPTION
## Summary
- The `PUT /workflows/:id` endpoint's 409 response was returning `existingWorkflowId: undefined` and `existingWorkflowSlug: undefined` instead of actual values
- Changed the conflict-check query from `select()` (all columns) to `select({ id: workflows.id, slug: workflows.slug })` to ensure fields are deterministically present in the response
- Added regression test verifying the 409 body contains both `existingWorkflowId` and `existingWorkflowSlug`

## Test plan
- [x] New test: 409 conflict returns correct `existingWorkflowId` and `existingWorkflowSlug`
- [x] All 482 existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)