### PR TITLE
fix: drop 10 unused/redundant database indexes

### DIFF
--- a/drizzle/0025_drop_unused_indexes.sql
+++ b/drizzle/0025_drop_unused_indexes.sql
@@ -1,0 +1,35 @@
+-- Drop unused and redundant indexes from workflows and workflow_runs tables.
+--
+-- workflows: 20 indexes for 475 rows is excessive. Dropping 7:
+--   - idx_workflows_name_active: (org_id, slug WHERE active) — redundant with globally-unique idx_workflows_slug_unique
+--   - idx_workflows_signature_active: (org_id, signature WHERE active) — replaced by idx_workflows_active_sig (feature_slug, signature WHERE active)
+--   - idx_workflows_signature_name_active: (org_id, signature_name WHERE active) — replaced by idx_workflows_active_signame (feature_slug, signature_name WHERE active)
+--   - idx_workflows_name_active_unique: (name WHERE active) — 0 scans
+--   - idx_workflows_org_style: (org_id, style_name) — 0 scans
+--   - idx_workflows_campaign: (campaign_id) — 1 scan
+--   - idx_workflows_org: (org_id) — 24 scans, covered by composites
+--
+-- workflow_runs: Dropping 3 zero-scan indexes:
+--   - idx_workflow_runs_brand_ids: GIN on brand_ids — 0 scans
+--   - idx_workflow_runs_windmill_job: windmill_job_id — 0 scans
+--   - idx_workflow_runs_org: org_id — 0 scans
+
+DROP INDEX IF EXISTS idx_workflows_name_active;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_workflows_signature_active;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_workflows_signature_name_active;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_workflows_name_active_unique;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_workflows_org_style;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_workflows_campaign;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_workflows_org;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_workflow_runs_brand_ids;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_workflow_runs_windmill_job;
+--> statement-breakpoint
+DROP INDEX IF EXISTS idx_workflow_runs_org;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1774834300000,
       "tag": "0024_multi_brand_runs",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1775200000000,
+      "tag": "0025_drop_unused_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -45,11 +45,7 @@ export const workflows = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
   },
   (table) => [
-    index("idx_workflows_org").on(table.orgId),
-    index("idx_workflows_campaign").on(table.campaignId),
-    index("idx_workflows_org_style").on(table.orgId, table.styleName),
     uniqueIndex("idx_workflows_slug_unique").on(table.slug),
-    uniqueIndex("idx_workflows_name_active_unique").on(table.name).where(sql`status = 'active'`),
     index("idx_workflows_dynasty_slug").on(table.dynastySlug),
   ]
 );
@@ -80,9 +76,7 @@ export const workflowRuns = pgTable(
   },
   (table) => [
     index("idx_workflow_runs_workflow").on(table.workflowId),
-    index("idx_workflow_runs_windmill_job").on(table.windmillJobId),
     index("idx_workflow_runs_status").on(table.status),
-    index("idx_workflow_runs_org").on(table.orgId),
   ]
 );
 

--- a/tests/unit/migration-journal.test.ts
+++ b/tests/unit/migration-journal.test.ts
@@ -62,6 +62,29 @@ describe("Drizzle migration journal", () => {
     expect(sql).not.toContain("status");
   });
 
+  it("migration 0025 drops all 10 unused/redundant indexes", () => {
+    const sql = readFileSync(resolve(DRIZZLE_DIR, "0025_drop_unused_indexes.sql"), "utf-8");
+
+    // 7 workflows indexes
+    expect(sql).toContain("DROP INDEX IF EXISTS idx_workflows_name_active;");
+    expect(sql).toContain("DROP INDEX IF EXISTS idx_workflows_signature_active;");
+    expect(sql).toContain("DROP INDEX IF EXISTS idx_workflows_signature_name_active;");
+    expect(sql).toContain("DROP INDEX IF EXISTS idx_workflows_name_active_unique;");
+    expect(sql).toContain("DROP INDEX IF EXISTS idx_workflows_org_style;");
+    expect(sql).toContain("DROP INDEX IF EXISTS idx_workflows_campaign;");
+    expect(sql).toContain("DROP INDEX IF EXISTS idx_workflows_org;");
+
+    // 3 workflow_runs indexes
+    expect(sql).toContain("DROP INDEX IF EXISTS idx_workflow_runs_brand_ids;");
+    expect(sql).toContain("DROP INDEX IF EXISTS idx_workflow_runs_windmill_job;");
+    expect(sql).toContain("DROP INDEX IF EXISTS idx_workflow_runs_org;");
+
+    // Uses IF EXISTS for idempotency
+    const dropStatements = sql.match(/DROP INDEX/g);
+    const ifExistsStatements = sql.match(/DROP INDEX IF EXISTS/g);
+    expect(dropStatements?.length).toBe(ifExistsStatements?.length);
+  });
+
   it("includes style columns migration (0010)", () => {
     const entry = journal.entries.find((e) => e.tag === "0010_add_style_columns");
     expect(entry).toBeDefined();


### PR DESCRIPTION
## Summary
- Drops 7 unused/redundant indexes from `workflows` (20→13 indexes for 475 rows): org-scoped unique constraints superseded by feature_slug-scoped ones, plus 3 zero-scan indexes
- Drops 3 zero-scan indexes from `workflow_runs` (7→4 indexes for 24.5K rows): `brand_ids` GIN, `windmill_job_id`, `org_id`
- Updates Drizzle schema to match
- Migration uses `DROP INDEX IF EXISTS` for idempotency

## Context
Neon audit flagged 28K+ seq scans on `workflow_runs` and 18K+ on `workflows`. While the tables are small enough that this isn't causing timeouts, the excess indexes add write overhead and confuse the query planner. The org-scoped unique indexes (`idx_workflows_name_active`, `idx_workflows_signature_active`, `idx_workflows_signature_name_active`) are from before workflows became globally shared — they've been replaced by `idx_workflows_active_sig` and `idx_workflows_active_signame` (feature_slug-scoped).

## Indexes dropped

### workflows (7 dropped)
| Index | Scans | Why |
|---|---|---|
| `idx_workflows_name_active` (org_id, slug WHERE active) | 1,053 | Redundant with global `idx_workflows_slug_unique` |
| `idx_workflows_signature_active` (org_id, signature WHERE active) | 174 | Replaced by `idx_workflows_active_sig` (feature_slug) |
| `idx_workflows_signature_name_active` (org_id, signature_name WHERE active) | 169 | Replaced by `idx_workflows_active_signame` (feature_slug) |
| `idx_workflows_name_active_unique` (name WHERE active) | 0 | Never used |
| `idx_workflows_org_style` (org_id, style_name) | 0 | Never used |
| `idx_workflows_campaign` (campaign_id) | 1 | Essentially unused |
| `idx_workflows_org` (org_id) | 24 | Barely used, covered by composites |

### workflow_runs (3 dropped)
| Index | Scans | Why |
|---|---|---|
| `idx_workflow_runs_brand_ids` (GIN) | 0 | Never used |
| `idx_workflow_runs_windmill_job` | 0 | Never used |
| `idx_workflow_runs_org` | 0 | Never used |

## Test plan
- [x] All 483 existing tests pass
- [x] New migration journal test validates all 10 DROP statements use IF EXISTS
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)