### PR TITLE
feat(cleanup): set Windmill retention 7d + periodic stale/orphan cleanup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { db } from "./db/index.js";
 import { workflowRuns } from "./db/schema.js";
 import { getWindmillClient } from "./lib/windmill-client.js";
 import { JobPoller } from "./lib/job-poller.js";
+import { PeriodicCleanup } from "./lib/periodic-cleanup.js";
 import { requireIdentity } from "./middleware/auth.js";
 import { checkApiRegistryHealth, validateAndUpgradeWorkflows } from "./lib/startup-validator.js";
 import { assertEnvironmentConsistency } from "./lib/env-safety.js";
@@ -66,7 +67,22 @@ if (process.env.NODE_ENV !== "test") {
 
       // Start job poller (only if Windmill is configured)
       const windmillClient = getWindmillClient();
+      let periodicCleanup: PeriodicCleanup | null = null;
       if (windmillClient) {
+        // Set instance-wide retention for Windmill completed_job rows.
+        // 7 days = 604_800 s. CE caps at 30 days; our value is well under.
+        // Requires the API token to be superadmin — fail loud (warn) if not,
+        // but do not block boot: cleanup still works without retention set.
+        try {
+          await windmillClient.setGlobalSetting("retention_period_secs", 604800);
+          console.log("[workflow-service] Windmill retention_period_secs set to 604800 (7 days)");
+        } catch (err) {
+          console.warn(
+            "[workflow-service] Failed to set Windmill retention_period_secs — token may not be superadmin:",
+            err instanceof Error ? err.message : err,
+          );
+        }
+
         // Sync node scripts to Windmill — idempotent, skips unchanged scripts
         try {
           const deployed = await deployNodes(windmillClient);
@@ -80,9 +96,24 @@ if (process.env.NODE_ENV !== "test") {
 
         const poller = new JobPoller(db, windmillClient, workflowRuns);
         poller.start();
+
+        // Periodic cleanup: re-runs stale-deprecation + Windmill orphan-flow
+        // cleanup every 24h. Boot already runs them once in validateAndUpgradeWorkflows;
+        // this keeps the system tidy without requiring service restarts.
+        const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+        periodicCleanup = new PeriodicCleanup(db, windmillClient, ONE_DAY_MS);
+        periodicCleanup.start();
       } else {
         console.log("Windmill not configured (WINDMILL_SERVER_URL / WINDMILL_SERVER_API_KEY missing) — job poller disabled");
       }
+
+      const shutdown = (signal: string) => {
+        console.log(`[workflow-service] ${signal} received — shutting down`);
+        periodicCleanup?.stop();
+        process.exit(0);
+      };
+      process.on("SIGTERM", () => shutdown("SIGTERM"));
+      process.on("SIGINT", () => shutdown("SIGINT"));
 
       app.listen(Number(PORT), "::", () => {
         console.log(`workflow-service running on port ${PORT}`);

--- a/src/lib/periodic-cleanup.ts
+++ b/src/lib/periodic-cleanup.ts
@@ -1,0 +1,98 @@
+import type { db as DbInstance } from "../db/index.js";
+import type { WindmillClient } from "./windmill-client.js";
+import { deprecateStaleWorkflows } from "./stale-workflow-deprecator.js";
+import { cleanupOrphanedWindmillFlows } from "./windmill-flow-cleanup.js";
+import { fetchActiveWorkflowSlugs } from "./campaign-client.js";
+
+type Database = typeof DbInstance;
+
+/**
+ * Periodically re-runs the same cleanup the boot path runs once:
+ *   1. Deprecate stale active workflows (>1 week old, zero runs, no active campaign).
+ *   2. Delete Windmill flows of deprecated workflows no longer referenced by a campaign.
+ *
+ * Both steps independently survive failures of their downstream dependencies
+ * (DB hiccup, campaign-service unreachable) — one bad tick must not stop the loop.
+ */
+export class PeriodicCleanup {
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private db: Database,
+    private windmillClient: WindmillClient,
+    private intervalMs: number,
+  ) {}
+
+  start(): void {
+    if (this.intervalId) return;
+    console.log(
+      `[workflow-service] PeriodicCleanup starting (every ${this.intervalMs}ms)`,
+    );
+    this.intervalId = setInterval(() => {
+      this.runOnce().catch((err) => {
+        console.error(
+          "[workflow-service] PeriodicCleanup tick failed:",
+          err instanceof Error ? err.message : err,
+        );
+      });
+    }, this.intervalMs);
+  }
+
+  stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+      console.log("[workflow-service] PeriodicCleanup stopped");
+    }
+  }
+
+  async runOnce(): Promise<void> {
+    try {
+      const result = await deprecateStaleWorkflows(this.db);
+      if (result.deprecatedCount > 0) {
+        console.log(
+          `[workflow-service] PeriodicCleanup: deprecated ${result.deprecatedCount} stale workflows, kept ${result.keptByCampaign} by active campaign`,
+        );
+      }
+      if (result.skippedNoCampaignService) {
+        console.warn(
+          "[workflow-service] PeriodicCleanup: stale deprecation skipped — campaign-service unreachable",
+        );
+      }
+    } catch (err) {
+      console.error(
+        "[workflow-service] PeriodicCleanup: deprecateStaleWorkflows failed:",
+        err instanceof Error ? err.message : err,
+      );
+    }
+
+    let activeSlugs: Set<string>;
+    try {
+      activeSlugs = await fetchActiveWorkflowSlugs();
+    } catch (err) {
+      console.warn(
+        "[workflow-service] PeriodicCleanup: cannot fetch active campaign slugs — skipping orphan-flow cleanup this tick:",
+        err instanceof Error ? err.message : err,
+      );
+      return;
+    }
+
+    try {
+      const result = await cleanupOrphanedWindmillFlows(
+        this.db,
+        this.windmillClient,
+        activeSlugs,
+      );
+      if (result.deleted > 0 || result.failed > 0) {
+        console.log(
+          `[workflow-service] PeriodicCleanup: Windmill cleanup deleted=${result.deleted} kept=${result.kept} failed=${result.failed}`,
+        );
+      }
+    } catch (err) {
+      console.error(
+        "[workflow-service] PeriodicCleanup: cleanupOrphanedWindmillFlows failed:",
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}

--- a/src/lib/windmill-client.ts
+++ b/src/lib/windmill-client.ts
@@ -135,6 +135,32 @@ export class WindmillClient {
     await this.request("POST", `/jobs/queue/cancel/${jobId}`, { reason });
   }
 
+  // === GLOBAL INSTANCE SETTINGS ===
+
+  /**
+   * Set an instance-wide global setting (not workspace-scoped).
+   * Requires the API token to belong to a superadmin user.
+   * See Windmill `POST /api/settings/global/{key}` (operationId `setGlobal`).
+   */
+  async setGlobalSetting(key: string, value: unknown): Promise<void> {
+    const url = `${this.baseUrl}/api/settings/global/${key}`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ value }),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `Windmill setGlobalSetting "${key}" failed: ${res.status} ${res.statusText}: ${text}`,
+      );
+    }
+  }
+
   // === HEALTH ===
 
   async healthCheck(): Promise<boolean> {

--- a/tests/unit/periodic-cleanup.test.ts
+++ b/tests/unit/periodic-cleanup.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("../../src/lib/stale-workflow-deprecator.js", () => ({
+  deprecateStaleWorkflows: vi.fn(),
+}));
+
+vi.mock("../../src/lib/windmill-flow-cleanup.js", () => ({
+  cleanupOrphanedWindmillFlows: vi.fn(),
+}));
+
+vi.mock("../../src/lib/campaign-client.js", () => ({
+  fetchActiveWorkflowSlugs: vi.fn(),
+}));
+
+import { PeriodicCleanup } from "../../src/lib/periodic-cleanup.js";
+import { deprecateStaleWorkflows } from "../../src/lib/stale-workflow-deprecator.js";
+import { cleanupOrphanedWindmillFlows } from "../../src/lib/windmill-flow-cleanup.js";
+import { fetchActiveWorkflowSlugs } from "../../src/lib/campaign-client.js";
+
+const deprecateMock = vi.mocked(deprecateStaleWorkflows);
+const cleanupMock = vi.mocked(cleanupOrphanedWindmillFlows);
+const fetchSlugsMock = vi.mocked(fetchActiveWorkflowSlugs);
+
+describe("PeriodicCleanup", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("start schedules an interval and stop clears it", () => {
+    vi.useFakeTimers();
+    const db = {} as never;
+    const windmillClient = {} as never;
+    const cleanup = new PeriodicCleanup(db, windmillClient, 60_000);
+
+    cleanup.start();
+    expect(vi.getTimerCount()).toBe(1);
+
+    cleanup.start(); // idempotent — should not double-schedule
+    expect(vi.getTimerCount()).toBe(1);
+
+    cleanup.stop();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("runOnce calls deprecateStaleWorkflows then cleanupOrphanedWindmillFlows with fetched slugs", async () => {
+    deprecateMock.mockResolvedValueOnce({
+      deprecatedCount: 0,
+      keptByCampaign: 0,
+      skippedNoCampaignService: false,
+    });
+    fetchSlugsMock.mockResolvedValueOnce(new Set(["active-slug"]));
+    cleanupMock.mockResolvedValueOnce({ deleted: 0, kept: 0, failed: 0 });
+
+    const db = { tag: "db" } as never;
+    const windmillClient = { tag: "wm" } as never;
+    const cleanup = new PeriodicCleanup(db, windmillClient, 60_000);
+
+    await cleanup.runOnce();
+
+    expect(deprecateMock).toHaveBeenCalledWith(db);
+    expect(fetchSlugsMock).toHaveBeenCalledTimes(1);
+    expect(cleanupMock).toHaveBeenCalledWith(db, windmillClient, new Set(["active-slug"]));
+
+    const deprecateOrder = deprecateMock.mock.invocationCallOrder[0];
+    const cleanupOrder = cleanupMock.mock.invocationCallOrder[0];
+    expect(deprecateOrder).toBeLessThan(cleanupOrder);
+  });
+
+  it("skips cleanupOrphanedWindmillFlows when fetchActiveWorkflowSlugs throws", async () => {
+    deprecateMock.mockResolvedValueOnce({
+      deprecatedCount: 0,
+      keptByCampaign: 0,
+      skippedNoCampaignService: false,
+    });
+    fetchSlugsMock.mockRejectedValueOnce(new Error("campaign-service down"));
+
+    const cleanup = new PeriodicCleanup({} as never, {} as never, 60_000);
+
+    await expect(cleanup.runOnce()).resolves.toBeUndefined();
+    expect(cleanupMock).not.toHaveBeenCalled();
+  });
+
+  it("continues if deprecateStaleWorkflows throws — still attempts cleanup", async () => {
+    deprecateMock.mockRejectedValueOnce(new Error("db blew up"));
+    fetchSlugsMock.mockResolvedValueOnce(new Set());
+    cleanupMock.mockResolvedValueOnce({ deleted: 0, kept: 0, failed: 0 });
+
+    const cleanup = new PeriodicCleanup({} as never, {} as never, 60_000);
+
+    await expect(cleanup.runOnce()).resolves.toBeUndefined();
+    expect(cleanupMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/windmill-client-global-setting.test.ts
+++ b/tests/unit/windmill-client-global-setting.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { WindmillClient } from "../../src/lib/windmill-client.js";
+
+describe("WindmillClient.setGlobalSetting", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("POSTs to /api/settings/global/{key} with no workspace prefix", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("OK", { status: 200 }));
+
+    const client = new WindmillClient({
+      baseUrl: "https://windmill.example.com",
+      token: "tok",
+      workspace: "prod",
+    });
+
+    await client.setGlobalSetting("retention_period_secs", 604800);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://windmill.example.com/api/settings/global/retention_period_secs");
+    expect(init?.method).toBe("POST");
+    const headers = init?.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer tok");
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(init?.body).toBe(JSON.stringify({ value: 604800 }));
+  });
+
+  it("strips trailing slash from baseUrl", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("OK", { status: 200 }));
+
+    const client = new WindmillClient({
+      baseUrl: "https://windmill.example.com/",
+      token: "tok",
+    });
+
+    await client.setGlobalSetting("retention_period_secs", 604800);
+
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      "https://windmill.example.com/api/settings/global/retention_period_secs",
+    );
+  });
+
+  it("throws with status + body on non-2xx response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("forbidden: requires superadmin", {
+        status: 403,
+        statusText: "Forbidden",
+      }),
+    );
+
+    const client = new WindmillClient({
+      baseUrl: "https://windmill.example.com",
+      token: "tok",
+    });
+
+    await expect(
+      client.setGlobalSetting("retention_period_secs", 604800),
+    ).rejects.toThrow(/403.*Forbidden.*forbidden: requires superadmin/);
+  });
+});


