### PR TITLE
fix: read campaign status === ongoing after nextRunAt rename

### DIFF
--- a/src/lib/campaign-client.ts
+++ b/src/lib/campaign-client.ts
@@ -10,7 +10,7 @@ interface Campaign {
   id: string;
   workflowSlug: string;
   status: string;
-  toResumeAt: string | null;
+  nextRunAt: string | null;
 }
 
 /**
@@ -50,28 +50,21 @@ export async function fetchAllCampaigns(
 }
 
 /**
- * Returns the set of workflow slugs that are currently "in use" by a campaign.
- * A campaign is considered in-use if:
- *   - status is "active", OR
- *   - toResumeAt is in the future (periodic campaign scheduled to resume).
+ * Returns the set of workflow slugs currently in use by a campaign.
  *
- * A past toResumeAt is ignored — the campaign was scheduled to resume at some
- * point in the past and either has resumed (and moved to a non-active status)
- * or never will.
+ * A campaign is in-use iff its status is "ongoing". Campaign-service uses two
+ * statuses: "ongoing" and "stopped". Gate-blocked campaigns (e.g. waiting for a
+ * budget window) stay "ongoing" with `nextRunAt` set, so a single status check
+ * covers them.
  */
 export async function fetchActiveWorkflowSlugs(
   downstreamHeaders?: DownstreamHeaders,
 ): Promise<Set<string>> {
   const campaigns = await fetchAllCampaigns(downstreamHeaders);
-  const now = Date.now();
 
   const activeSlugs = new Set<string>();
   for (const c of campaigns) {
-    if (c.status === "active") {
-      activeSlugs.add(c.workflowSlug);
-      continue;
-    }
-    if (c.toResumeAt && new Date(c.toResumeAt).getTime() > now) {
+    if (c.status === "ongoing") {
       activeSlugs.add(c.workflowSlug);
     }
   }

--- a/tests/unit/campaign-client.test.ts
+++ b/tests/unit/campaign-client.test.ts
@@ -27,8 +27,8 @@ describe("campaign-client", () => {
 
     it("fetches campaigns from campaign-service", async () => {
       const campaigns = [
-        { id: "c1", workflowSlug: "wf-1", status: "active", toResumeAt: null },
-        { id: "c2", workflowSlug: "wf-2", status: "stopped", toResumeAt: null },
+        { id: "c1", workflowSlug: "wf-1", status: "ongoing", nextRunAt: null },
+        { id: "c2", workflowSlug: "wf-2", status: "stopped", nextRunAt: null },
       ];
 
       vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
@@ -56,15 +56,14 @@ describe("campaign-client", () => {
   });
 
   describe("fetchActiveWorkflowSlugs", () => {
-    it("returns slugs for active campaigns and campaigns whose toResumeAt is in the future", async () => {
+    it("returns slugs only for ongoing campaigns (gate-blocked campaigns stay ongoing with nextRunAt set)", async () => {
       const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
       const past = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
       const campaigns = [
-        { id: "c1", workflowSlug: "wf-active", status: "active", toResumeAt: null },
-        { id: "c2", workflowSlug: "wf-stopped", status: "stopped", toResumeAt: null },
-        { id: "c3", workflowSlug: "wf-paused-future", status: "paused", toResumeAt: future },
-        { id: "c4", workflowSlug: "wf-paused-past", status: "paused", toResumeAt: past },
-        { id: "c5", workflowSlug: "wf-completed", status: "completed", toResumeAt: null },
+        { id: "c1", workflowSlug: "wf-ongoing", status: "ongoing", nextRunAt: null },
+        { id: "c2", workflowSlug: "wf-gate-blocked", status: "ongoing", nextRunAt: future },
+        { id: "c3", workflowSlug: "wf-stopped", status: "stopped", nextRunAt: null },
+        { id: "c4", workflowSlug: "wf-stopped-past", status: "stopped", nextRunAt: past },
       ];
 
       vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
@@ -74,10 +73,9 @@ describe("campaign-client", () => {
       const { fetchActiveWorkflowSlugs } = await import("../../src/lib/campaign-client.js");
       const result = await fetchActiveWorkflowSlugs();
 
-      expect(result).toEqual(new Set(["wf-active", "wf-paused-future"]));
-      expect(result.has("wf-paused-past")).toBe(false);
+      expect(result).toEqual(new Set(["wf-ongoing", "wf-gate-blocked"]));
       expect(result.has("wf-stopped")).toBe(false);
-      expect(result.has("wf-completed")).toBe(false);
+      expect(result.has("wf-stopped-past")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- campaign-service PR #152 (v0.20.0, in prod) renamed `toResumeAt` → `nextRunAt` and reduced status vocabulary to `ongoing` / `stopped`.
- workflow-service was reading `c.toResumeAt` (now `undefined`) and matching `c.status === "active"` (status no longer exists), so `fetchActiveWorkflowSlugs()` returned an empty set for any campaign that wasn't trivially running.
- Workflow GC consequently treated gate-blocked / scheduled campaigns as orphaned and could delete their Windmill flows.

## Fix
- `Campaign.toResumeAt` → `Campaign.nextRunAt` to match the upstream response shape.
- `fetchActiveWorkflowSlugs()` now keys on `c.status === "ongoing"`. Gate-blocked campaigns stay `ongoing` with `nextRunAt` set, so a single status check covers them. Dropped the `nextRunAt`-based OR branch — unreachable today since scheduler never sets `nextRunAt` on stopped rows.
- Test mocks updated to use real campaign-service statuses (`ongoing` / `stopped`); previous mocks referenced statuses (`active`, `paused`, `completed`) that campaign-service never actually emits.

## Test plan
- [x] `pnpm test` — 492 passed
- [x] `grep -rn "toResumeAt |toResume|resumeAt" src/ tests/` — empty
- [ ] Verify Railway prod deploy `status: SUCCESS` post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)