### PR TITLE
hotfix: Inline requiredProviders on GET /workflows to kill api-service N+1 fanout

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -535,6 +535,46 @@
           "dag"
         ]
       },
+      "ProviderInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Provider name (e.g. 'anthropic', 'apollo')."
+          },
+          "domain": {
+            "type": "string",
+            "nullable": true,
+            "description": "Provider's primary domain for logo lookup (e.g. 'anthropic.com'). Null if unknown."
+          }
+        },
+        "required": [
+          "name",
+          "domain"
+        ]
+      },
+      "WorkflowListItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/WorkflowResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "requiredProviders": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ProviderInfo"
+                },
+                "description": "Providers required by this workflow (with domain info for logo lookup). Empty array if the workflow has no http.call nodes. Computed via a single deduped key-service POST per list request, so callers no longer need to fan out N follow-up requests to /workflows/{id}/required-providers."
+              }
+            },
+            "required": [
+              "requiredProviders"
+            ]
+          }
+        ]
+      },
       "ServiceEndpoint": {
         "type": "object",
         "properties": {
@@ -555,24 +595,6 @@
           "service",
           "method",
           "path"
-        ]
-      },
-      "ProviderInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Provider name (e.g. 'anthropic', 'apollo')."
-          },
-          "domain": {
-            "type": "string",
-            "nullable": true,
-            "description": "Provider's primary domain for logo lookup (e.g. 'anthropic.com'). Null if unknown."
-          }
-        },
-        "required": [
-          "name",
-          "domain"
         ]
       },
       "ProviderRequirementsResponse": {
@@ -1850,7 +1872,7 @@
         ],
         "responses": {
           "200": {
-            "description": "List of workflows",
+            "description": "List of workflows, each enriched with requiredProviders",
             "content": {
               "application/json": {
                 "schema": {
@@ -1859,13 +1881,23 @@
                     "workflows": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/WorkflowResponse"
+                        "$ref": "#/components/schemas/WorkflowListItem"
                       }
                     }
                   },
                   "required": [
                     "workflows"
                   ]
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Key service unavailable or returned an error while computing requiredProviders",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -668,6 +668,11 @@ router.get("/workflows/dynasty/stats", requireApiKey, async (req, res) => {
 });
 
 // GET /workflows — List workflows (defaults to active only; ?status=all for all)
