### PR TITLE
fix(fetch): 10-min AbortSignal timeout on every outbound fetch

### DIFF
--- a/scripts/nodes/app-resolve-discount.ts
+++ b/scripts/nodes/app-resolve-discount.ts
@@ -21,6 +21,7 @@ export async function main(
     `${baseUrl}/coupons/${couponId}`,
     {
       headers: reqHeaders,
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/app-resolve-product.ts
+++ b/scripts/nodes/app-resolve-product.ts
@@ -21,6 +21,7 @@ export async function main(
     `${baseUrl}/products/${productId}`,
     {
       headers: reqHeaders,
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/client-create-user.ts
+++ b/scripts/nodes/client-create-user.ts
@@ -29,6 +29,7 @@ export async function main(
       method: "POST",
       headers: reqHeaders,
       body: JSON.stringify({ orgId, email, firstName, lastName, phone, metadata }),
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/client-get-users.ts
+++ b/scripts/nodes/client-get-users.ts
@@ -26,6 +26,7 @@ export async function main(
     `${baseUrl}/anonymous-users?${params}`,
     {
       headers: reqHeaders,
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/client-service.ts
+++ b/scripts/nodes/client-service.ts
@@ -32,6 +32,7 @@ export async function main(
         appId,
         ...contactData,
       }),
+      signal: AbortSignal.timeout(600_000),
     });
     return response.json();
   }
@@ -39,7 +40,7 @@ export async function main(
   if (action === "list") {
     const response = await fetch(
       `${baseUrl}/anonymous-users?appId=${appId}`,
-      { headers }
+      { headers, signal: AbortSignal.timeout(600_000) }
     );
     return response.json();
   }
@@ -47,7 +48,7 @@ export async function main(
   if (action === "get" && contactData?.id) {
     const response = await fetch(
       `${baseUrl}/anonymous-users/${contactData.id}`,
-      { headers }
+      { headers, signal: AbortSignal.timeout(600_000) }
     );
     return response.json();
   }

--- a/scripts/nodes/client-update-user.ts
+++ b/scripts/nodes/client-update-user.ts
@@ -29,6 +29,7 @@ export async function main(
       method: "PATCH",
       headers: reqHeaders,
       body: JSON.stringify({ firstName, lastName, phone, userId: linkedUserId, orgId, metadata }),
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/content-sentiment.ts
+++ b/scripts/nodes/content-sentiment.ts
@@ -29,6 +29,7 @@ export async function main(
       method: "POST",
       headers: reqHeaders,
       body: JSON.stringify({ content: emailContent }),
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/http-call.ts
+++ b/scripts/nodes/http-call.ts
@@ -80,7 +80,13 @@ export async function main(
   // Resolved x-api-key always takes precedence
   if (apiKey) reqHeaders["x-api-key"] = apiKey;
 
-  const options: RequestInit = { method, headers: reqHeaders };
+  const options: RequestInit = {
+    method,
+    headers: reqHeaders,
+    // 10-min deadline. Some downstream endpoints (RAG ranking, heavy enrichment)
+    // legitimately need 5-10 min to respond; Bun's default fetch timeout is shorter.
+    signal: AbortSignal.timeout(600_000),
+  };
 
   if (body && ["POST", "PUT", "PATCH"].includes(method.toUpperCase())) {
     options.body = JSON.stringify(body);

--- a/scripts/nodes/lead-service.ts
+++ b/scripts/nodes/lead-service.ts
@@ -40,6 +40,7 @@ export async function main(
         parentRunId: resolvedRunId,
         searchParams: searchParams ?? {},
       }),
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/outbound-sending.ts
+++ b/scripts/nodes/outbound-sending.ts
@@ -46,6 +46,7 @@ export async function main(
         campaignId: context.campaignId,
         brandId: context.brandId,
       }),
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/stripe-create-checkout.ts
+++ b/scripts/nodes/stripe-create-checkout.ts
@@ -37,6 +37,7 @@ export async function main(
         lineItems, successUrl, cancelUrl, mode, customerId, customerEmail,
         metadata, discounts, orgId, brandId, campaignId, runId,
       }),
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/stripe-create-coupon.ts
+++ b/scripts/nodes/stripe-create-coupon.ts
@@ -34,6 +34,7 @@ export async function main(
       method: "POST",
       headers: reqHeaders,
       body: JSON.stringify({ orgId, id, name, percentOff, amountOffInCents, currency, duration, durationInMonths, maxRedemptions, redeemBy, metadata }),
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/stripe-create-price.ts
+++ b/scripts/nodes/stripe-create-price.ts
@@ -29,6 +29,7 @@ export async function main(
       method: "POST",
       headers: reqHeaders,
       body: JSON.stringify({ orgId, productId, unitAmountInCents, currency, recurring, metadata }),
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/stripe-create-product.ts
+++ b/scripts/nodes/stripe-create-product.ts
@@ -28,6 +28,7 @@ export async function main(
       method: "POST",
       headers: reqHeaders,
       body: JSON.stringify({ orgId, name, description, id, metadata }),
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/stripe-get-coupon.ts
+++ b/scripts/nodes/stripe-get-coupon.ts
@@ -24,6 +24,7 @@ export async function main(
     url.toString(),
     {
       headers: reqHeaders,
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/stripe-get-prices-by-product.ts
+++ b/scripts/nodes/stripe-get-prices-by-product.ts
@@ -24,6 +24,7 @@ export async function main(
     url.toString(),
     {
       headers: reqHeaders,
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/stripe-get-product.ts
+++ b/scripts/nodes/stripe-get-product.ts
@@ -24,6 +24,7 @@ export async function main(
     url.toString(),
     {
       headers: reqHeaders,
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/stripe-get-stats.ts
+++ b/scripts/nodes/stripe-get-stats.ts
@@ -27,6 +27,7 @@ export async function main(
       method: "POST",
       headers: reqHeaders,
       body: JSON.stringify({ runIds, orgId, brandId, campaignId }),
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/transactional-email-get-stats.ts
+++ b/scripts/nodes/transactional-email-get-stats.ts
@@ -25,6 +25,7 @@ export async function main(
       method: "POST",
       headers: reqHeaders,
       body: JSON.stringify({ orgId, userId, eventType }),
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/scripts/nodes/transactional-email-send.ts
+++ b/scripts/nodes/transactional-email-send.ts
@@ -30,6 +30,7 @@ export async function main(
       method: "POST",
       headers: reqHeaders,
       body: JSON.stringify({ eventType, recipientEmail, brandId, campaignId, productId, userId, orgId, metadata }),
+      signal: AbortSignal.timeout(600_000),
     }
   );
 

--- a/src/lib/api-registry-client.ts
+++ b/src/lib/api-registry-client.ts
@@ -49,6 +49,7 @@ export async function fetchLlmContext(downstreamHeaders?: DownstreamHeaders): Pr
   const res = await fetch(`${baseUrl}/llm-context`, {
     method: "GET",
     headers: buildHeaders(apiKey, downstreamHeaders),
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {
@@ -73,6 +74,7 @@ export async function fetchServiceEndpoints(
     {
       method: "GET",
       headers: buildHeaders(apiKey, downstreamHeaders),
+      signal: AbortSignal.timeout(600_000),
     },
   );
 
@@ -95,6 +97,7 @@ export async function fetchServiceList(
   const res = await fetch(`${baseUrl}/services`, {
     method: "GET",
     headers: buildHeaders(apiKey, downstreamHeaders),
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {
@@ -146,6 +149,7 @@ export async function fetchServiceSpec(
     {
       method: "GET",
       headers: buildHeaders(apiKey, downstreamHeaders),
+      signal: AbortSignal.timeout(600_000),
     },
   );
 

--- a/src/lib/campaign-client.ts
+++ b/src/lib/campaign-client.ts
@@ -36,6 +36,7 @@ export async function fetchAllCampaigns(
       "x-service-name": "workflow-service",
       ...downstreamHeaders,
     },
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {

--- a/src/lib/chat-service-client.ts
+++ b/src/lib/chat-service-client.ts
@@ -48,6 +48,7 @@ export async function chatServiceComplete(
       ...downstreamHeaders,
     },
     body: JSON.stringify(request),
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {
@@ -76,6 +77,7 @@ export async function chatServicePlatformComplete(
       "x-api-key": apiKey,
     },
     body: JSON.stringify(request),
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {

--- a/src/lib/content-generation-client.ts
+++ b/src/lib/content-generation-client.ts
@@ -37,6 +37,7 @@ export async function fetchPromptTemplate(
     {
       method: "GET",
       headers: { "x-api-key": apiKey, ...downstreamHeaders },
+      signal: AbortSignal.timeout(600_000),
     },
   );
 

--- a/src/lib/features-client.ts
+++ b/src/lib/features-client.ts
@@ -40,6 +40,7 @@ export async function fetchFeatureOutputs(
     {
       method: "GET",
       headers: { "x-api-key": config.apiKey, ...downstreamHeaders },
+      signal: AbortSignal.timeout(600_000),
     },
   );
 
@@ -80,6 +81,7 @@ export async function fetchStatsRegistry(
   const res = await fetch(`${config.baseUrl}/stats/registry`, {
     method: "GET",
     headers: { "x-api-key": config.apiKey, ...downstreamHeaders },
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {

--- a/src/lib/key-service-client.ts
+++ b/src/lib/key-service-client.ts
@@ -40,6 +40,7 @@ export async function fetchProviderRequirements(
       ...downstreamHeaders,
     },
     body: JSON.stringify({ endpoints }),
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -59,6 +59,7 @@ export async function createRun(opts: {
     method: "POST",
     headers,
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {
@@ -96,6 +97,7 @@ export async function createPlatformRun(opts: {
       "x-service-name": "workflow-service",
     },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {
@@ -125,6 +127,7 @@ export async function closeRun(
       "x-org-id": orgId,
     },
     body: JSON.stringify({ status }),
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {
@@ -150,6 +153,7 @@ export async function closePlatformRun(
       "x-service-name": "workflow-service",
     },
     body: JSON.stringify({ status }),
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {

--- a/src/lib/source-stats-client.ts
+++ b/src/lib/source-stats-client.ts
@@ -42,6 +42,7 @@ export async function fetchLeadStats(
       "x-api-key": apiKey,
       ...downstreamHeaders,
     },
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {
@@ -81,6 +82,7 @@ export async function fetchJournalistStats(
       "x-api-key": apiKey,
       ...downstreamHeaders,
     },
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {
@@ -122,6 +124,7 @@ export async function fetchOutletStats(
       "x-api-key": apiKey,
       ...downstreamHeaders,
     },
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {

--- a/src/lib/stats-client.ts
+++ b/src/lib/stats-client.ts
@@ -63,6 +63,7 @@ export async function fetchRunCostsAuth(
       "x-api-key": apiKey,
       ...downstreamHeaders,
     },
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {
@@ -111,6 +112,7 @@ export async function fetchRunCostsPublic(filters?: {
   const res = await fetch(`${baseUrl}/v1/stats/public/costs?${params}`, {
     method: "GET",
     headers: { "x-api-key": apiKey },
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {
@@ -190,6 +192,7 @@ export async function fetchEmailStatsAuth(
       "x-api-key": apiKey,
       ...downstreamHeaders,
     },
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {
@@ -216,6 +219,7 @@ export async function fetchEmailStatsPublic(
   const res = await fetch(`${baseUrl}/public/stats?${params}`, {
     method: "GET",
     headers: { "x-api-key": apiKey },
+    signal: AbortSignal.timeout(600_000),
   });
 
   if (!res.ok) {

--- a/src/lib/trace-event.ts
+++ b/src/lib/trace-event.ts
@@ -48,6 +48,7 @@ export async function traceEvent(
       method: "POST",
       headers: outHeaders,
       body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(600_000),
     });
   } catch (err) {
     console.error("[workflow-service] Failed to trace event:", err);

--- a/src/lib/windmill-client.ts
+++ b/src/lib/windmill-client.ts
@@ -45,6 +45,7 @@ export class WindmillClient {
         "Content-Type": "application/json",
       },
       body: body ? JSON.stringify(body) : undefined,
+      signal: AbortSignal.timeout(600_000),
     });
 
     if (!res.ok) {
@@ -151,6 +152,7 @@ export class WindmillClient {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ value }),
+      signal: AbortSignal.timeout(600_000),
     });
 
     if (!res.ok) {
@@ -166,6 +168,7 @@ export class WindmillClient {
   async healthCheck(): Promise<boolean> {
     const res = await fetch(`${this.baseUrl}/api/version`, {
       headers: { Authorization: `Bearer ${this.token}` },
+      signal: AbortSignal.timeout(600_000),
     });
     return res.ok;
   }

--- a/tests/unit/content-generation-client.test.ts
+++ b/tests/unit/content-generation-client.test.ts
@@ -45,7 +45,10 @@ describe("content-generation-client", () => {
     expect(result!.type).toBe("cold-email");
     expect(mockFetch).toHaveBeenCalledWith(
       "https://cg.example.com/platform-prompts?type=cold-email",
-      { method: "GET", headers: { "x-api-key": "key-123" } },
+      expect.objectContaining({
+        method: "GET",
+        headers: { "x-api-key": "key-123" },
+      }),
     );
   });
 

--- a/tests/unit/fetch-timeout-audit.test.ts
+++ b/tests/unit/fetch-timeout-audit.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/**
+ * Every outbound fetch in this repo must carry an AbortSignal with a >=10min
+ * deadline. Bun's default fetch idle timeout (~5min) kills the connection
+ * mid-flight for long-running downstreams (RAG ranking, heavy enrichment),
+ * which surfaces as `TimeoutError` step failures in Windmill flows.
+ */
+
+const TIMEOUT_LITERAL = "AbortSignal.timeout(600_000)";
+
+function listTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      out.push(...listTsFiles(join(dir, entry.name)));
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      out.push(join(dir, entry.name));
+    }
+  }
+  return out;
+}
+
+function countOutboundFetchCalls(source: string): number {
+  // Count `fetch(` occurrences that are outbound HTTP calls (excluding
+  // res.text/json and method declarations). Whitespace-tolerant.
+  const matches = source.match(/(^|\s|=|\()fetch\(/g);
+  return matches ? matches.length : 0;
+}
+
+function countTimeoutMarkers(source: string): number {
+  return source.split(TIMEOUT_LITERAL).length - 1;
+}
+
+describe("fetch-timeout audit", () => {
+  const targets = [
+    ...listTsFiles(join(REPO_ROOT, "scripts", "nodes")),
+    ...listTsFiles(join(REPO_ROOT, "src", "lib")),
+  ];
+
+  for (const filePath of targets) {
+    const source = readFileSync(filePath, "utf8");
+    const fetchCount = countOutboundFetchCalls(source);
+    if (fetchCount === 0) continue;
+
+    const relPath = filePath.slice(REPO_ROOT.length + 1);
+    it(`${relPath} — every fetch has AbortSignal.timeout(600_000)`, () => {
+      const timeoutCount = countTimeoutMarkers(source);
+      expect(timeoutCount).toBeGreaterThanOrEqual(fetchCount);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Adds `signal: AbortSignal.timeout(600_000)` to every outbound `fetch()` in the repo so Bun's default ~5-minute fetch idle timeout no longer kills connections to long-running downstreams (RAG ranking, heavy enrichment, etc.).

## Prod symptom (2026-05-28 ~02:39 UTC)

Windmill flow steps invoking long-running services failed with:

```
{"error":{"message":"The operation timed out.","name":"TimeoutError","stack":"","step_id":"fetch_opportunity"}}
```

Parent flow status cascaded as failed → campaign-service rescheduled every 60s → same hang every retry → no forward progress.

## Where the limit lives

| Layer | Where | Status |
|---|---|---|
| **L1** — workflow-service Bun `fetch()` (`scripts/nodes/*.ts`, `src/lib/*-client.ts`) | this repo | **Fixed here**: every fetch now carries `AbortSignal.timeout(600_000)` (10 min) |
| L2 — api-service undici `headersTimeout` / `bodyTimeout` for `/orgs/opportunities/ranked` | parallel workspace | Being raised independently. Workflow-service scripts hit downstream services directly (per `prompt-templates.ts` rule "NEVER use api"), so this fix is independent — it covers calls that don't transit api-service at all. |
| L3 — journalists-quotes-service `/orgs/opportunities/ranked` RAG runtime | out of scope | RAG legitimately needs 5–10 min on large brand-sets. Tracked separately. |

Windmill step-level timeout (PR #213 set this at 3600s) is also fine — the failure was at the HTTP-client layer below it.

## Scope

48 fetch call sites updated:

- **`scripts/nodes/*.ts` (22 sites)** — every Windmill node script. The generic `http.call` script (used by the `fetch_opportunity` LLM-generated node) is the immediate fix. Named-type legacy scripts (lead, stripe-*, transactional-email, etc.) updated too — they call downstream services directly with no enforcement that those services stay sub-second.
- **`src/lib/*-client.ts` (26 sites)** — every cross-service HTTP client (chat-service, content-generation, runs, key-service, features, campaign, stats, source-stats, api-registry, windmill-client, trace-event). chat-service especially can run long under heavy validator/upgrade load.

## Regression guard

`tests/unit/fetch-timeout-audit.test.ts` walks both directories and asserts every `fetch(` call site carries the `AbortSignal.timeout(600_000)` literal. Future fetch additions without the timeout will fail CI.

## Test plan

- [x] `npx vitest run tests/unit` — 476 / 476 pass
- [x] `npx vitest run tests/integration` — 124 / 124 pass
- [x] `npm run build` — clean
- [x] One existing test (`content-generation-client.test.ts`) updated from exact-match to `expect.objectContaining({...})` so it no longer asserts the absence of `signal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)