### PR TITLE
fix: update brand-service URLs to new route prefixes

### DIFF
--- a/scripts/nodes/brand-intel.ts
+++ b/scripts/nodes/brand-intel.ts
@@ -24,7 +24,7 @@ export async function main(
   if (runId) reqHeaders["x-run-id"] = runId;
 
   const response = await fetch(
-    `${baseUrl}/brands/${context.brandId}`,
+    `${baseUrl}/internal/brands/${context.brandId}`,
     { headers: reqHeaders }
   );
 

--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -92,7 +92,7 @@ Dot-notation keys create nested objects:
 
 Static body fields go in config.body, dynamic overrides go in inputMapping with dot-notation.
 
-For path parameters (e.g. \`/brands/{brandId}/sales-profile\`), use \`params.*\` in inputMapping:
+For path parameters (e.g. \`/internal/brands/{brandId}\`), use \`params.*\` in inputMapping:
 - "params.brandId": "$ref:start-run.output.brandId" → replaces {brandId} in the path
 
 ## Special Config Keys (stripped before passing to script)
@@ -196,7 +196,7 @@ Campaign service orchestrates workflow execution with budget constraints. Key co
     {
       "id": "brand-profile",
       "type": "http.call",
-      "config": { "service": "brand", "method": "GET", "path": "/brands/{brandId}/sales-profile" },
+      "config": { "service": "brand", "method": "GET", "path": "/internal/brands/{brandId}" },
       "inputMapping": { "params.brandId": "$ref:start-run.output.brandId" }
     },
     {

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -273,7 +273,7 @@ export const DAG_WITH_BANNED_API_SERVICE: DAG = {
     {
       id: "brand-profile",
       type: "http.call",
-      config: { service: "api", method: "GET", path: "/brands/123/profile" },
+      config: { service: "api", method: "GET", path: "/internal/brands/123/profile" },
     },
   ],
   edges: [],
@@ -545,7 +545,7 @@ export const DAG_WITH_PATH_PARAMS: DAG = {
       id: "fetch-brand",
       type: "http.call",
       config: {
-        path: "/brands/:brandId/sales-profile",
+        path: "/internal/brands/:brandId",
         method: "GET",
         service: "brand",
       },

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -613,7 +613,7 @@ describe("dagToOpenFlow", () => {
         { type: string; value?: unknown; expr?: string }
       >;
       // path should remain the static string, NOT be replaced by an object
-      expect(transforms.path).toEqual({ type: "static", value: "/brands/:brandId/sales-profile" });
+      expect(transforms.path).toEqual({ type: "static", value: "/internal/brands/:brandId" });
       // params should contain the dynamic path parameter
       expect(transforms.params).toBeDefined();
       expect(transforms.params.type).toBe("javascript");

--- a/tests/unit/http-call.test.ts
+++ b/tests/unit/http-call.test.ts
@@ -176,7 +176,7 @@ describe("http-call script", () => {
       };
 
       await main(
-        "brand", "POST", "/brands/{brandId}/sales-profile",
+        "brand", "POST", "/internal/brands/{brandId}",
         { workflowSlug: "test" },
         undefined,
         brandServiceEnvs,
@@ -189,7 +189,7 @@ describe("http-call script", () => {
       );
 
       const [url] = mockFetch.mock.calls[0];
-      expect(url).toBe("https://brand.example.com/brands/brand-uuid-123/sales-profile");
+      expect(url).toBe("https://brand.example.com/internal/brands/brand-uuid-123");
     });
 
     it("replaces multiple path params", async () => {

--- a/tests/unit/validate-workflow-endpoints.test.ts
+++ b/tests/unit/validate-workflow-endpoints.test.ts
@@ -650,7 +650,7 @@ describe("field validation — nested object detection in additionalProperties",
 
   const BRAND_SPEC: Record<string, unknown> = {
     paths: {
-      "/brands/{brandId}/sales-profile": {
+      "/internal/brands/{brandId}": {
         get: {
           summary: "Get brand sales profile",
           responses: {
@@ -692,7 +692,7 @@ describe("field validation — nested object detection in additionalProperties",
         {
           id: "brand-profile",
           type: "http.call",
-          config: { service: "brand", method: "GET", path: "/brands/{brandId}/sales-profile" },
+          config: { service: "brand", method: "GET", path: "/internal/brands/{brandId}" },
           inputMapping: {
             "params.brandId": "$ref:flow_input.brandId",
           },
@@ -922,7 +922,7 @@ describe("field validation — nested object detection in additionalProperties",
   it("accepts array-indexed output paths like results.0.value (regression: regulus false positive)", () => {
     const BRAND_EXTRACT_SPEC: Record<string, unknown> = {
       paths: {
-        "/brands/{brandId}/extract-fields": {
+        "/orgs/brands/extract-fields": {
           post: {
             summary: "Extract fields from brand",
             requestBody: {
@@ -973,7 +973,7 @@ describe("field validation — nested object detection in additionalProperties",
         {
           id: "brand-extract",
           type: "http.call",
-          config: { service: "brand", method: "POST", path: "/brands/{brandId}/extract-fields" },
+          config: { service: "brand", method: "POST", path: "/orgs/brands/extract-fields" },
           inputMapping: {
             "body.fields": "$ref:flow_input.fields",
           },


### PR DESCRIPTION
## Summary
- Brand-service applied standard route tier convention (PR #129): all routes now prefixed with `/internal/*` or `/orgs/*`
- Updated `brand-intel.ts` node script: `/brands/{id}` → `/internal/brands/{id}`
- Updated prompt templates and all test fixtures to use new paths
- `extract-fields` path: `/brands/{brandId}/extract-fields` → `/orgs/brands/extract-fields`

## Test plan
- [x] All 486 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)