### PR TITLE
fix: correct outlets-service stats URL to /orgs/ (plural)

### DIFF
--- a/src/lib/source-stats-client.ts
+++ b/src/lib/source-stats-client.ts
@@ -117,7 +117,7 @@ export async function fetchOutletStats(
     workflowSlugs: workflowSlugs.join(","),
   });
 
-  const res = await fetch(`${baseUrl}/org/outlets/stats?${params}`, {
+  const res = await fetch(`${baseUrl}/orgs/outlets/stats?${params}`, {
     headers: {
       "x-api-key": apiKey,
       ...downstreamHeaders,
@@ -126,7 +126,7 @@ export async function fetchOutletStats(
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`outlets-service error: GET /org/outlets/stats -> ${res.status} ${res.statusText}: ${text}`);
+    throw new Error(`outlets-service error: GET /orgs/outlets/stats -> ${res.status} ${res.statusText}: ${text}`);
   }
 
   const body = (await res.json()) as {

--- a/tests/unit/source-stats-client.test.ts
+++ b/tests/unit/source-stats-client.test.ts
@@ -27,7 +27,7 @@ describe("fetchOutletStats", () => {
     "x-workflow-slug": "wf",
   } as any;
 
-  it("calls /org/outlets/stats (not /outlets/stats)", async () => {
+  it("calls /orgs/outlets/stats (not /outlets/stats)", async () => {
     const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -42,7 +42,7 @@ describe("fetchOutletStats", () => {
     await fetchOutletStats(["wf-slug"], dummyHeaders);
 
     const calledUrl = spy.mock.calls[0][0] as string;
-    expect(calledUrl).toBe("https://outlets.test/org/outlets/stats?groupBy=workflowSlug&workflowSlugs=wf-slug");
+    expect(calledUrl).toBe("https://outlets.test/orgs/outlets/stats?groupBy=workflowSlug&workflowSlugs=wf-slug");
   });
 
   it("returns mapped stats by workflow slug", async () => {
@@ -70,7 +70,7 @@ describe("fetchOutletStats", () => {
     );
 
     await expect(fetchOutletStats(["x"], dummyHeaders)).rejects.toThrow(
-      "GET /org/outlets/stats",
+      "GET /orgs/outlets/stats",
     );
   });
 });


### PR DESCRIPTION
## Summary
- Fixes the outlets-service stats URL from `/org/outlets/stats` (singular, from PR #216) to `/orgs/outlets/stats` (plural) matching the actual v4.0.0 route prefix
- Updates test assertions to match

## Test plan
- [x] 3 unit tests pass (`source-stats-client.test.ts`)
- [x] Full unit suite (374 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)