### PR TITLE
fix(attribution): thread per-run audienceId into for-each loop bodies (#321)

### DIFF
--- a/src/lib/dag-to-openflow.ts
+++ b/src/lib/dag-to-openflow.ts
@@ -5,6 +5,25 @@ import { buildInputTransforms } from "./input-mapping.js";
 /** Global timeout applied to every script module (in seconds). 1 hour. */
 const NODE_TIMEOUT_SECONDS = 3600;
 
+/**
+ * Reserved key under which the per-run `audienceId` is attached to each element
+ * of a for-each iterator so it survives into the loop body.
+ *
+ * Windmill runs a `forloopflow` body as an isolated subflow: `flow_input.*`
+ * (top-level) and `flow_input.iter.value` (current element) resolve inside it,
+ * but `results.<outerStep>` does NOT (the start-run result reference used for
+ * top-level/branch nodes returns undefined inside the loop). So a value chosen
+ * mid-flow (the audienceId returned by campaign `/start-run`) cannot reach a
+ * loop-body node via `results.start_run` — it must be folded onto the iterated
+ * elements by the iterator expression (which IS evaluated in the parent scope
+ * where `results.start_run` resolves) and read back as
+ * `flow_input.iter.value?.<AUDIENCE_ITER_KEY>` inside the body.
+ */
+const AUDIENCE_ITER_KEY = "__wf_audience_id";
+
+/** The reference every loop-body node uses to read the threaded audienceId. */
+const LOOP_BODY_AUDIENCE_REF = `flow_input.iter.value?.${AUDIENCE_ITER_KEY}`;
+
 export interface FlowModule {
   id: string;
   summary?: string;
@@ -159,6 +178,15 @@ function buildModules(orderedNodes: DAGNode[], dag: DAG): FlowModule[] {
     }
   }
 
+  // The JS expression a start-run DESCENDANT uses to read the per-run audienceId.
+  // Inline contexts (top-level, branchone body) resolve `results.start_run`;
+  // for-each bodies override this to the iter-threaded reference (see
+  // buildForEachModule). Null when the DAG has no campaign /start-run node.
+  const { startRunModuleId } = getAudiencePropagationScope(dag);
+  const audienceRef = startRunModuleId
+    ? `results.${startRunModuleId}?.audienceId`
+    : null;
+
   // Build pass: iterate ordered nodes, skip consumed, build containers with nested modules
   const modules: FlowModule[] = [];
 
@@ -166,13 +194,13 @@ function buildModules(orderedNodes: DAGNode[], dag: DAG): FlowModule[] {
     if (consumed.has(node.id)) continue;
 
     if (node.type === "condition") {
-      const mod = buildConditionModule(node, dag, orderedNodes, conditionInfo.get(node.id)!);
+      const mod = buildConditionModule(node, dag, orderedNodes, conditionInfo.get(node.id)!, audienceRef);
       modules.push(mod);
     } else if (node.type === "for-each") {
-      const mod = buildForEachModule(node, orderedNodes, loopBodyInfo.get(node.id)!, dag);
+      const mod = buildForEachModule(node, orderedNodes, loopBodyInfo.get(node.id)!, dag, audienceRef);
       modules.push(mod);
     } else {
-      const mod = nodeToModule(node, dag);
+      const mod = nodeToModule(node, dag, audienceRef);
       if (mod) modules.push(mod);
     }
   }
@@ -284,6 +312,7 @@ function buildConditionModule(
   dag: DAG,
   orderedNodes: DAGNode[],
   info: { branchNodeSets: Map<string, Set<string>>; afterNodes: Set<string> },
+  audienceRef: string | null,
 ): FlowModule {
   const moduleId = node.id.replace(/-/g, "_");
   const outEdges = dag.edges.filter((e) => e.from === node.id && e.condition);
@@ -321,7 +350,9 @@ function buildConditionModule(
     const branchNodes = orderedNodes.filter((n) => branchNodeIds.has(n.id));
     const branchModules: FlowModule[] = [];
     for (const bn of branchNodes) {
-      const mod = nodeToModule(bn, dag);
+      // branchone runs inline in the parent flow scope, so `results.start_run`
+      // still resolves inside a branch body — forward the inline audienceRef.
+      const mod = nodeToModule(bn, dag, audienceRef);
       if (mod) branchModules.push(mod);
     }
 
@@ -340,14 +371,38 @@ function buildForEachModule(
   orderedNodes: DAGNode[],
   bodyNodeIds: Set<string>,
   dag: DAG,
+  audienceRef: string | null,
 ): FlowModule {
   const moduleId = node.id.replace(/-/g, "_");
-  const iteratorExpr = (node.config?.iterator as string) ?? "flow_input.items";
+  let iteratorExpr = (node.config?.iterator as string) ?? "flow_input.items";
+
+  // A for-each body is an isolated subflow — `results.start_run` (the inline
+  // audienceRef) does NOT resolve inside it. When this loop runs downstream of
+  // start-run, fold the per-run audienceId onto every iterated element via the
+  // iterator expression (evaluated in the PARENT scope, where the inbound
+  // audienceRef resolves), then have body nodes read it from the iteration
+  // context. This is what carries per-(audience × workflow) attribution to the
+  // per-lead send/generation calls nested in the loop.
+  const carriesAudience =
+    audienceRef !== null && isStartRunDescendant(dag, moduleId);
+
+  if (carriesAudience) {
+    // (origIter ?? []).map(el => el && typeof el === "object"
+    //   ? { ...el, __wf_audience_id: <audienceRef> } : el)
+    iteratorExpr =
+      `(${iteratorExpr} ?? []).map((__wf_el) => ` +
+      `(__wf_el && typeof __wf_el === "object") ? ` +
+      `{ ...__wf_el, ${AUDIENCE_ITER_KEY}: ${audienceRef} } : __wf_el)`;
+  }
+
+  // Inside the loop body, audienceId is read from the (possibly wrapped)
+  // iteration element, not from the out-of-scope start-run result.
+  const bodyAudienceRef = carriesAudience ? LOOP_BODY_AUDIENCE_REF : null;
 
   const bodyNodes = orderedNodes.filter((n) => bodyNodeIds.has(n.id));
   const bodyModules: FlowModule[] = [];
   for (const bn of bodyNodes) {
-    const mod = nodeToModule(bn, dag);
+    const mod = nodeToModule(bn, dag, bodyAudienceRef);
     if (mod) bodyModules.push(mod);
   }
 
@@ -362,6 +417,16 @@ function buildForEachModule(
       parallel: (node.config?.parallel as boolean) ?? false,
     },
   };
+}
+
+/**
+ * Whether `moduleId` is reachable forward from the campaign /start-run node —
+ * i.e. it runs strictly after start-run, so the run's audienceId is available
+ * to thread into it. False for non-campaign DAGs (no start-run node).
+ */
+function isStartRunDescendant(dag: DAG, moduleId: string): boolean {
+  const { startRunModuleId, descendants } = getAudiencePropagationScope(dag);
+  return startRunModuleId !== null && descendants.has(moduleId);
 }
 
 /**
@@ -453,7 +518,11 @@ function getAudiencePropagationScope(dag: DAG): AudiencePropagationScope {
   return scope;
 }
 
-function nodeToModule(node: DAGNode, dag: DAG): FlowModule | null {
+function nodeToModule(
+  node: DAGNode,
+  dag: DAG,
+  audienceRef: string | null,
+): FlowModule | null {
   const moduleId = node.id.replace(/-/g, "_");
 
   if (node.type === "wait") {
@@ -567,20 +636,25 @@ function nodeToModule(node: DAGNode, dag: DAG): FlowModule | null {
 
   // Propagate the per-run audience chosen by campaign-service inside /start-run.
   // Unlike the identity fields above, audienceId is not a flow_input — it is
-  // only known once start-run has executed, so it is threaded from that node's
-  // result into every node DOWNSTREAM of start-run as the x-audience-id header.
-  // Scope to descendants only: Windmill resolves `results.<start_run>` via a
-  // result-by-id fetch BEFORE the JS `?.` runs, so injecting it into a node that
-  // runs at-or-before start-run (e.g. gate-check) 404s the lookup at dispatch.
+  // only known once start-run has executed, so it is threaded downstream as the
+  // x-audience-id header. `audienceRef` is the caller-scoped expression that
+  // resolves to it: `results.start_run?.audienceId` for inline (top-level /
+  // branchone) nodes, or the iter-threaded `flow_input.iter.value?...` for
+  // nodes inside a for-each body (where the start-run result is out of scope).
+  // Scope to start-run descendants only: Windmill resolves `results.<start_run>`
+  // via a result-by-id fetch BEFORE the JS `?.` runs, so injecting the inline
+  // ref into a node that runs at-or-before start-run (e.g. gate-check) 404s the
+  // lookup at dispatch.
   const { startRunModuleId, descendants } = getAudiencePropagationScope(dag);
   if (
+    audienceRef &&
     startRunModuleId &&
     descendants.has(moduleId) &&
     !inputTransforms.audienceId
   ) {
     inputTransforms.audienceId = {
       type: "javascript",
-      expr: `results.${startRunModuleId}?.audienceId`,
+      expr: audienceRef,
     };
   }
 

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -513,6 +513,62 @@ export const DAG_WITH_CAMPAIGN_START_RUN: DAG = {
   ],
 };
 
+/**
+ * Campaign flow whose per-lead generation + send run INSIDE a for-each loop
+ * body (batch multiple leads per run). start-run returns the per-run audienceId;
+ * the loop body is an isolated Windmill subflow where `results.start_run` does
+ * NOT resolve, so audienceId must be threaded via the iterator + iter context.
+ */
+export const DAG_WITH_CAMPAIGN_FOREACH: DAG = {
+  nodes: [
+    {
+      id: "gate-check",
+      type: "http.call",
+      config: { service: "campaign", method: "POST", path: "/gate-check" },
+      inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" },
+    },
+    {
+      id: "start-run",
+      type: "http.call",
+      config: { service: "campaign", method: "POST", path: "/start-run" },
+      inputMapping: { "body.campaignId": "$ref:flow_input.campaignId" },
+      retries: 0,
+    },
+    {
+      id: "fetch-leads",
+      type: "http.call",
+      config: { service: "lead", method: "POST", path: "/buffer/batch" },
+      retries: 0,
+    },
+    {
+      id: "loop-leads",
+      type: "for-each",
+      config: { iterator: "results.fetch_leads.leads", parallel: false },
+    },
+    {
+      id: "email-generate",
+      type: "http.call",
+      config: { service: "content-generation", method: "POST", path: "/generate" },
+      inputMapping: { "body.leadEmail": "$ref:loop-leads.output.email" },
+      retries: 0,
+    },
+    {
+      id: "email-send",
+      type: "http.call",
+      config: { service: "email-gateway", method: "POST", path: "/send" },
+      inputMapping: { "body.subject": "$ref:email-generate.output.subject" },
+      retries: 0,
+    },
+  ],
+  edges: [
+    { from: "gate-check", to: "start-run" },
+    { from: "start-run", to: "fetch-leads" },
+    { from: "fetch-leads", to: "loop-leads" },
+    { from: "loop-leads", to: "email-generate" },
+    { from: "email-generate", to: "email-send" },
+  ],
+};
+
 export const DAG_WITH_DOT_NOTATION_AND_STATIC_BASE: DAG = {
   nodes: [
     {

--- a/tests/unit/dag-to-openflow.test.ts
+++ b/tests/unit/dag-to-openflow.test.ts
@@ -14,6 +14,7 @@ import {
   DAG_WITH_FLOW_INPUT_REFS,
   DAG_WITH_CONFIG_RETRIES,
   DAG_WITH_CAMPAIGN_START_RUN,
+  DAG_WITH_CAMPAIGN_FOREACH,
   DAG_WITH_DOT_NOTATION_AND_STATIC_BASE,
   DAG_WITH_STOP_AFTER_IF,
   DAG_WITH_SKIP_IF,
@@ -317,6 +318,82 @@ describe("dagToOpenFlow", () => {
         expect(transforms.audienceId).toBeUndefined();
       }
     }
+  });
+
+  describe("audienceId threading into for-each loop bodies", () => {
+    // Regression for #321: per-lead gen/send nodes nested inside a for-each
+    // loop body must carry the run's audienceId, but `results.start_run` does
+    // NOT resolve inside a Windmill forloopflow subflow. audienceId is folded
+    // onto each iterated element (via the iterator expr, evaluated in the parent
+    // scope) and read back from `flow_input.iter.value` inside the body.
+    const flow = dagToOpenFlow(DAG_WITH_CAMPAIGN_FOREACH, "Campaign ForEach");
+    const topById = new Map(flow.value.modules.map((m) => [m.id, m]));
+    const loop = topById.get("loop_leads");
+
+    function loopBodyTransforms(id: string): Record<string, { type: string; expr?: string }> {
+      if (loop?.value.type !== "forloopflow") throw new Error("loop not a forloopflow");
+      const bodyMod = loop.value.modules.find((m) => m.id === id);
+      if (!bodyMod || bodyMod.value.type !== "script") throw new Error(`no script body ${id}`);
+      return bodyMod.value.input_transforms as Record<string, { type: string; expr?: string }>;
+    }
+
+    it("wraps the loop iterator to attach the per-run audienceId to each element", () => {
+      expect(loop).toBeDefined();
+      if (loop!.value.type === "forloopflow") {
+        const expr = (loop!.value.iterator as { type: string; expr: string }).expr;
+        // original iterator preserved, mapped, and audienceId attached from
+        // start-run's result (resolvable in the parent/iterator scope)
+        expect(expr).toContain("results.fetch_leads.leads");
+        expect(expr).toContain(".map(");
+        expect(expr).toContain("__wf_audience_id: results.start_run?.audienceId");
+      }
+    });
+
+    it("references audienceId from the iteration context on every loop-body node", () => {
+      for (const id of ["email_generate", "email_send"]) {
+        expect(loopBodyTransforms(id).audienceId).toEqual({
+          type: "javascript",
+          expr: "flow_input.iter.value?.__wf_audience_id",
+        });
+      }
+    });
+
+    it("does NOT reference the out-of-scope start-run result inside the loop body", () => {
+      for (const id of ["email_generate", "email_send"]) {
+        expect(loopBodyTransforms(id).audienceId.expr).not.toContain("results.start_run");
+      }
+    });
+
+    it("keeps the inline start-run result ref for descendants OUTSIDE the loop", () => {
+      const fetchLeads = topById.get("fetch_leads");
+      expect(fetchLeads).toBeDefined();
+      if (fetchLeads!.value.type === "script") {
+        const transforms = fetchLeads!.value.input_transforms as Record<
+          string,
+          { type: string; expr?: string }
+        >;
+        expect(transforms.audienceId).toEqual({
+          type: "javascript",
+          expr: "results.start_run?.audienceId",
+        });
+      }
+    });
+
+    it("does not wrap a for-each iterator when the DAG has no start-run node", () => {
+      const noCampaign = dagToOpenFlow(DAG_WITH_FOREACH, "No Campaign Loop");
+      const loopMod = noCampaign.value.modules.find((m) => m.id === "loop");
+      expect(loopMod).toBeDefined();
+      if (loopMod!.value.type === "forloopflow") {
+        // iterator untouched, no audienceId attach
+        expect((loopMod!.value.iterator as { expr: string }).expr).toBe("flow_input.contacts");
+        for (const body of loopMod!.value.modules) {
+          if (body.value.type === "script") {
+            const t = body.value.input_transforms as Record<string, unknown>;
+            expect(t.audienceId).toBeUndefined();
+          }
+        }
+      }
+    });
   });
 
   it("does not override explicit orgId in node config but auto-injects userId", () => {


### PR DESCRIPTION
## Job
Downstream stats need per-(audience × workflow) attribution at the recipient grain: for each email send and its engagement, which (audience, workflow) couple produced it. features-service already attributes cost per (audience × workflow) and resolves outcomes per audience via membership; the blocker is that **outcomes can't be split by workflow within an audience** because loop-body sends carry no audience/workflow identity.

## Problem
PR #307 threaded the per-run `audienceId` (from campaign `/start-run`) onto top-level + branchone descendant nodes via `results.start_run?.audienceId`. That reference does **not** resolve inside a Windmill `forloopflow` body — the loop runs as an isolated subflow where only `flow_input.*` and `flow_input.iter.value` are in scope. So per-lead generation + send calls nested in a for-each-lead loop carried no `x-audience-id`, leaving their runs-service cost/engagement rows untagged (issue #321: ~97% of a campaign's spend unattributed). Tracked as #321 / #366 / #367.

## Fix (single file: `src/lib/dag-to-openflow.ts`)
When a for-each node runs downstream of start-run, fold the run's `audienceId` onto each iterated element **via the iterator expression** — which is evaluated in the parent scope where `results.start_run` resolves — then have every loop-body node read it back as `flow_input.iter.value?.__wf_audience_id`.

- Inline (top-level / branchone) nodes are unchanged: still `results.start_run?.audienceId`.
- The `audienceRef` expression is threaded through `buildModules → buildConditionModule / buildForEachModule → nodeToModule`; the for-each override is the only place it changes.
- **Workflow identity** (`x-workflow-slug`) already reaches loop bodies via `flow_input.workflowSlug` (flow_input is in scope inside loops). `http-call.ts` already maps `audienceId → x-audience-id` and `workflowSlug → x-workflow-slug`, and both keys are already in the `downstream-headers.ts` allowlist — so **no node-script or allowlist change is needed**.

## Blast radius
Zero on current prod: no deployed Windmill flow uses a for-each (all campaign flows are one-lead-per-run `branchone`, which already tag correctly). This only takes effect for loop-shaped workflows. Boot-sync `syncFlowToWindmill` re-pushes codegen to active flows on restart, so a codegen change needs no manual re-create — but active flows have no loop, so re-push is a no-op for this path.

## AC (consumer-observable)
A send triggered inside the per-lead loop body carries the run's `audienceId` + workflow identity end-to-end, so a downstream consumer grouping send/engagement by `(audienceId, workflow)` sees non-null attribution for loop-body sends. Attribution originates at the send (no consumer heuristic).

## Tests
`DAG_WITH_CAMPAIGN_FOREACH` fixture + 5 assertions: iterator wrap attaches audienceId from start-run's result; loop-body nodes read `flow_input.iter.value?.__wf_audience_id`; no out-of-scope `results.start_run` ref inside the loop; inline descendants unchanged; no-op for non-campaign loops. Full suite green: 495 unit + 133 integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
