### PR TITLE
feat(dag): add script node + Zod enum on node type + enriched validator error

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -258,15 +258,49 @@
           },
           "type": {
             "type": "string",
-            "minLength": 1,
-            "description": "Node type. Use \"http.call\" to call any microservice (recommended), or a specific node type. http.call config requires: service (name, e.g. \"stripe\"), method (HTTP verb), path (endpoint path). Native flow control types: \"condition\" — if/then/else branching (uses Windmill branchone). Outgoing edges with 'condition' define branches; nodes downstream of a conditional edge are nested inside that branch. Outgoing edges without 'condition' define after-branch steps that always execute. \"wait\" — sleep/delay. \"for-each\" — loop over items (body nodes are nested inside the loop). Legacy named types: stripe.createProduct, client.createUser, transactional-email.send."
+            "enum": [
+              "lead-service",
+              "outbound-sending",
+              "content-sentiment",
+              "client-service",
+              "stripe.createProduct",
+              "stripe.getProduct",
+              "stripe.createPrice",
+              "stripe.getPricesByProduct",
+              "stripe.createCoupon",
+              "stripe.getCoupon",
+              "stripe.createCheckout",
+              "stripe.getStats",
+              "client.createUser",
+              "client.updateUser",
+              "client.getUsers",
+              "transactional-email.send",
+              "transactional-email.getStats",
+              "app.resolveProduct",
+              "app.resolveDiscount",
+              "twilio-sms",
+              "order-service",
+              "product-service",
+              "stripe-service",
+              "linkedin-dm",
+              "linkedin-connect",
+              "linkedin-post",
+              "google-ads",
+              "meta-ads",
+              "http.call",
+              "wait",
+              "condition",
+              "for-each",
+              "script"
+            ],
+            "description": "Node type. Must be one of the registered types — unknown strings are rejected (no silent fallback). Preferred: \"http.call\" — call any microservice. config requires { service, method, path }. Inline JS: \"script\" — runs node.config.code (string) inline as a Windmill rawscript. config = { code: string, language?: \"bun\" | \"deno\" }. Inputs via inputMapping, outputs via `return { … }`. Native flow control: \"condition\" — if/then/else branching (uses Windmill branchone). Outgoing edges with 'condition' define branches; nodes downstream of a conditional edge are nested inside that branch. Outgoing edges without 'condition' define after-branch steps that always execute. \"wait\" — sleep/delay. \"for-each\" — loop over items (body nodes are nested inside the loop). Legacy named types: stripe.createProduct, client.createUser, transactional-email.send."
           },
           "config": {
             "type": "object",
             "additionalProperties": {
               "nullable": true
             },
-            "description": "Static parameters passed to the node. For http.call: { service, method, path, body?, query?, headers? }. For wait: { seconds }. For for-each: { iterator, parallel?, skipFailures? }. Each key becomes a direct parameter of the underlying script. Special config keys (stripped before passing to script): retries (number) — override default retry count; validateResponse ({ field, equals }) — throw error if response[field] !== equals, triggers onError handler; stopAfterIf (string) — native Windmill stop_after_if. JS expression evaluated after step completes using 'result' variable, stops the entire flow gracefully (no onError, no subsequent steps) when true. Example: \"result.found == false\". For conditional branching (run some steps but not others), use a \"condition\" node instead; skipIf (string) — native Windmill skip_if. JS expression evaluated before this step runs, skips only this step when true. Can reference previous results via results.<module_id>. Example: \"results.fetch_lead.found == false\". For multi-step skipping, prefer a \"condition\" node."
+            "description": "Static parameters passed to the node. For http.call: { service, method, path, body?, query?, headers? }. For script: { code (string, required, inline JS), language? (\"bun\" | \"deno\", default \"bun\") }. For wait: { seconds }. For for-each: { iterator, parallel?, skipFailures? }. Each key becomes a direct parameter of the underlying script. Special config keys (stripped before passing to script): retries (number) — override default retry count; validateResponse ({ field, equals }) — throw error if response[field] !== equals, triggers onError handler; stopAfterIf (string) — native Windmill stop_after_if. JS expression evaluated after step completes using 'result' variable, stops the entire flow gracefully (no onError, no subsequent steps) when true. Example: \"result.found == false\". For conditional branching (run some steps but not others), use a \"condition\" node instead; skipIf (string) — native Windmill skip_if. JS expression evaluated before this step runs, skips only this step when true. Can reference previous results via results.<module_id>. Example: \"results.fetch_lead.found == false\". For multi-step skipping, prefer a \"condition\" node."
           },
           "inputMapping": {
             "type": "object",

--- a/src/lib/dag-to-openflow.ts
+++ b/src/lib/dag-to-openflow.ts
@@ -373,6 +373,40 @@ function nodeToModule(node: DAGNode, dag: DAG): FlowModule | null {
     };
   }
 
