### PR TITLE
feat: restore dynasty endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1791,6 +1791,230 @@
         }
       }
     },
+    "/workflows/dynasties": {
+      "get": {
+        "summary": "List all dynasties with their versioned workflow slugs",
+        "tags": [
+          "Dynasties"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of dynasties",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "dynasties": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "workflowDynastySlug": {
+                            "type": "string",
+                            "description": "Stable dynasty slug (constant across versions)."
+                          },
+                          "workflowDynastyName": {
+                            "type": "string",
+                            "description": "Stable dynasty display name."
+                          },
+                          "workflowSlugs": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "All versioned workflow slugs belonging to this dynasty."
+                          }
+                        },
+                        "required": [
+                          "workflowDynastySlug",
+                          "workflowDynastyName",
+                          "workflowSlugs"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "dynasties"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/dynasty/slugs": {
+      "get": {
+        "summary": "Resolve a dynasty slug to all versioned workflow slugs",
+        "tags": [
+          "Dynasties"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "The dynasty slug to resolve."
+            },
+            "required": true,
+            "description": "The dynasty slug to resolve.",
+            "name": "workflowDynastySlug",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dynasty resolved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "workflowDynastySlug": {
+                      "type": "string",
+                      "description": "Stable dynasty slug (constant across versions)."
+                    },
+                    "workflowDynastyName": {
+                      "type": "string",
+                      "description": "Stable dynasty display name."
+                    },
+                    "workflowSlugs": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "All versioned workflow slugs belonging to this dynasty."
+                    }
+                  },
+                  "required": [
+                    "workflowDynastySlug",
+                    "workflowDynastyName",
+                    "workflowSlugs"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing query parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No workflows found for this dynasty slug",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/dynasty/stats": {
+      "get": {
+        "summary": "Aggregated stats for a dynasty (full upgrade chain)",
+        "tags": [
+          "Dynasties"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "The dynasty slug to get stats for."
+            },
+            "required": true,
+            "description": "The dynasty slug to get stats for.",
+            "name": "workflowDynastySlug",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Stats key to optimize for (e.g. 'emailsReplied')."
+            },
+            "required": true,
+            "description": "Stats key to optimize for (e.g. 'emailsReplied').",
+            "name": "objective",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dynasty stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "workflowDynastySlug": {
+                      "type": "string"
+                    },
+                    "workflowDynastyName": {
+                      "type": "string"
+                    },
+                    "stats": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "nullable": true
+                      },
+                      "description": "Aggregated stats for the dynasty (costs, email metrics, completed runs)."
+                    }
+                  },
+                  "required": [
+                    "workflowDynastySlug",
+                    "workflowDynastyName",
+                    "stats"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing query parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No workflows found for this dynasty slug",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/workflows/{id}": {
       "get": {
         "summary": "Get a workflow",

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -29,6 +29,7 @@ import { enrichProvidersWithDomains } from "../lib/provider-domains.js";
 import { extractTemplateRefs, validateTemplateContracts, type TemplateContractIssue, type TemplateRef } from "../lib/validate-template-contracts.js";
 import { fetchPromptTemplates } from "../lib/content-generation-client.js";
 import { extractDownstreamHeaders } from "../lib/downstream-headers.js";
+import { computeWorkflowScores, aggregateSectionStats, handleExternalServiceError } from "../lib/workflow-scoring.js";
 
 const router = Router();
 
@@ -789,6 +790,132 @@ router.put("/workflows/upgrade", requireApiKey, async (req, res) => {
     }
     console.error("[workflow-service] PUT deploy error:", err);
     res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// GET /workflows/dynasties — List all dynasties with their versioned workflow slugs
+router.get("/workflows/dynasties", requireApiKey, async (req, res) => {
+  try {
+    const allWorkflows = await db
+      .select({ workflowSlug: workflows.workflowSlug, dynastySlug: workflows.dynastySlug, dynastyName: workflows.dynastyName })
+      .from(workflows);
+
+    const dynastyMap = new Map<string, { dynastyName: string; workflowSlugs: string[] }>();
+    for (const w of allWorkflows) {
+      const entry = dynastyMap.get(w.dynastySlug);
+      if (entry) {
+        entry.workflowSlugs.push(w.workflowSlug);
+      } else {
+        dynastyMap.set(w.dynastySlug, { dynastyName: w.dynastyName, workflowSlugs: [w.workflowSlug] });
+      }
+    }
+
+    const dynasties = [...dynastyMap.entries()].map(([workflowDynastySlug, { dynastyName, workflowSlugs }]) => ({
+      workflowDynastySlug,
+      workflowDynastyName: dynastyName,
+      workflowSlugs,
+    }));
+
+    res.json({ dynasties });
+  } catch (err) {
+    console.error("[workflow-service] GET dynasties error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// GET /workflows/dynasty/slugs — Resolve a dynasty slug to all versioned workflow slugs
+router.get("/workflows/dynasty/slugs", requireApiKey, async (req, res) => {
+  try {
+    const dynastySlug = req.query.workflowDynastySlug ?? req.query.dynastySlug;
+    if (!dynastySlug || typeof dynastySlug !== "string") {
+      res.status(400).json({ error: "Missing required query parameter: workflowDynastySlug" });
+      return;
+    }
+
+    const matching = await db
+      .select({ workflowSlug: workflows.workflowSlug, dynastyName: workflows.dynastyName })
+      .from(workflows)
+      .where(eq(workflows.dynastySlug, dynastySlug));
+
+    if (matching.length === 0) {
+      res.status(404).json({ error: `No workflows found for workflowDynastySlug: ${dynastySlug}` });
+      return;
+    }
+
+    res.json({
+      workflowDynastySlug: dynastySlug,
+      workflowDynastyName: matching[0].dynastyName,
+      workflowSlugs: matching.map((w) => w.workflowSlug),
+    });
+  } catch (err) {
+    console.error("[workflow-service] GET dynasty/slugs error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// GET /workflows/dynasty/stats — Aggregated stats for a dynasty (full upgrade chain)
+router.get("/workflows/dynasty/stats", requireApiKey, async (req, res) => {
+  try {
+    const dynastySlug = req.query.workflowDynastySlug ?? req.query.dynastySlug;
+    if (!dynastySlug || typeof dynastySlug !== "string") {
+      res.status(400).json({ error: "Missing required query parameter: workflowDynastySlug" });
+      return;
+    }
+
+    const objectiveParam = req.query.objective;
+    if (!objectiveParam || typeof objectiveParam !== "string") {
+      res.status(400).json({ error: "Missing required query parameter: objective (stats key, e.g. 'emailsReplied')" });
+      return;
+    }
+    const objective = objectiveParam;
+
+    const dsHeaders = extractDownstreamHeaders(req);
+
+    const allDynastyWorkflows = await db
+      .select()
+      .from(workflows)
+      .where(eq(workflows.dynastySlug, dynastySlug));
+
+    if (allDynastyWorkflows.length === 0) {
+      res.status(404).json({ error: `No workflows found for workflowDynastySlug: ${dynastySlug}` });
+      return;
+    }
+
+    const activeWorkflows = allDynastyWorkflows.filter((w) => w.status === "active");
+    const deprecatedWorkflows = allDynastyWorkflows.filter((w) => w.status === "deprecated");
+
+    if (activeWorkflows.length === 0) {
+      res.json({
+        workflowDynastySlug: dynastySlug,
+        workflowDynastyName: allDynastyWorkflows[0].dynastyName,
+        stats: {
+          totalCostInUsdCents: 0,
+          totalOutcomes: 0,
+          costPerOutcome: null,
+          completedRuns: 0,
+          email: {
+            transactional: { sent: 0, delivered: 0, opened: 0, clicked: 0, replied: 0, bounced: 0, unsubscribed: 0, recipients: 0 },
+            broadcast: { sent: 0, delivered: 0, opened: 0, clicked: 0, replied: 0, bounced: 0, unsubscribed: 0, recipients: 0 },
+          },
+        },
+      });
+      return;
+    }
+
+    const { scores } = await computeWorkflowScores(activeWorkflows, deprecatedWorkflows, objective, { kind: "auth", downstreamHeaders: dsHeaders });
+
+    const stats = aggregateSectionStats(scores);
+
+    res.json({
+      workflowDynastySlug: dynastySlug,
+      workflowDynastyName: allDynastyWorkflows[0].dynastyName,
+      stats,
+    });
+  } catch (err: unknown) {
+    if (!handleExternalServiceError(err, res, "dynasty/stats")) {
+      console.error("[workflow-service] GET dynasty/stats error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
   }
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -797,6 +797,91 @@ registry.registerPath({
   },
 });
 
+const DynastyItemSchema = z.object({
+  workflowDynastySlug: z.string().describe("Stable dynasty slug (constant across versions)."),
+  workflowDynastyName: z.string().describe("Stable dynasty display name."),
+  workflowSlugs: z.array(z.string()).describe("All versioned workflow slugs belonging to this dynasty."),
+});
+
+const DynastyStatsSchema = z.object({
+  workflowDynastySlug: z.string(),
+  workflowDynastyName: z.string(),
+  stats: z.record(z.unknown()).describe("Aggregated stats for the dynasty (costs, email metrics, completed runs)."),
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/workflows/dynasties",
+  summary: "List all dynasties with their versioned workflow slugs",
+  tags: ["Dynasties"],
+  security: [{ apiKey: [] }],
+  responses: {
+    200: {
+      description: "List of dynasties",
+      content: {
+        "application/json": {
+          schema: z.object({ dynasties: z.array(DynastyItemSchema) }),
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/workflows/dynasty/slugs",
+  summary: "Resolve a dynasty slug to all versioned workflow slugs",
+  tags: ["Dynasties"],
+  security: [{ apiKey: [] }],
+  request: {
+    query: z.object({
+      workflowDynastySlug: z.string().describe("The dynasty slug to resolve."),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Dynasty resolved",
+      content: { "application/json": { schema: DynastyItemSchema } },
+    },
+    400: {
+      description: "Missing query parameter",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "No workflows found for this dynasty slug",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/workflows/dynasty/stats",
+  summary: "Aggregated stats for a dynasty (full upgrade chain)",
+  tags: ["Dynasties"],
+  security: [{ apiKey: [] }],
+  request: {
+    query: z.object({
+      workflowDynastySlug: z.string().describe("The dynasty slug to get stats for."),
+      objective: z.string().describe("Stats key to optimize for (e.g. 'emailsReplied')."),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Dynasty stats",
+      content: { "application/json": { schema: DynastyStatsSchema } },
+    },
+    400: {
+      description: "Missing query parameter",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "No workflows found for this dynasty slug",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
 registry.registerPath({
   method: "get",
   path: "/workflows",


### PR DESCRIPTION
## Summary
- Restores the three dynasty endpoints that were incorrectly removed in PR #251:
  - `GET /workflows/dynasties` — list all dynasties with their versioned workflow slugs
  - `GET /workflows/dynasty/slugs?workflowDynastySlug=...` — resolve a dynasty slug to all workflow slugs
  - `GET /workflows/dynasty/stats?workflowDynastySlug=...&objective=...` — aggregated stats for a dynasty
- Response fields use the new naming convention (`workflowDynastySlug`, `workflowDynastyName`, `workflowSlugs`)
- OpenAPI spec updated with all three endpoints

## Context
runs-service's `dynasty-resolver.ts` calls these endpoints. They were removed in PR #251 (which confused feature dynasty with workflow dynasty), causing runs-service to break.

## Test plan
- [x] Build passes
- [x] All 490 tests pass
- [ ] Verify runs-service can call the restored endpoints after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)