### PR TITLE
fix: update outlets-service stats URL to /org/ prefix

### DIFF
--- a/src/lib/source-stats-client.ts
+++ b/src/lib/source-stats-client.ts
@@ -117,7 +117,7 @@ export async function fetchOutletStats(
     workflowSlugs: workflowSlugs.join(","),
   });
 
-  const res = await fetch(`${baseUrl}/outlets/stats?${params}`, {
+  const res = await fetch(`${baseUrl}/org/outlets/stats?${params}`, {
     headers: {
       "x-api-key": apiKey,
       ...downstreamHeaders,
@@ -126,7 +126,7 @@ export async function fetchOutletStats(
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`outlets-service error: GET /outlets/stats -> ${res.status} ${res.statusText}: ${text}`);
+    throw new Error(`outlets-service error: GET /org/outlets/stats -> ${res.status} ${res.statusText}: ${text}`);
   }
 
   const body = (await res.json()) as {

--- a/tests/unit/source-stats-client.test.ts
+++ b/tests/unit/source-stats-client.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchOutletStats } from "../../src/lib/source-stats-client.js";
+
+describe("fetchOutletStats", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      OUTLETS_SERVICE_URL: "https://outlets.test",
+      OUTLETS_SERVICE_API_KEY: "test-key",
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  const dummyHeaders = {
+    "x-org-id": "org-1",
+    "x-user-id": "user-1",
+    "x-run-id": "run-1",
+    "x-campaign-id": "camp-1",
+    "x-brand-id": "brand-1",
+    "x-feature-slug": "feat",
+    "x-workflow-slug": "wf",
+  } as any;
+
+  it("calls /org/outlets/stats (not /outlets/stats)", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          groups: [
+            { key: "wf-slug", outletsDiscovered: 5, avgRelevanceScore: 0.8, searchQueriesUsed: 3 },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await fetchOutletStats(["wf-slug"], dummyHeaders);
+
+    const calledUrl = spy.mock.calls[0][0] as string;
+    expect(calledUrl).toBe("https://outlets.test/org/outlets/stats?groupBy=workflowSlug&workflowSlugs=wf-slug");
+  });
+
+  it("returns mapped stats by workflow slug", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          groups: [
+            { key: "slug-a", outletsDiscovered: 10, avgRelevanceScore: 0.9, searchQueriesUsed: 7 },
+            { key: "slug-b", outletsDiscovered: 3, avgRelevanceScore: 0.5, searchQueriesUsed: 2 },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await fetchOutletStats(["slug-a", "slug-b"], dummyHeaders);
+
+    expect(result.get("slug-a")).toEqual({ outletsDiscovered: 10, searchQueriesUsed: 7 });
+    expect(result.get("slug-b")).toEqual({ outletsDiscovered: 3, searchQueriesUsed: 2 });
+  });
+
+  it("throws with correct path in error message on non-OK response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("not found", { status: 404, statusText: "Not Found" }),
+    );
+
+    await expect(fetchOutletStats(["x"], dummyHeaders)).rejects.toThrow(
+      "GET /org/outlets/stats",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Updates `fetchOutletStats` to call `GET /org/outlets/stats` instead of `GET /outlets/stats` (outlets-service route prefix migration)
- Adds unit tests for `fetchOutletStats` covering URL correctness, response mapping, and error messages

## Test plan
- [x] 3 new unit tests pass (`source-stats-client.test.ts`)
- [x] Full unit suite (374 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)