+  if (node.type === "script") {
+    const code = node.config?.code as string;
+    const language = (node.config?.language as string) ?? "bun";
+    const retries = node.retries
+      ?? (typeof node.config?.retries === "number" ? node.config.retries : 3);
+    const stopAfterIf = typeof node.config?.stopAfterIf === "string"
+      ? node.config.stopAfterIf : undefined;
+    const skipIf = typeof node.config?.skipIf === "string"
+      ? node.config.skipIf : undefined;
+    const inputTransforms = buildInputTransforms(undefined, node.inputMapping);
+
+    const mod: FlowModule = {
+      id: moduleId,
+      summary: `script: ${node.id}`,
+      value: {
+        type: "rawscript",
+        content: code,
+        language,
+        input_transforms: inputTransforms,
+      },
+      timeout: { type: "static", value: NODE_TIMEOUT_SECONDS },
+      retry: retries > 0
+        ? { constant: { attempts: retries, seconds: 5 } }
+        : { constant: { attempts: 0, seconds: 0 } },
+    };
+    if (stopAfterIf) {
+      mod.stop_after_if = { expr: stopAfterIf, skip_if_stopped: true };
+    }
+    if (skipIf) {
+      mod.skip_if = { expr: skipIf };
+    }
+    return mod;
+  }
+
   // Normal node: script reference
   const scriptPath = getScriptPath(node.type);
   if (scriptPath === undefined || scriptPath === null) {

--- a/src/lib/dag-validator.ts
+++ b/src/lib/dag-validator.ts
@@ -1,4 +1,4 @@
-import { isKnownNodeType } from "./node-type-registry.js";
+import { isKnownNodeType, NODE_TYPE_REGISTRY } from "./node-type-registry.js";
 
 export interface DAGNode {
   id: string;
@@ -56,11 +56,12 @@ export function validateDAG(dag: DAG): ValidationResult {
   }
 
   // 2. Unknown node types
+  const allowedTypes = Object.keys(NODE_TYPE_REGISTRY).join(", ");
   for (const node of dag.nodes) {
     if (!isKnownNodeType(node.type)) {
       errors.push({
         field: `nodes[${node.id}].type`,
-        message: `Unknown node type: "${node.type}"`,
+        message: `Unknown node type: "${node.type}". Allowed: ${allowedTypes}`,
       });
     }
   }
@@ -146,6 +147,18 @@ export function validateDAG(dag: DAG): ValidationResult {
       field: "onError",
       message: `onError references unknown node: "${dag.onError}"`,
     });
+  }
+
+  // 9. Validate script nodes: require non-empty config.code
+  for (const node of dag.nodes) {
+    if (node.type !== "script") continue;
+    const code = node.config?.code;
+    if (typeof code !== "string" || !code.trim()) {
+      errors.push({
+        field: `nodes[${node.id}].config.code`,
+        message: `script node "${node.id}" is missing required config field "code" (non-empty string of inline JS).`,
+      });
+    }
   }
 
   return { valid: errors.length === 0, errors };

