### PR TITLE
fix(workflow-service): eden post-mortem — dynastySlug upgrade input + validator drill-down + $ref rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,11 +120,11 @@ The legacy `upgraded_to` and `forked_from` columns are gone. The successor of a 
 - This endpoint never upgrades existing dynasties.
 
 **Upgrade — `POST /workflows/upgrade`:**
-- Body: `{ workflowSlug, description?, dag?, hints? }`. **Exactly one of `dag` or `description` MUST be provided** (Zod refine enforces it; missing both → 400).
+- Body: `{ workflowDynastySlug, description?, dag?, hints? }`. The input is the **stable dynasty slug** (constant across all versions of the dynasty), NOT a versioned `workflowSlug`. The route looks up the currently-active row via `WHERE workflow_dynasty_slug = ? AND status = 'active'`, so callers do not need to track which version is current after prior upgrades. **Exactly one of `dag` or `description` MUST be provided** (Zod refine enforces it; missing both → 400).
 - Two DAG sources:
   - `dag` supplied → client-supplied DAG path. The LLM is **not invoked**. The DAG is run through `validateDAG` (rejects with 400 on invalid topology), its signature computed, and the rest of the flow is identical to the LLM path. `category`/`channel`/`audienceType` are **inherited from the existing row** (no LLM to infer them). `description`, if also provided, replaces the stored description on the resulting row. Use this for surgical edits (e.g. patch a single script node) without burning an LLM round-trip — the LLM-regen path tends to drift on small fixes.
   - `dag` absent → LLM path. `description` is required (min 10 chars) and `generateWorkflow()` regenerates the full DAG from it. `hints` is forwarded to the generator; ignored when `dag` is supplied.
