### PR TITLE
hotfix: fix: filter api-service spec from LLM workflow generator/upgrader context

### DIFF
--- a/src/lib/workflow-generator.ts
+++ b/src/lib/workflow-generator.ts
@@ -51,16 +51,28 @@ async function callComplete(
   return chatServiceComplete(request, downstreamHeaders);
 }
 
+// api-service is a proxy — the prompt forbids `service: "api"`. Filter it out of
+// the registry context entirely so the LLM cannot see api-service paths and
+// copy them onto another service's call (e.g. /v1/campaigns/pipeline/gate-check
+// being attached to service="campaign"), which would otherwise 422 on validation.
+const HIDDEN_SERVICES = new Set(["api"]);
+
 async function fetchServiceContext(downstreamHeaders: DownstreamHeaders): Promise<ServiceContext> {
   const context = await fetchLlmContext(downstreamHeaders);
-  const serviceNames = context.services.map((s: { service: string }) => s.service);
+  const visibleServices = context.services.filter(
+    (s: { service: string }) => !HIDDEN_SERVICES.has(s.service),
+  );
+  const serviceNames = visibleServices.map((s: { service: string }) => s.service);
   const specsMap = await fetchSpecsForServices(serviceNames, downstreamHeaders);
 
   const specs: Record<string, unknown> = {};
-  for (const [name, spec] of specsMap) specs[name] = spec;
+  for (const [name, spec] of specsMap) {
+    if (HIDDEN_SERVICES.has(name)) continue;
+    specs[name] = spec;
+  }
 
   return {
-    services: context.services.map((s: { service: string; description?: string; endpointCount: number }) => ({
+    services: visibleServices.map((s: { service: string; description?: string; endpointCount: number }) => ({
       name: s.service,
       description: s.description ?? "",
       endpointCount: s.endpointCount,

--- a/src/lib/workflow-upgrader.ts
+++ b/src/lib/workflow-upgrader.ts
@@ -35,6 +35,11 @@ async function callComplete(
   return chatServicePlatformComplete(request);
 }
 
+// api-service is a proxy — the prompt forbids `service: "api"`. Filter it out of
+// the registry context entirely so the LLM cannot see api-service paths during
+// an upgrade and reapply them to the wrong service.
+const HIDDEN_SERVICES = new Set(["api"]);
+
 async function fetchServiceContext(
   invalidEndpoints: InvalidEndpoint[],
   fieldErrors: FieldValidationIssue[],
@@ -48,20 +53,28 @@ async function fetchServiceContext(
   let services: Array<{ name: string; description: string; endpointCount: number }> = [];
   try {
     const context = await fetchLlmContext(downstreamHeaders);
-    services = context.services.map((s: { service: string; description?: string; endpointCount: number }) => ({
+    const visibleContextServices = context.services.filter(
+      (s: { service: string }) => !HIDDEN_SERVICES.has(s.service),
+    );
+    services = visibleContextServices.map((s: { service: string; description?: string; endpointCount: number }) => ({
       name: s.service,
       description: s.description ?? "",
       endpointCount: s.endpointCount,
     }));
     // Also add all service names from the context so the LLM can find replacements
-    for (const s of context.services) serviceNames.add(s.service);
+    for (const s of visibleContextServices) serviceNames.add(s.service);
   } catch {
     // Non-blocking — proceed with just the broken service specs
   }
 
+  for (const hidden of HIDDEN_SERVICES) serviceNames.delete(hidden);
+
   const specsMap = await fetchSpecsForServices([...serviceNames], downstreamHeaders);
   const specs: Record<string, unknown> = {};
-  for (const [name, spec] of specsMap) specs[name] = spec;
+  for (const [name, spec] of specsMap) {
+    if (HIDDEN_SERVICES.has(name)) continue;
+    specs[name] = spec;
+  }
 
   return { services, specs };
 }

--- a/tests/unit/workflow-generator.test.ts
+++ b/tests/unit/workflow-generator.test.ts
@@ -359,4 +359,58 @@ describe("generateWorkflow", () => {
     expect(mockComplete).toHaveBeenCalledTimes(1);
   });
 
+  it("filters out the 'api' service from LLM context (services list + specs map)", async () => {
+    mockFetchLlmContext.mockResolvedValueOnce({
+      _description: "LLM-friendly context",
+      _usage: "Use this to discover services",
+      services: [
+        { service: "lead", description: "Lead service", endpointCount: 2 },
+        { service: "api", description: "Proxy", endpointCount: 99 },
+        { service: "campaign", description: "Campaign service", endpointCount: 1 },
+      ],
+    });
+    mockFetchSpecsForServices.mockResolvedValueOnce(new Map([
+      ["lead", { paths: { "/buffer/next": { post: {} } } }],
+      ["campaign", { paths: { "/gate-check": { post: {} } } }],
+    ]));
+    mockComplete.mockResolvedValueOnce(createMockResponse(VALID_LINEAR_DAG));
+
+    await generateWorkflow({ description: "test workflow" }, TEST_IDENTITY);
+
+    // 'api' must NOT be passed to fetchSpecsForServices
+    expect(mockFetchSpecsForServices).toHaveBeenCalledWith(
+      ["lead", "campaign"],
+      TEST_IDENTITY,
+    );
+
+    // 'api' must NOT appear in system prompt service list
+    const call = mockComplete.mock.calls[0][0] as ChatServiceCompleteRequest;
+    expect(call.systemPrompt).not.toContain("- **api**:");
+    expect(call.systemPrompt).toContain("- **lead**:");
+    expect(call.systemPrompt).toContain("- **campaign**:");
+  });
+
+  it("filters 'api' from specs map even if returned by registry", async () => {
+    mockFetchLlmContext.mockResolvedValueOnce({
+      _description: "LLM-friendly context",
+      _usage: "Use this to discover services",
+      services: [
+        { service: "lead", description: "Lead service", endpointCount: 2 },
+        { service: "api", description: "Proxy", endpointCount: 99 },
+      ],
+    });
+    // Registry still returns api spec defensively — generator must drop it
+    mockFetchSpecsForServices.mockResolvedValueOnce(new Map([
+      ["lead", { paths: { "/buffer/next": { post: {} } } }],
+      ["api", { paths: { "/v1/campaigns/pipeline/gate-check": { post: {} } } }],
+    ]));
+    mockComplete.mockResolvedValueOnce(createMockResponse(VALID_LINEAR_DAG));
+
+    await generateWorkflow({ description: "test workflow" }, TEST_IDENTITY);
+
+    const call = mockComplete.mock.calls[0][0] as ChatServiceCompleteRequest;
+    expect(call.systemPrompt).not.toContain("/v1/campaigns/pipeline/gate-check");
+    expect(call.systemPrompt).not.toContain('"api":');
+  });
+
 });

--- a/tests/unit/workflow-upgrader.test.ts
+++ b/tests/unit/workflow-upgrader.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import type { DAG } from "../../src/lib/dag-validator.js";
 import type {
   ChatServiceCompleteRequest,
@@ -7,26 +7,40 @@ import type {
 import type { DownstreamHeaders } from "../../src/lib/downstream-headers.js";
 
 // Mock the API registry client
+const mockFetchLlmContext = vi.fn();
+const mockFetchSpecsForServices = vi.fn();
+
 vi.mock("../../src/lib/api-registry-client.js", () => ({
-  fetchLlmContext: vi.fn().mockResolvedValue({
-    services: [
-      {
-        service: "campaign",
-        description: "Campaign service",
-        endpointCount: 3,
-      },
-    ],
-  }),
-  fetchSpecsForServices: vi.fn().mockResolvedValue(new Map([
-    ["campaign", {
-      paths: {
-        "/gate-check": { post: {} },
-        "/start-run": { post: {} },
-        "/end-run": { post: {} },
-      },
-    }],
-  ])),
+  fetchLlmContext: (...args: unknown[]) => mockFetchLlmContext(...args),
+  fetchSpecsForServices: (...args: unknown[]) => mockFetchSpecsForServices(...args),
 }));
+
+const DEFAULT_LLM_CONTEXT = {
+  services: [
+    {
+      service: "campaign",
+      description: "Campaign service",
+      endpointCount: 3,
+    },
+  ],
+};
+
+const DEFAULT_SPECS_MAP = new Map<string, unknown>([
+  ["campaign", {
+    paths: {
+      "/gate-check": { post: {} },
+      "/start-run": { post: {} },
+      "/end-run": { post: {} },
+    },
+  }],
+]);
+
+beforeEach(() => {
+  mockFetchLlmContext.mockReset();
+  mockFetchSpecsForServices.mockReset();
+  mockFetchLlmContext.mockResolvedValue(DEFAULT_LLM_CONTEXT);
+  mockFetchSpecsForServices.mockResolvedValue(DEFAULT_SPECS_MAP);
+});
 
 import {
   upgradeWorkflow,
@@ -198,5 +212,45 @@ describe("upgradeWorkflow", () => {
     // which routes to chatServicePlatformComplete (no org/user/run headers)
     const headers = mockComplete.mock.calls[0][1];
     expect(headers).toBeUndefined();
+  });
+
+  it("filters 'api' from LLM context (services list, invalidEndpoint, fieldError, specs map)", async () => {
+    mockFetchLlmContext.mockResolvedValueOnce({
+      services: [
+        { service: "campaign", description: "Campaign service", endpointCount: 3 },
+        { service: "api", description: "Proxy", endpointCount: 99 },
+      ],
+    });
+    // Registry defensively still returns api spec — upgrader must drop it.
+    // Use a unique marker path that does NOT appear elsewhere (e.g. broken
+    // endpoint list) so the assertion can prove the api spec was filtered.
+    mockFetchSpecsForServices.mockResolvedValueOnce(new Map<string, unknown>([
+      ["campaign", { paths: { "/gate-check": { post: {} } } }],
+      ["api", { paths: { "/UNIQUE_API_ONLY_MARKER_PATH": { post: {} } } }],
+    ]));
+
+    const mockComplete = vi.fn().mockResolvedValue(createMockResponse(FIXED_DAG));
+    setUpgradeChatServiceClient(mockComplete);
+
+    await upgradeWorkflow(
+      BROKEN_DAG,
+      // Broken endpoint references the api service — must still be filtered out of context
+      [{ service: "api", method: "POST", path: "/v1/campaigns/pipeline/gate-check", reason: "not found" }],
+      [{ nodeId: "x", service: "api", method: "POST", path: "/x", field: "body.y", reason: "unknown field" }],
+      IDENTITY,
+      METADATA,
+    );
+
+    // 'api' must NOT be passed to fetchSpecsForServices
+    const specsCallArg = mockFetchSpecsForServices.mock.calls[0][0] as string[];
+    expect(specsCallArg).not.toContain("api");
+    expect(specsCallArg).toContain("campaign");
+
+    // 'api' spec must NOT appear in system prompt. The broken endpoint path
+    // /v1/campaigns/pipeline/gate-check will appear in the Broken Endpoints
+    // section by design; assert on the api-spec-only marker instead.
+    const call = mockComplete.mock.calls[0][0] as ChatServiceCompleteRequest;
+    expect(call.systemPrompt).not.toContain("/UNIQUE_API_ONLY_MARKER_PATH");
+    expect(call.systemPrompt).not.toContain('"api":');
   });
 });


### PR DESCRIPTION
Automated by release.sh