--- a/src/lib/node-type-registry.ts
+++ b/src/lib/node-type-registry.ts
@@ -52,6 +52,7 @@ export const NODE_TYPE_REGISTRY: Record<string, string | null> = {
   wait: null,
   condition: null,
   "for-each": null,
+  script: null,
 };
 
 export function getScriptPath(nodeType: string): string | null {

--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -78,6 +78,28 @@ Example:
 - "wait": delay. config: { seconds: number }
 - "for-each": loop over items. config: { iterator: string (JS expression), parallel?: boolean, skipFailures?: boolean }
 
+## Inline Script Node
+
+Use "script" for small inline transforms (date stamping, normalisation, simple shape changes) when no microservice fits. Avoid for anything non-trivial — push real logic into a service instead.
+
+- config.code (REQUIRED, string): the JS body. \`return { … }\` to produce outputs. The returned object is the node's \`output\`, addressable via \`$ref:node-id.output.field\`.
+- config.language (optional, default "bun"): "bun" | "deno". Windmill compiles to rawscript.
+- inputMapping: declares inputs. Each key becomes a top-level variable in the script body. Example: \`{ "first": "$ref:flow_input.firstName" }\` → \`first\` is in scope.
+
+Example — inject \`currentDate\` for a downstream LLM prompt:
+
+\`\`\`json
+{
+  "id": "get-date",
+  "type": "script",
+  "config": {
+    "code": "return { currentDate: new Date().toISOString().split('T')[0] };"
+  }
+}
+\`\`\`
+
+Then map it downstream: \`"body.variables.currentDate": "$ref:get-date.output.currentDate"\`.
+
 ## Input Mapping ($ref syntax)
 
 Use inputMapping to pass dynamic data between nodes:

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3,10 +3,13 @@ import {
   OpenAPIRegistry,
   extendZodWithOpenApi,
 } from "@asteasolutions/zod-to-openapi";
+import { NODE_TYPE_REGISTRY } from "./lib/node-type-registry.js";
 
 extendZodWithOpenApi(z);
 
 export const registry = new OpenAPIRegistry();
+
+const REGISTERED_NODE_TYPES = Object.keys(NODE_TYPE_REGISTRY) as [string, ...string[]];
 
 // --- Security scheme ---
 registry.registerComponent("securitySchemes", "apiKey", {
@@ -20,10 +23,12 @@ registry.registerComponent("securitySchemes", "apiKey", {
 export const DAGNodeSchema = z
   .object({
     id: z.string().min(1).describe("Unique identifier for this node within the DAG. Used in edges and $ref input mappings."),
-    type: z.string().min(1).describe(
-      "Node type. Use \"http.call\" to call any microservice (recommended), or a specific node type. " +
-      "http.call config requires: service (name, e.g. \"stripe\"), method (HTTP verb), path (endpoint path). " +
-      "Native flow control types: " +
+    type: z.enum(REGISTERED_NODE_TYPES).describe(
+      "Node type. Must be one of the registered types — unknown strings are rejected (no silent fallback). " +
+      "Preferred: \"http.call\" — call any microservice. config requires { service, method, path }. " +
+      "Inline JS: \"script\" — runs node.config.code (string) inline as a Windmill rawscript. " +
+      "config = { code: string, language?: \"bun\" | \"deno\" }. Inputs via inputMapping, outputs via `return { … }`. " +
+      "Native flow control: " +
       "\"condition\" — if/then/else branching (uses Windmill branchone). " +
       "Outgoing edges with 'condition' define branches; nodes downstream of a conditional edge are nested inside that branch. " +
       "Outgoing edges without 'condition' define after-branch steps that always execute. " +
@@ -32,6 +37,7 @@ export const DAGNodeSchema = z
     ),
     config: z.record(z.unknown()).optional().describe(
       "Static parameters passed to the node. For http.call: { service, method, path, body?, query?, headers? }. " +
+      "For script: { code (string, required, inline JS), language? (\"bun\" | \"deno\", default \"bun\") }. " +
       "For wait: { seconds }. For for-each: { iterator, parallel?, skipFailures? }. " +
       "Each key becomes a direct parameter of the underlying script. " +
       "Special config keys (stripped before passing to script): " +

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -312,6 +312,80 @@ export const DAG_WITH_HTTP_CALL_MISSING_PATH: DAG = {
   edges: [],
 };
 
+export const DAG_WITH_SCRIPT_NODE: DAG = {
+  nodes: [
+    {
+      id: "get-date",
+      type: "script",
+      config: {
+        code: "return { currentDate: new Date().toISOString().split('T')[0] };",
+      },
+    },
+    {
+      id: "use-date",
+      type: "http.call",
+      config: { service: "content-generation", method: "POST", path: "/generate" },
+      inputMapping: {
+        "body.variables.currentDate": "$ref:get-date.output.currentDate",
+      },
+    },
+  ],
+  edges: [{ from: "get-date", to: "use-date" }],
+};
+
+export const DAG_WITH_SCRIPT_NODE_INPUTS: DAG = {
+  nodes: [
+    {
+      id: "format-name",
+      type: "script",
+      config: {
+        code: "return { full: `${first} ${last}` };",
+      },
+      inputMapping: {
+        first: "$ref:flow_input.firstName",
+        last: "$ref:flow_input.lastName",
+      },
+    },
+  ],
+  edges: [],
+};
+
+export const DAG_WITH_SCRIPT_NODE_DENO: DAG = {
+  nodes: [
+    {
+      id: "deno-script",
+      type: "script",
+      config: {
+        code: "export async function main() { return { ok: true }; }",
+        language: "deno",
+      },
+    },
+  ],
+  edges: [],
+};
+
+export const DAG_WITH_SCRIPT_NODE_MISSING_CODE: DAG = {
+  nodes: [
+    {
+      id: "bad-script",
+      type: "script",
+      config: {},
+    },
+  ],
+  edges: [],
+};
+
+export const DAG_WITH_SCRIPT_NODE_EMPTY_CODE: DAG = {
+  nodes: [
+    {
+      id: "empty-script",
+      type: "script",
+      config: { code: "   " },
+    },
+  ],
+  edges: [],
+};
+
 export const DAG_WITH_CUSTOM_RETRIES: DAG = {
   nodes: [
     {

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -211,7 +211,7 @@ describe("POST /workflows", () => {
     expect(res.body.tags).toEqual(["email", "linkedin"]);
   });
 
-  it("rejects an invalid DAG", async () => {
+  it("rejects an invalid DAG (unknown node type rejected by Zod enum)", async () => {
     const res = await request
       .post("/workflows")
       .set(AUTH)
@@ -225,7 +225,7 @@ describe("POST /workflows", () => {
       });
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toBe("Invalid DAG");
+    expect(res.body.error).toBe("Validation error");
     expect(res.body.details).toBeDefined();
   });
 

--- a/tests/unit/dag-node-schema.test.ts
+++ b/tests/unit/dag-node-schema.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { DAGNodeSchema } from "../../src/schemas.js";
+
+describe("DAGNodeSchema.type enum", () => {
+  it("accepts http.call", () => {
+    const result = DAGNodeSchema.safeParse({
+      id: "x",
+      type: "http.call",
+      config: { service: "lead", method: "POST", path: "/buffer/next" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts script", () => {
+    const result = DAGNodeSchema.safeParse({
+      id: "x",
+      type: "script",
+      config: { code: "return { ok: true };" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts condition, wait, for-each natives", () => {
+    expect(
+      DAGNodeSchema.safeParse({ id: "c", type: "condition" }).success
+    ).toBe(true);
+    expect(
+      DAGNodeSchema.safeParse({ id: "w", type: "wait", config: { seconds: 5 } })
+        .success
+    ).toBe(true);
+    expect(
+      DAGNodeSchema.safeParse({
+        id: "f",
+        type: "for-each",
+        config: { iterator: "flow_input.items" },
+      }).success
+    ).toBe(true);
+  });
+
+  it("rejects unknown type via z.enum", () => {
+    const result = DAGNodeSchema.safeParse({
+      id: "x",
+      type: "foobar",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty type via z.enum", () => {
+    const result = DAGNodeSchema.safeParse({
+      id: "x",
+      type: "",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -21,6 +21,9 @@ import {
   DAG_WITH_PATH_PARAMS,
   DAG_WITH_HYPHENATED_CONDITION,
   DAG_WITH_BRANCH_CONVERGENCE,
+  DAG_WITH_SCRIPT_NODE,
+  DAG_WITH_SCRIPT_NODE_INPUTS,
+  DAG_WITH_SCRIPT_NODE_DENO,
 } from "../helpers/fixtures.js";
 
 describe("dagToOpenFlow", () => {
@@ -679,5 +682,77 @@ describe("dagToOpenFlow", () => {
     const result = dagToOpenFlow(DAG_WITH_WAIT, "Wait Timeout");
     const waitMod = result.value.modules.find((m) => m.id === "pause");
     expect(waitMod!.timeout).toBeUndefined();
+  });
+
+  it("translates a script node to a rawscript module with bun language by default", () => {
+    const result = dagToOpenFlow(DAG_WITH_SCRIPT_NODE, "Script Flow");
+
+    const scriptModule = result.value.modules.find((m) => m.id === "get_date");
+    expect(scriptModule).toBeDefined();
+    expect(scriptModule!.value.type).toBe("rawscript");
+
+    if (scriptModule!.value.type === "rawscript") {
+      expect(scriptModule!.value.content).toBe(
+        "return { currentDate: new Date().toISOString().split('T')[0] };"
+      );
+      expect(scriptModule!.value.language).toBe("bun");
+    }
+  });
+
+  it("downstream node can $ref a script node's output", () => {
+    const result = dagToOpenFlow(DAG_WITH_SCRIPT_NODE, "Script Ref");
+
+    const useDate = result.value.modules.find((m) => m.id === "use_date");
+    expect(useDate).toBeDefined();
+    expect(useDate!.value.type).toBe("script");
+
+    if (useDate!.value.type === "script") {
+      const transforms = useDate!.value.input_transforms as Record<
+        string,
+        { type: string; expr?: string; value?: unknown }
+      >;
+      expect(transforms.body).toBeDefined();
+      expect(transforms.body.type).toBe("javascript");
+      expect(transforms.body.expr).toContain("results.get_date?.currentDate");
+    }
+  });
+
+  it("populates rawscript input_transforms from inputMapping", () => {
+    const result = dagToOpenFlow(DAG_WITH_SCRIPT_NODE_INPUTS, "Script Inputs");
+
+    const mod = result.value.modules[0];
+    expect(mod.value.type).toBe("rawscript");
+
+    if (mod.value.type === "rawscript") {
+      const transforms = mod.value.input_transforms as Record<
+        string,
+        { type: string; expr?: string; value?: unknown }
+      >;
+      expect(transforms.first).toEqual({
+        type: "javascript",
+        expr: "flow_input.firstName",
+      });
+      expect(transforms.last).toEqual({
+        type: "javascript",
+        expr: "flow_input.lastName",
+      });
+    }
+  });
+
+  it("honours an explicit config.language for script nodes", () => {
+    const result = dagToOpenFlow(DAG_WITH_SCRIPT_NODE_DENO, "Script Deno");
+
+    const mod = result.value.modules[0];
+    expect(mod.value.type).toBe("rawscript");
+
+    if (mod.value.type === "rawscript") {
+      expect(mod.value.language).toBe("deno");
+    }
+  });
+
+  it("sets timeout on script modules", () => {
+    const result = dagToOpenFlow(DAG_WITH_SCRIPT_NODE, "Script Timeout");
+    const scriptModule = result.value.modules.find((m) => m.id === "get_date");
+    expect(scriptModule!.timeout).toEqual({ type: "static", value: 3600 });
   });
 });

--- a/tests/unit/dag-validator.test.ts
+++ b/tests/unit/dag-validator.test.ts
@@ -25,6 +25,11 @@ import {
   DAG_WITH_HTTP_CALL_MISSING_SERVICE,
   DAG_WITH_HTTP_CALL_MISSING_METHOD,
   DAG_WITH_HTTP_CALL_MISSING_PATH,
+  DAG_WITH_SCRIPT_NODE,
+  DAG_WITH_SCRIPT_NODE_INPUTS,
+  DAG_WITH_SCRIPT_NODE_DENO,
+  DAG_WITH_SCRIPT_NODE_MISSING_CODE,
+  DAG_WITH_SCRIPT_NODE_EMPTY_CODE,
 } from "../helpers/fixtures.js";
 
 describe("validateDAG", () => {
@@ -177,6 +182,59 @@ describe("validateDAG", () => {
     expect(result.valid).toBe(false);
     expect(
       result.errors.some((e) => e.message.includes('missing required config field "path"'))
+    ).toBe(true);
+  });
+
+  it("enriches unknown-node-type errors with the list of registered types", () => {
+    const result = validateDAG(DAG_WITH_UNKNOWN_TYPE);
+    expect(result.valid).toBe(false);
+    const unknownTypeError = result.errors.find((e) =>
+      e.message.includes("Unknown node type")
+    );
+    expect(unknownTypeError).toBeDefined();
+    expect(unknownTypeError!.message).toContain("Allowed:");
+    expect(unknownTypeError!.message).toContain("http.call");
+    expect(unknownTypeError!.message).toContain("script");
+    expect(unknownTypeError!.message).toContain("condition");
+    expect(unknownTypeError!.message).toContain("wait");
+    expect(unknownTypeError!.message).toContain("for-each");
+  });
+
+  it("accepts a DAG with a valid script node", () => {
+    const result = validateDAG(DAG_WITH_SCRIPT_NODE);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("accepts a DAG with a script node that has input mapping", () => {
+    const result = validateDAG(DAG_WITH_SCRIPT_NODE_INPUTS);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("accepts a DAG with a script node using language: deno", () => {
+    const result = validateDAG(DAG_WITH_SCRIPT_NODE_DENO);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("rejects a script node missing config.code", () => {
+    const result = validateDAG(DAG_WITH_SCRIPT_NODE_MISSING_CODE);
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) =>
+        e.message.includes('missing required config field "code"')
+      )
+    ).toBe(true);
+  });
+
+  it("rejects a script node with blank config.code", () => {
+    const result = validateDAG(DAG_WITH_SCRIPT_NODE_EMPTY_CODE);
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) =>
+        e.message.includes('missing required config field "code"')
+      )
     ).toBe(true);
   });
 

--- a/tests/unit/prompt-templates.test.ts
+++ b/tests/unit/prompt-templates.test.ts
@@ -46,4 +46,10 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain("NEVER include cost-tracking nodes");
     expect(prompt).toContain("handled internally by each downstream service");
   });
+
+  it("documents the script node type with a code example", () => {
+    expect(prompt).toContain('"script"');
+    expect(prompt).toContain("config.code");
+    expect(prompt).toContain("rawscript");
+  });
 });


### PR DESCRIPTION
## Summary

Three bundled improvements to make the workflow-service contract clearer for LLM/agent callers and to unblock inline-transform use cases:

1. **New `script` node type.** Inline JS via Windmill `rawscript`. config: `{ code: string, language?: "bun" | "deno" }`. Inputs via `inputMapping`, outputs via `return { … }`. Unblocks small transforms (date stamping, normalisation) without registering a dedicated node script.
2. **`DAGNodeSchema.type` switched to `z.enum`** derived from `NODE_TYPE_REGISTRY` keys. Unknown types now rejected at Zod parse → `400 "Validation error"` (was `400 "Invalid DAG"` from the validator pass). **Breaking** for callers passing types outside the registry — intentional per plan.
3. **Enriched validator error.** `Unknown node type: "x"` now appends the registered allow-list so the LLM/agent can self-correct (`Allowed: http.call, condition, wait, for-each, script, …`). Also a fail-loud check on `script.config.code` (non-empty string required).

OpenAPI surface now exposes the explicit enum + `script` documentation. Prompt template gets a new "Inline Script Node" section with a `currentDate` example.

## Test plan

- [x] `npm run test:unit` — 433 pass
- [x] `npm run test:integration` — 108 pass (1 updated to match new "Validation error" string)
- [x] `npm run build` — TypeScript clean, openapi.json regenerated
- [ ] Post-deploy: fork a workflow with a `script` node via MCP (`get-date` → downstream `email-generate`), confirm rawscript executes and downstream `$ref:get-date.output.currentDate` resolves.

## Breaking changes

- Callers that previously POSTed DAGs with node types outside `NODE_TYPE_REGISTRY` now get `400 "Validation error"` (Zod) instead of `400 "Invalid DAG"` (validator). Both shapes contain `details`, but the inner structure differs (`ZodError` tree vs `ValidationError[]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)