-- 404 if no active workflow matches `workflowSlug`.
+- 404 if no active row matches `workflowDynastySlug`.
 - If the new signature equals the existing one → in-place update, returns 200.
 - Otherwise inserts a new row in the **same** dynasty (`workflow_dynasty_slug`, `workflow_dynasty_name`, `workflow_dynasty_signature_name` all unchanged — the dynasty signature name is immutable per dynasty) with `creation_type='upgrade'`, `created_from_workflow=existing.id`, `version=existing.version+1`, version suffix on `workflow_slug`/`workflow_name`. Returns 201.
 - **Predecessor deprecation order matters.** The partial unique index `idx_workflows_active_signame (feature_slug, signature_name) WHERE status='active'` rejects two `status='active'` rows sharing `(feature_slug, signature_name)`. The upgrade route therefore wraps the deprecate+insert in a `db.transaction(...)` block and flips the predecessor to `status='deprecated'` **before** inserting the new active row. Windmill cleanup (deleting the predecessor's flow) runs **after** the DB commit so a rolled-back transaction does not leave Windmill in an inconsistent state.

--- a/openapi.json
+++ b/openapi.json
@@ -1342,10 +1342,10 @@
       "UpgradeWorkflowFromDescriptionRequest": {
         "type": "object",
         "properties": {
-          "workflowSlug": {
+          "workflowDynastySlug": {
             "type": "string",
             "minLength": 1,
-            "description": "Slug of the active workflow to upgrade. Must reference an active row."
+            "description": "Stable dynasty slug (constant across all versions of the dynasty). The route resolves it to the currently-active row, so callers do not need to track which version is active after prior upgrades."
           },
           "description": {
             "type": "string",
@@ -1374,7 +1374,7 @@
           }
         },
         "required": [
-          "workflowSlug"
+          "workflowDynastySlug"
         ]
       },
       "PublicWorkflowItem": {

--- a/src/lib/openapi-schema-resolver.ts
+++ b/src/lib/openapi-schema-resolver.ts
@@ -188,7 +188,7 @@ export function walkSchemaPath(
       return {
         valid: false,
         resolvedPath,
-        availableAt: Object.keys(current.properties),
+        availableAt: formatAvailableKeys(current.properties, spec),
       };
     }
 
@@ -211,6 +211,31 @@ export function walkSchemaPath(
   }
 
   return { valid: true, resolvedPath };
+}
+
+/**
+ * Formats the keys available at a path-failure point. For object-typed values,
+ * inlines up to 5 sub-keys as `key{sub1,sub2,...}` so callers see one level
+ * deeper without a second round-trip. Scalars stay bare.
+ *
+ * Example: `lead.data.organizationName` fails at `lead.data` →
+ *   ["leadId", "firstName", "organization{name,industry,estimatedNumEmployees,...}"]
+ */
+function formatAvailableKeys(
+  properties: Record<string, unknown>,
+  spec: Record<string, unknown>,
+): string[] {
+  const MAX_SUB_KEYS = 5;
+  return Object.entries(properties).map(([key, value]) => {
+    if (typeof value !== "object" || value === null) return key;
+    const raw = resolveRawSchema(value as Record<string, unknown>, spec);
+    const resolved = resolveSchema(raw, spec);
+    if (!resolved || Object.keys(resolved.properties).length === 0) return key;
+    const subKeys = Object.keys(resolved.properties);
+    const shown = subKeys.slice(0, MAX_SUB_KEYS).join(",");
+    const suffix = subKeys.length > MAX_SUB_KEYS ? ",..." : "";
+    return `${key}{${shown}${suffix}}`;
+  });
 }
 
 /**

--- a/src/lib/prompt-templates.ts
+++ b/src/lib/prompt-templates.ts
@@ -120,6 +120,16 @@ Examples below use natural-language placeholders like \`<path to X>\` for any va
 For path parameters (e.g. \`/internal/brands/{brandId}\`), use \`params.*\` in inputMapping:
 - "params.brandId": "$ref:start-run.output.<path to brandId in start-run response>" → replaces {brandId} in the path
 
+### \`$ref\` resolution rule (HARD)
+
+Every \`$ref\` path you emit MUST resolve against the OpenAPI specs injected below. Two distinct cases:
+
+1. **Fixed-schema objects** (declared via \`properties\`): use the property names verbatim from the spec. NEVER invent a key. If the upstream node response declares \`data.organization.name\`, you MUST emit \`$ref:node.output.data.organization.name\` — not \`data.organizationName\`, not \`data.org.name\`, not \`data.organization_name\`. Resolution failure = validation error.
+
+2. **Dynamic-key maps** (declared via \`additionalProperties\`): the keys are caller-chosen. Match the key you sent in the request body. Example: \`brand-extract-fields\` body sends \`fields: [{key: "companyOverview"}, ...]\` and the response is \`{fields: {<caller-key>: MultiBrandFieldValue}}\` — so \`$ref:brand-extract-fields.output.fields.companyOverview.value\` is valid (the key \`companyOverview\` was supplied in the body).
+
+If a needed field is absent from a fixed-schema response, do NOT invent a path. Either pick a different upstream node that legitimately exposes the value, or omit the field. Inventing paths against fixed schemas is a hard failure.
+
 ## Special Config Keys (stripped before passing to script)
 
 - retries (number): retry attempts on failure. Default 3. Set 0 for non-idempotent ops (email sends, SMS, queue consumes).

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -272,13 +272,13 @@ router.post("/workflows/upgrade", requireApiKey, createRateLimit, async (req, re
       .from(workflows)
       .where(
         and(
-          eq(workflows.workflowSlug, body.workflowSlug),
+          eq(workflows.workflowDynastySlug, body.workflowDynastySlug),
           eq(workflows.status, "active"),
         )
       );
 
     if (!existing) {
-      res.status(404).json({ error: `Active workflow not found for slug "${body.workflowSlug}"` });
+      res.status(404).json({ error: `Active workflow not found for dynasty "${body.workflowDynastySlug}"` });
       return;
     }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -468,8 +468,8 @@ export const CreateWorkflowFromDescriptionSchema = z
 
 export const UpgradeWorkflowFromDescriptionSchema = z
   .object({
-    workflowSlug: z.string().min(1).describe(
-      "Slug of the active workflow to upgrade. Must reference an active row."
+    workflowDynastySlug: z.string().min(1).describe(
+      "Stable dynasty slug (constant across all versions of the dynasty). The route resolves it to the currently-active row, so callers do not need to track which version is active after prior upgrades."
     ),
     description: z.string().min(10).optional().describe(
       "Natural-language description of the desired upgraded workflow. " +

--- a/tests/integration/generate-workflow.test.ts
+++ b/tests/integration/generate-workflow.test.ts
@@ -462,7 +462,7 @@ describe("POST /workflows/upgrade", () => {
       .post("/workflows/upgrade")
       .set(AUTH)
       .send({
-        workflowSlug: "missing-slug",
+        workflowDynastySlug: "missing-slug",
         description: "Upgrade something that does not exist at all",
       });
 
@@ -505,7 +505,7 @@ describe("POST /workflows/upgrade", () => {
       .post("/workflows/upgrade")
       .set(AUTH)
       .send({
-        workflowSlug: "cold-email-outreach-obsidian",
+        workflowDynastySlug: "cold-email-outreach-obsidian",
         description: "Upgrade with same DAG produces same signature",
       });
 
@@ -548,7 +548,7 @@ describe("POST /workflows/upgrade", () => {
     const res = await request
       .post("/workflows/upgrade")
       .set(AUTH)
-      .send({ workflowSlug: "feature-obsidian", description: "Upgrade with a new signature for AC6" });
+      .send({ workflowDynastySlug: "feature-obsidian", description: "Upgrade with a new signature for AC6" });
 
     expect(res.status).toBe(201);
     expect(res.body.workflow.action).toBe("upgraded");
@@ -589,7 +589,7 @@ describe("POST /workflows/upgrade", () => {
       .post("/workflows/upgrade")
       .set(AUTH)
       .send({
-        workflowSlug: "stage-test-feature-umber",
+        workflowDynastySlug: "stage-test-feature-umber",
         description: "Upgrade that will fail at the LLM call",
       });
 
@@ -608,7 +608,7 @@ describe("POST /workflows/upgrade", () => {
       .post("/workflows/upgrade")
       .set(AUTH)
       .send({
-        workflowSlug: "stage-test-feature-umber",
+        workflowDynastySlug: "stage-test-feature-umber",
         description: "Upgrade that will fail at the registry call",
       });
 
@@ -625,7 +625,7 @@ describe("POST /workflows/upgrade", () => {
       .post("/workflows/upgrade")
       .set(AUTH)
       .send({
-        workflowSlug: "stage-test-feature-umber",
+        workflowDynastySlug: "stage-test-feature-umber",
         description: "Upgrade that will fail with an unrecognized error",
       });
 
@@ -699,7 +699,7 @@ describe("POST /workflows/upgrade", () => {
       .post("/workflows/upgrade")
       .set(AUTH)
       .send({
-        workflowSlug: "feat-a-alabaster",
+        workflowDynastySlug: "feat-a-alabaster",
         dag: VALID_LINEAR_DAG,
       });
 
@@ -724,7 +724,7 @@ describe("POST /workflows/upgrade", () => {
       .post("/workflows/upgrade")
       .set(AUTH)
       .send({
-        workflowSlug: "client-dag-feature-umber",
+        workflowDynastySlug: "client-dag-feature-umber",
         dag: NEW_DAG,
       });
 
@@ -760,7 +760,7 @@ describe("POST /workflows/upgrade", () => {
       .post("/workflows/upgrade")
       .set(AUTH)
       .send({
-        workflowSlug: "client-dag-feature-umber",
+        workflowDynastySlug: "client-dag-feature-umber",
         dag: NEW_DAG,
       });
 
@@ -786,7 +786,7 @@ describe("POST /workflows/upgrade", () => {
       .post("/workflows/upgrade")
       .set(AUTH)
       .send({
-        workflowSlug: "client-dag-feature-umber",
+        workflowDynastySlug: "client-dag-feature-umber",
         dag: NEW_DAG,
         description: "Surgical fix for the serialize_brand_fields script node",
       });
@@ -806,7 +806,7 @@ describe("POST /workflows/upgrade", () => {
       .post("/workflows/upgrade")
       .set(AUTH)
       .send({
-        workflowSlug: "client-dag-feature-umber",
+        workflowDynastySlug: "client-dag-feature-umber",
       });
 
     expect(res.status).toBe(400);
@@ -821,7 +821,7 @@ describe("POST /workflows/upgrade", () => {
       .post("/workflows/upgrade")
       .set(AUTH)
       .send({
-        workflowSlug: "client-dag-feature-umber",
+        workflowDynastySlug: "client-dag-feature-umber",
         dag: INVALID_DAG,
       });
 

--- a/tests/integration/workflows.test.ts
+++ b/tests/integration/workflows.test.ts
@@ -8,6 +8,7 @@ import {
   DAG_WITH_CONTENT_GEN_MISSING_VAR,
   DAG_WITH_CONTENT_GEN_ALL_VARS,
 } from "../helpers/fixtures.js";
+import { computeDAGSignature } from "../../src/lib/dag-signature.js";
 
 // Mock DB
 const mockDbRows: Record<string, unknown>[] = [];
@@ -1199,5 +1200,78 @@ describe("UUID validation on :id routes", () => {
     const res = await request.post("/workflows/ranked/validate").set(AUTH);
     expect(res.status).toBe(400);
     expect(res.body.error).toBe("Invalid workflow ID format");
+  });
+});
+
+describe("POST /workflows/upgrade (workflowDynastySlug lookup)", () => {
+  beforeEach(() => {
+    mockDbRows.length = 0;
+  });
+
+  it("looks up the active row by dynastySlug regardless of which version is current", async () => {
+    // Simulate dynasty 'eden' where v1, v2 are deprecated and v3 is active.
+    // The route's WHERE filter is (workflowDynastySlug = ? AND status = 'active'),
+    // so seeding only the active row mirrors what the DB would return.
+    const signature = computeDAGSignature(VALID_LINEAR_DAG);
+    mockDbRows.push({
+      id: WF_HTTP_ID,
+      orgId: "org-1",
+      workflowSlug: "sales-cold-email-outreach-eden-v3",
+      workflowName: "Sales Cold Email Outreach Eden v3",
+      workflowDynastySlug: "sales-cold-email-outreach-eden",
+      workflowDynastyName: "Sales Cold Email Outreach Eden",
+      workflowDynastySignatureName: "eden",
+      featureSlug: "sales-cold-email-outreach",
+      category: "sales",
+      channel: "email",
+      audienceType: "cold-outreach",
+      version: 3,
+      status: "active",
+      signature,
+      dag: VALID_LINEAR_DAG,
+      tags: [],
+      description: "v3 active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const res = await request
+      .post("/workflows/upgrade")
+      .set(AUTH)
+      .send({
+        workflowDynastySlug: "sales-cold-email-outreach-eden",
+        dag: VALID_LINEAR_DAG, // same signature -> in-place update (200)
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.workflow.workflowDynastySlug).toBe("sales-cold-email-outreach-eden");
+    expect(res.body.workflow.version).toBe(3);
+    expect(res.body.workflow.action).toBe("updated");
+  });
+
+  it("returns 404 when no active row matches the dynastySlug", async () => {
+    const res = await request
+      .post("/workflows/upgrade")
+      .set(AUTH)
+      .send({
+        workflowDynastySlug: "no-such-dynasty",
+        dag: VALID_LINEAR_DAG,
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("dynasty");
+    expect(res.body.error).toContain("no-such-dynasty");
+  });
+
+  it("rejects legacy workflowSlug field with a Zod validation error (post-rename bigbang)", async () => {
+    const res = await request
+      .post("/workflows/upgrade")
+      .set(AUTH)
+      .send({
+        workflowSlug: "sales-cold-email-outreach-eden",
+        dag: VALID_LINEAR_DAG,
+      });
+
+    expect(res.status).toBe(400);
   });
 });

--- a/tests/unit/openapi-schema-resolver.test.ts
+++ b/tests/unit/openapi-schema-resolver.test.ts
@@ -361,6 +361,161 @@ describe("walkSchemaPath with additionalProperties (dynamic keys)", () => {
   });
 });
 
+describe("walkSchemaPath availableAt drill-down (1-level nested keys)", () => {
+  // Mirrors lead-service POST /orgs/buffer/next response shape: the `data` object
+  // has scalar keys (firstName, leadId) plus an `organization` sub-object. When a
+  // caller tries `lead.data.organizationName` (flat — does not exist), they should
+  // see "organization{name,industry,...}" in the failure listing so they know to
+  // descend without a second guess-and-check round-trip.
+  const leadResponseSchema = resolveSchema(
+    {
+      type: "object",
+      properties: {
+        lead: {
+          type: "object",
+          properties: {
+            data: {
+              type: "object",
+              properties: {
+                leadId: { type: "string" },
+                firstName: { type: "string" },
+                currentTitle: { type: "string" },
+                organization: {
+                  type: "object",
+                  properties: {
+                    name: { type: "string" },
+                    industry: { type: "string" },
+                    estimatedNumEmployees: { type: "number" },
+                    annualRevenue: { type: "number" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    {},
+  )!;
+
+  it("inlines object-typed sibling keys at the failure depth", () => {
+    const result = walkSchemaPath(
+      leadResponseSchema,
+      ["lead", "data", "organizationName"],
+      {},
+    );
+    expect(result.valid).toBe(false);
+    expect(result.availableAt).toContain("leadId");
+    expect(result.availableAt).toContain("firstName");
+    expect(result.availableAt).toContain("currentTitle");
+    expect(result.availableAt).toContain(
+      "organization{name,industry,estimatedNumEmployees,annualRevenue}",
+    );
+  });
+
+  it("keeps scalar siblings bare (no curly suffix)", () => {
+    const result = walkSchemaPath(
+      leadResponseSchema,
+      ["lead", "data", "bogus"],
+      {},
+    );
+    expect(result.availableAt).toContain("leadId");
+    expect(result.availableAt?.find((k) => k.startsWith("leadId"))).toBe("leadId");
+  });
+
+  it("truncates wide objects at 5 sub-keys with ellipsis", () => {
+    const wideSchema = resolveSchema(
+      {
+        type: "object",
+        properties: {
+          outer: {
+            type: "object",
+            properties: {
+              wide: {
+                type: "object",
+                properties: {
+                  a: { type: "string" },
+                  b: { type: "string" },
+                  c: { type: "string" },
+                  d: { type: "string" },
+                  e: { type: "string" },
+                  f: { type: "string" },
+                  g: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      },
+      {},
+    )!;
+    const result = walkSchemaPath(wideSchema, ["outer", "missing"], {});
+    expect(result.availableAt).toContain("wide{a,b,c,d,e,...}");
+  });
+
+  it("resolves $ref when listing nested sub-keys", () => {
+    const spec = {
+      components: {
+        schemas: {
+          Organization: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              industry: { type: "string" },
+            },
+          },
+        },
+      },
+    };
+    const schema = resolveSchema(
+      {
+        type: "object",
+        properties: {
+          data: {
+            type: "object",
+            properties: {
+              organization: { $ref: "#/components/schemas/Organization" },
+              firstName: { type: "string" },
+            },
+          },
+        },
+      },
+      spec,
+    )!;
+
+    const result = walkSchemaPath(schema, ["data", "missing"], spec);
+    expect(result.availableAt).toContain("firstName");
+    expect(result.availableAt).toContain("organization{name,industry}");
+  });
+
+  it("falls back to bare key when sub-schema has no properties (e.g. additionalProperties-only)", () => {
+    // brand-service extract-fields shape: outer.fields is an object with only
+    // additionalProperties, no properties. Formatter must NOT crash and should
+    // keep the key bare.
+    const schema = resolveSchema(
+      {
+        type: "object",
+        properties: {
+          outer: {
+            type: "object",
+            properties: {
+              fields: {
+                type: "object",
+                additionalProperties: { type: "string" },
+              },
+              scalar: { type: "string" },
+            },
+          },
+        },
+      },
+      {},
+    )!;
+    const result = walkSchemaPath(schema, ["outer", "missing"], {});
+    expect(result.availableAt).toContain("fields");
+    expect(result.availableAt).toContain("scalar");
+  });
+});
+
 describe("getRequestBodySchema", () => {
   const spec = {
     paths: {

--- a/tests/unit/prompt-templates.test.ts
+++ b/tests/unit/prompt-templates.test.ts
@@ -52,4 +52,14 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain("config.code");
     expect(prompt).toContain("rawscript");
   });
+
+  it("documents the $ref resolution rule (properties vs additionalProperties)", () => {
+    expect(prompt).toContain("$ref` resolution rule");
+    expect(prompt).toContain("Fixed-schema objects");
+    expect(prompt).toContain("properties");
+    expect(prompt).toContain("Dynamic-key maps");
+    expect(prompt).toContain("additionalProperties");
+    expect(prompt).toContain("caller-chosen");
+    expect(prompt).toContain("Inventing paths against fixed schemas is a hard failure");
+  });
 });

--- a/tests/unit/upgrade-schema.test.ts
+++ b/tests/unit/upgrade-schema.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { UpgradeWorkflowFromDescriptionSchema } from "../../src/schemas.js";
+
+describe("UpgradeWorkflowFromDescriptionSchema", () => {
+  const VALID_DESCRIPTION = "Patch the email-generate node $ref paths to match the lead service schema.";
+
+  it("accepts workflowDynastySlug + description", () => {
+    const result = UpgradeWorkflowFromDescriptionSchema.safeParse({
+      workflowDynastySlug: "sales-cold-email-outreach-eden",
+      description: VALID_DESCRIPTION,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects legacy workflowSlug field (post-rename: bigbang)", () => {
+    const result = UpgradeWorkflowFromDescriptionSchema.safeParse({
+      workflowSlug: "sales-cold-email-outreach-eden",
+      description: VALID_DESCRIPTION,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issues = result.error.issues.map((i) => i.path.join("."));
+      expect(issues).toContain("workflowDynastySlug");
+    }
+  });
+
+  it("rejects missing workflowDynastySlug", () => {
+    const result = UpgradeWorkflowFromDescriptionSchema.safeParse({
+      description: VALID_DESCRIPTION,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty workflowDynastySlug", () => {
+    const result = UpgradeWorkflowFromDescriptionSchema.safeParse({
+      workflowDynastySlug: "",
+      description: VALID_DESCRIPTION,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when both dag and description absent", () => {
+    const result = UpgradeWorkflowFromDescriptionSchema.safeParse({
+      workflowDynastySlug: "sales-cold-email-outreach-eden",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.message.includes("Either"))).toBe(true);
+    }
+  });
+
+  it("accepts workflowDynastySlug + dag (no description)", () => {
+    const dag = {
+      nodes: [
+        {
+          id: "n1",
+          type: "http.call",
+          config: { service: "campaign", method: "POST", path: "/foo" },
+        },
+      ],
+      edges: [],
+    };
+    const result = UpgradeWorkflowFromDescriptionSchema.safeParse({
+      workflowDynastySlug: "sales-cold-email-outreach-eden",
+      dag,
+    });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Three fixes surfaced by the Eden cold-email workflow `$ref`-fix post-mortem (DIS-36). See attached transcript in workspace `brisbane-v10` for context.

- **Upgrade endpoint input renamed** `workflowSlug` → `workflowDynastySlug`. Bigbang (no soft-accept). Route now looks up the active row via `WHERE workflow_dynasty_slug = ? AND status = 'active'` — callers no longer need to track which version is active after prior upgrades.
- **Validator drill-down 1 level** into object sub-fields. `availableAt` now lists `organization{name,industry,estimatedNumEmployees,...}` for object-typed properties so `$ref` failure messages show the next attempt path without a guess-and-check round-trip.
- **Prompt rule** in `buildSystemPrompt`: explicit `properties` vs `additionalProperties` distinction for `$ref` resolution. Codifies what the validator already enforces.

Linear: DIS-36

## ⚠️ Deployment ordering

This PR is **breaking** on the upgrade endpoint input field name. The dashboard chat platform tool definition for `upgrade_workflow` must update in lockstep. Sister workspace is open at `/Users/kevinlourd/conductor/repos/distribute.you` (or `chat-service` depending on owner re-verification). Recommend merging the dashboard PR first (calls degrade to 400 instead of crashing), then this PR within minutes. Brief chat-upgrade 400 window on staging is acceptable.

Linear: DIS-37 tracks the campaign-service `/start-run` response addition (gated on team confirm).

## Test plan

- [x] `npm test` — 569 passing (3 new integration tests + 4 new unit tests).
- [x] `npm run build` — TypeScript compiles, openapi.json regenerated.
- [ ] After merge, sister dashboard PR ships in same staging window.
- [ ] Manual: chat agent E2E in staging — verify `validate_workflow` → `upgrade_workflow(workflowDynastySlug, dag)` round-trip with corrected `$ref` paths uses `dag` param (no LLM regen drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)