### PR TITLE
fix: update journalists-service stats URL to /orgs/stats

### DIFF
--- a/src/lib/source-stats-client.ts
+++ b/src/lib/source-stats-client.ts
@@ -76,7 +76,7 @@ export async function fetchJournalistStats(
     workflowSlugs: workflowSlugs.join(","),
   });
 
-  const res = await fetch(`${baseUrl}/stats?${params}`, {
+  const res = await fetch(`${baseUrl}/orgs/stats?${params}`, {
     headers: {
       "x-api-key": apiKey,
       ...downstreamHeaders,
@@ -85,7 +85,7 @@ export async function fetchJournalistStats(
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`journalists-service error: GET /stats -> ${res.status} ${res.statusText}: ${text}`);
+    throw new Error(`journalists-service error: GET /orgs/stats -> ${res.status} ${res.statusText}: ${text}`);
   }
 
   const body = (await res.json()) as {


### PR DESCRIPTION
## Summary
- `GET /stats` → `GET /orgs/stats` per journalists-service PR #74 route migration
- Only call from workflow-service is the grouped stats fetch in `source-stats-client.ts`

## Test plan
- [x] 374 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)