+// Each item is enriched with `requiredProviders` so the caller does not need
+// to fan out N follow-up requests to /workflows/:id/required-providers.
+// Implementation: walk every returned workflow's DAG once, union all unique
+// (service, method, path) endpoints, make a SINGLE key-service POST, then
+// remap providers back per workflow.
 router.get("/workflows", requireApiKey, async (req, res) => {
   try {
     const { orgId, brandId, humanId, campaignId, featureSlug, workflowSlug, workflowDynastySlug, tag, status } = req.query;
@@ -708,7 +713,82 @@ router.get("/workflows", requireApiKey, async (req, res) => {
       ? await db.select().from(workflows).where(and(...conditions))
       : await db.select().from(workflows);
 
-    res.json({ workflows: results.map(formatWorkflow) });
+    // Per-workflow endpoint lists + global deduped union
+    const endpointsPerWorkflow = results.map((w) =>
+      extractHttpEndpoints((w.dag as DAG) ?? { nodes: [], edges: [] }),
+    );
+    const unionMap = new Map<string, { service: string; method: string; path: string }>();
+    for (const list of endpointsPerWorkflow) {
+      for (const ep of list) {
+        const key = `${ep.service}|${ep.method}|${ep.path}`;
+        if (!unionMap.has(key)) unionMap.set(key, ep);
+      }
+    }
+
+    // Map endpointKey → set of providers (populated by single key-service call)
+    const endpointProviders = new Map<string, Set<string>>();
+
+    if (unionMap.size > 0) {
+      const dsHeaders = extractDownstreamHeaders(req);
+      try {
+        const result = await fetchProviderRequirements([...unionMap.values()], dsHeaders);
+        for (const r of result.requirements as Array<{
+          service?: unknown;
+          method?: unknown;
+          path?: unknown;
+          provider?: unknown;
+        }>) {
+          if (
+            typeof r.service !== "string" ||
+            typeof r.method !== "string" ||
+            typeof r.path !== "string" ||
+            typeof r.provider !== "string"
+          ) continue;
+          const key = `${r.service}|${r.method}|${r.path}`;
+          let set = endpointProviders.get(key);
+          if (!set) {
+            set = new Set();
+            endpointProviders.set(key, set);
+          }
+          set.add(r.provider);
+        }
+      } catch (err) {
+        if (err instanceof Error && err.message.startsWith("key-service error:")) {
+          console.error("[workflow-service] GET /workflows: key-service error:", err.message);
+          res.status(502).json({ error: err.message });
+          return;
+        }
+        if (err instanceof Error && err.message.includes("KEY_SERVICE_URL")) {
+          res.status(502).json({ error: err.message });
+          return;
+        }
+        if (err instanceof TypeError && err.message === "fetch failed") {
+          const cause = (err as unknown as { cause?: { code?: string } }).cause;
+          const detail = cause?.code ? ` (${cause.code})` : "";
+          console.error(`[workflow-service] GET /workflows: key-service unreachable${detail}`, err);
+          res.status(502).json({ error: `key-service unreachable${detail}` });
+          return;
+        }
+        throw err;
+      }
+    }
+
+    const enriched = results.map((w, i) => {
+      const providers = new Set<string>();
+      for (const ep of endpointsPerWorkflow[i]) {
+        const key = `${ep.service}|${ep.method}|${ep.path}`;
+        const set = endpointProviders.get(key);
+        if (set) {
+          for (const p of set) providers.add(p);
+        }
+      }
+      return {
+        ...formatWorkflow(w),
+        requiredProviders: enrichProvidersWithDomains([...providers].sort()),
+      };
+    });
+
+    res.json({ workflows: enriched });
   } catch (err) {
     console.error("[workflow-service] GET list error:", err);
     res.status(500).json({ error: "Internal server error" });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -637,6 +637,15 @@ export const ProviderRequirementsResponseSchema = z
   })
   .openapi("ProviderRequirementsResponse");
 
+export const WorkflowListItemSchema = WorkflowResponseSchema.extend({
+  requiredProviders: z.array(ProviderInfoSchema).describe(
+    "Providers required by this workflow (with domain info for logo lookup). " +
+    "Empty array if the workflow has no http.call nodes. Computed via a single " +
+    "deduped key-service POST per list request, so callers no longer need to " +
+    "fan out N follow-up requests to /workflows/{id}/required-providers."
+  ),
+}).openapi("WorkflowListItem");
+
 // --- Workflow conflict response (409 on PUT /workflows/:id) ---
 
 export const WorkflowConflictResponseSchema = z
@@ -860,12 +869,16 @@ registry.registerPath({
   },
   responses: {
     200: {
-      description: "List of workflows",
+      description: "List of workflows, each enriched with requiredProviders",
       content: {
         "application/json": {
-          schema: z.object({ workflows: z.array(WorkflowResponseSchema) }),
+          schema: z.object({ workflows: z.array(WorkflowListItemSchema) }),
         },
       },
+    },
+    502: {
+      description: "Key service unavailable or returned an error while computing requiredProviders",
+      content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },
 });

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -255,6 +255,11 @@ describe("POST /workflows", () => {
 describe("GET /workflows", () => {
   beforeEach(() => {
     mockDbRows.length = 0;
+    mockFetchProviderRequirements.mockReset();
+    // Default key-service response so existing list tests (whose fixtures may
+    // contain http.call nodes like VALID_LINEAR_DAG) don't 500 on undefined.
+    // Cases that exercise the enrichment override this with mockResolvedValue.
+    mockFetchProviderRequirements.mockResolvedValue({ requirements: [], providers: [] });
   });
 
   it("returns all workflows when no filters provided", async () => {
@@ -402,6 +407,259 @@ describe("GET /workflows", () => {
     expect(res.body.workflows[0].category).toBe("sales");
     expect(res.body.workflows[0].channel).toBe("email");
     expect(res.body.workflows[0].audienceType).toBe("cold-outreach");
+  });
+
+  // --- requiredProviders enrichment (inlined to kill api-service N+1 fanout) ---
+
+  it("returns empty list with no key-service call", async () => {
+    const res = await request.get("/workflows").set(AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body.workflows).toEqual([]);
+    expect(mockFetchProviderRequirements).not.toHaveBeenCalled();
+  });
+
+  it("enriches each item with requiredProviders for workflows with http.call nodes", async () => {
+    mockDbRows.push({
+      id: WF_HTTP_ID,
+      orgId: "org-1",
+      workflowSlug: "http-flow",
+      workflowName: "HTTP Flow",
+      workflowDynastySlug: "http-flow",
+      workflowDynastyName: "HTTP Flow",
+      version: 1,
+      dag: DAG_WITH_HTTP_CALL,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    mockFetchProviderRequirements.mockResolvedValue({
+      requirements: [
+        { service: "stripe", method: "GET", path: "/products/prod_123", provider: "stripe" },
+      ],
+      providers: ["stripe"],
+    });
+
+    const res = await request.get("/workflows").set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.workflows).toHaveLength(1);
+    expect(res.body.workflows[0].requiredProviders).toEqual([
+      { name: "stripe", domain: "stripe.com" },
+    ]);
+    expect(mockFetchProviderRequirements).toHaveBeenCalledTimes(1);
+    expect(mockFetchProviderRequirements).toHaveBeenCalledWith(
+      [{ service: "stripe", method: "GET", path: "/products/prod_123" }],
+      { "x-org-id": "org-1", "x-user-id": "user-1", "x-run-id": "run-caller-1", "x-brand-id": "brand-1" },
+    );
+  });
+
+  it("dedupes endpoints across multiple workflows into a single key-service call", async () => {
+    mockDbRows.push(
+      {
+        id: WF_HTTP_ID,
+        orgId: "org-1",
+        workflowSlug: "wf-a",
+        workflowName: "WF A",
+        workflowDynastySlug: "wf-a",
+        workflowDynastyName: "WF A",
+        version: 1,
+        dag: DAG_WITH_HTTP_CALL_CHAIN, // client POST /users + transactional-email POST /send
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: WF_FEATURE_ID,
+        orgId: "org-1",
+        workflowSlug: "wf-b",
+        workflowName: "WF B",
+        workflowDynastySlug: "wf-b",
+        workflowDynastyName: "WF B",
+        version: 1,
+        dag: DAG_WITH_HTTP_CALL, // stripe GET /products/prod_123
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: WF_LEGACY_ID,
+        orgId: "org-1",
+        workflowSlug: "wf-c",
+        workflowName: "WF C",
+        workflowDynastySlug: "wf-c",
+        workflowDynastyName: "WF C",
+        version: 1,
+        dag: DAG_WITH_HTTP_CALL_CHAIN, // duplicate of wf-a's endpoints
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    );
+
+    mockFetchProviderRequirements.mockResolvedValue({
+      requirements: [
+        { service: "client", method: "POST", path: "/users", provider: "client" },
+        { service: "transactional-email", method: "POST", path: "/send", provider: "postmark" },
+        { service: "stripe", method: "GET", path: "/products/prod_123", provider: "stripe" },
+      ],
+      providers: ["client", "postmark", "stripe"],
+    });
+
+    const res = await request.get("/workflows").set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.workflows).toHaveLength(3);
+
+    // Single key-service call, deduped to 3 unique endpoints (not 5)
+    expect(mockFetchProviderRequirements).toHaveBeenCalledTimes(1);
+    const [calledEndpoints] = mockFetchProviderRequirements.mock.calls[0];
+    expect(calledEndpoints).toHaveLength(3);
+    expect(calledEndpoints).toEqual(
+      expect.arrayContaining([
+        { service: "client", method: "POST", path: "/users" },
+        { service: "transactional-email", method: "POST", path: "/send" },
+        { service: "stripe", method: "GET", path: "/products/prod_123" },
+      ]),
+    );
+
+    // Per-workflow provider mapping
+    const byId = Object.fromEntries(res.body.workflows.map((w: any) => [w.id, w]));
+    expect(byId[WF_HTTP_ID].requiredProviders).toEqual(
+      expect.arrayContaining([
+        { name: "client", domain: null },
+        { name: "postmark", domain: "postmarkapp.com" },
+      ]),
+    );
+    expect(byId[WF_HTTP_ID].requiredProviders).toHaveLength(2);
+    expect(byId[WF_FEATURE_ID].requiredProviders).toEqual([
+      { name: "stripe", domain: "stripe.com" },
+    ]);
+    // wf-c has same endpoints as wf-a, gets same providers
+    expect(byId[WF_LEGACY_ID].requiredProviders).toEqual(
+      expect.arrayContaining([
+        { name: "client", domain: null },
+        { name: "postmark", domain: "postmarkapp.com" },
+      ]),
+    );
+  });
+
+  it("returns empty requiredProviders for workflows without http.call nodes and skips key-service when none exist", async () => {
+    mockDbRows.push({
+      id: WF_LEGACY_ID,
+      orgId: "org-1",
+      workflowSlug: "legacy-flow",
+      workflowName: "Legacy Flow",
+      workflowDynastySlug: "legacy-flow",
+      workflowDynastyName: "Legacy Flow",
+      version: 1,
+      dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const res = await request.get("/workflows").set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.workflows).toHaveLength(1);
+    expect(res.body.workflows[0].requiredProviders).toEqual([]);
+    expect(mockFetchProviderRequirements).not.toHaveBeenCalled();
+  });
+
+  it("handles mix of workflows with and without http.call nodes in one call", async () => {
+    mockDbRows.push(
+      {
+        id: WF_HTTP_ID,
+        orgId: "org-1",
+        workflowSlug: "http-flow",
+        workflowName: "HTTP Flow",
+        workflowDynastySlug: "http-flow",
+        workflowDynastyName: "HTTP Flow",
+        version: 1,
+        dag: DAG_WITH_HTTP_CALL,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: WF_LEGACY_ID,
+        orgId: "org-1",
+        workflowSlug: "legacy-flow",
+        workflowName: "Legacy Flow",
+        workflowDynastySlug: "legacy-flow",
+        workflowDynastyName: "Legacy Flow",
+        version: 1,
+        dag: DAG_WITH_TRANSACTIONAL_EMAIL_SEND,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    );
+
+    mockFetchProviderRequirements.mockResolvedValue({
+      requirements: [
+        { service: "stripe", method: "GET", path: "/products/prod_123", provider: "stripe" },
+      ],
+      providers: ["stripe"],
+    });
+
+    const res = await request.get("/workflows").set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(mockFetchProviderRequirements).toHaveBeenCalledTimes(1);
+    const byId = Object.fromEntries(res.body.workflows.map((w: any) => [w.id, w]));
+    expect(byId[WF_HTTP_ID].requiredProviders).toEqual([
+      { name: "stripe", domain: "stripe.com" },
+    ]);
+    expect(byId[WF_LEGACY_ID].requiredProviders).toEqual([]);
+  });
+
+  it("returns 502 when key-service fails", async () => {
+    mockDbRows.push({
+      id: WF_HTTP_ID,
+      orgId: "org-1",
+      workflowSlug: "http-flow",
+      workflowName: "HTTP Flow",
+      workflowDynastySlug: "http-flow",
+      workflowDynastyName: "HTTP Flow",
+      version: 1,
+      dag: DAG_WITH_HTTP_CALL,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    mockFetchProviderRequirements.mockRejectedValue(
+      new Error(
+        "key-service error: POST /provider-requirements -> 500 Internal Server Error: boom"
+      )
+    );
+
+    const res = await request.get("/workflows").set(AUTH);
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toContain("key-service error:");
+  });
+});
+
+describe("GET /workflows/:id (single)", () => {
+  beforeEach(() => {
+    mockDbRows.length = 0;
+    mockFetchProviderRequirements.mockReset();
+  });
+
+  it("does not inject requiredProviders on the single-workflow detail endpoint", async () => {
+    mockDbRows.push({
+      id: WF_HTTP_ID,
+      orgId: "org-1",
+      workflowSlug: "http-flow",
+      workflowName: "HTTP Flow",
+      workflowDynastySlug: "http-flow",
+      workflowDynastyName: "HTTP Flow",
+      version: 1,
+      dag: DAG_WITH_HTTP_CALL,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const res = await request.get(`/workflows/${WF_HTTP_ID}`).set(AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.requiredProviders).toBeUndefined();
+    expect(mockFetchProviderRequirements).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Automated by release.sh