### PR TITLE
fix(prompt-templates): require export async function main() in script-node example

### DIFF
--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -82,9 +82,9 @@ Example:
 
 Use "script" for small inline transforms (date stamping, normalisation, simple shape changes) when no microservice fits. Avoid for anything non-trivial — push real logic into a service instead.
 
-- config.code (REQUIRED, string): the JS body. \`return { … }\` to produce outputs. The returned object is the node's \`output\`, addressable via \`$ref:node-id.output.field\`.
+- config.code (REQUIRED, string): a Windmill rawscript. MUST export an \`async function main(...)\` whose return value becomes the node's \`output\`, addressable via \`$ref:node-id.output.field\`.
 - config.language (optional, default "bun"): "bun" | "deno". Windmill compiles to rawscript.
-- inputMapping: declares inputs. Each key becomes a top-level variable in the script body. Example: \`{ "first": "$ref:flow_input.firstName" }\` → \`first\` is in scope.
+- inputMapping: declares the args of \`main\`. Each key in inputMapping becomes a positional argument of \`main\` in declaration order. Example: \`{ "first": "$ref:flow_input.firstName", "last": "$ref:flow_input.lastName" }\` → signature \`export async function main(first: string, last: string)\`.
 
 Example — inject \`currentDate\` for a downstream LLM prompt:
 
@@ -93,7 +93,7 @@ Example — inject \`currentDate\` for a downstream LLM prompt:
   "id": "get-date",
   "type": "script",
   "config": {
-    "code": "return { currentDate: new Date().toISOString().split('T')[0] };"
+    "code": "export async function main() { return { currentDate: new Date().toISOString().split('T')[0] }; }"
   }
 }
 \`\`\`

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -318,7 +318,7 @@ export const DAG_WITH_SCRIPT_NODE: DAG = {
       id: "get-date",
       type: "script",
       config: {
-        code: "return { currentDate: new Date().toISOString().split('T')[0] };",
+        code: "export async function main() { return { currentDate: new Date().toISOString().split('T')[0] }; }",
       },
     },
     {
@@ -339,7 +339,7 @@ export const DAG_WITH_SCRIPT_NODE_INPUTS: DAG = {
       id: "format-name",
       type: "script",
       config: {
-        code: "return { full: `${first} ${last}` };",
+        code: "export async function main(first: string, last: string) { return { full: `${first} ${last}` }; }",
       },
       inputMapping: {
         first: "$ref:flow_input.firstName",

--- a/tests/unit/dag-node-schema.test.ts
+++ b/tests/unit/dag-node-schema.test.ts
@@ -15,7 +15,9 @@ describe("DAGNodeSchema.type enum", () => {
     const result = DAGNodeSchema.safeParse({
       id: "x",
       type: "script",
-      config: { code: "return { ok: true };" },
+      config: {
+        code: "export async function main() { return { ok: true }; }",
+      },
     });
     expect(result.success).toBe(true);
   });

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -693,7 +693,7 @@ describe("dagToOpenFlow", () => {
 
     if (scriptModule!.value.type === "rawscript") {
       expect(scriptModule!.value.content).toBe(
-        "return { currentDate: new Date().toISOString().split('T')[0] };"
+        "export async function main() { return { currentDate: new Date().toISOString().split('T')[0] }; }"
       );
       expect(scriptModule!.value.language).toBe("bun");
     }


### PR DESCRIPTION
## Summary

Follow-up to #286. The script-node example I added to `prompt-templates.ts` used a bare `return {...}` statement, which Windmill `rawscript` rejects at runtime — bun/deno rawscripts must export an `async function main(...)`. An LLM that copies the example verbatim would ship a workflow that 500s on first invocation.

- Fix the `get-date` example.
- Document that `inputMapping` keys become positional arguments of `main(...)` in declaration order.
- Align the `DAG_WITH_SCRIPT_NODE` / `DAG_WITH_SCRIPT_NODE_INPUTS` fixtures and the matching dag-to-openflow content assertion.

## Test plan

- [x] `npm test` — 541 pass
- [ ] Post-deploy: fork a workflow with a `script` node generated via MCP, confirm Windmill executes `main()` and `$ref:get-date.output.currentDate` resolves downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)