### PR DESCRIPTION
## Summary
- **Windmill retention (7d)**: at boot, POST `retention_period_secs=604800` to Windmill `POST /api/settings/global/retention_period_secs` so Windmill auto-purges its `completed_job` rows after 7 days. We do not want to read them — let Windmill garbage-collect itself.
- **Periodic cleanup (24h)**: runs `deprecateStaleWorkflows` + `cleanupOrphanedWindmillFlows` every 24h instead of only at boot. Long-lived containers stay tidy without restarts.
- **Graceful shutdown**: SIGTERM/SIGINT stops the cleanup loop cleanly.

## Why
Today the deprecation + Windmill-flow cleanup only runs at boot, inside `validateAndUpgradeWorkflows`. Containers boot rarely → garbage accumulates. Windmill's own `completed_job` table grows forever because no retention is configured. Both fixed here.

## Implementation notes
- `WindmillClient.setGlobalSetting(key, value)` is the first method that POSTs to `/api/` directly (not `/api/w/{workspace}/`). The endpoint is OSS — checked Windmill source (`backend/windmill-api-settings/src/lib.rs:449` `set_global_setting`), no EE feature gate on the route, just a `require_super_admin` check. CE clamps at 30 days; our 7d is well under.
- If the API token is not superadmin, the call returns 401/403; we log a warn at boot but do not block startup. The downstream cleanup still works without retention being set.
- `PeriodicCleanup.runOnce()` swallows each step independently: a DB failure in step 1 still lets step 2 attempt cleanup; a `campaign-service` outage skips step 2 only.

## Test plan
- [x] Unit tests: `windmill-client-global-setting.test.ts` (3 cases — URL/body shape, trailing slash, non-2xx throws)
- [x] Unit tests: `periodic-cleanup.test.ts` (4 cases — start/stop idempotency, ordering, campaign-service failure, deprecate failure)
- [x] Full unit suite green (411/411)
- [x] `npm run build` clean (TS + OpenAPI regenerate, no spec drift)
- [ ] Staging deploy: verify boot log `Windmill retention_period_secs set to 604800` appears
- [ ] Staging deploy: verify `PeriodicCleanup starting (every 86400000ms)` appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)