### PR TITLE
fix(boot): stop the background loops from pinning the Neon compute open

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,16 @@ Three pieces hold it together:
 
 Measured on 2026-07-31 against a database that never answers: pre-fix the port never opened and the process exited 1 at 30.3s; post-fix the port opened at 0.88s, `/health` answered 200 at 0.97s, gated routes returned 503, and the container stayed up retrying. On the real suspended staging compute the pre-fix bind cost 2.14s — i.e. pre-fix, time-to-port-open simply *is* the compute's resume time, whatever it happens to be that day.
 
+### No background loop may query the database unconditionally
+
+Scale-to-zero only pays off if the compute actually reaches its idle timeout (300s). **Any periodic loop that opens with a `SELECT` on a period shorter than that pins the compute open forever, and the whole billing period is charged as active even when nothing executed** — the setting looks enabled and saves nothing.
+
+- **`JobPoller`** (10s) **stops itself** once no run is `queued` or `running`, and `wakeJobPoller()` restarts it from `markExecutionDispatched` — the single place a run becomes pollable. The `wokenDuringPoll` flag is load-bearing: it is cleared *before* the query so a dispatch landing between the query and the idle check cannot be swallowed. If you add another path that makes a run pollable, it must call `wakeJobPoller()` or that run is never reconciled.
+- **`SpecWatcher`** runs hourly, not every 5 minutes. Do not lower it back below the idle timeout.
+- **`PeriodicCleanup`** (24h) is fine — it wakes the compute once a day.
+
+Before adding any `setInterval` that touches the database, ask what keeps it from holding the compute open. On-demand or wake-on-write beats a timer.
+
 **Failures inside `boot()` still exit the process** (API Registry unreachable, Windmill node deploy failure). Because the port is already bound, Railway grades the deploy SUCCESS first and only marks it CRASHED once `restartPolicyMaxRetries: 10` is exhausted — so when a staging/prod deploy looks green but the service is unreachable, read the container logs for a post-listen `process.exit(1)` rather than assuming the deploy is fine.
 
 ## Workflow naming and versioning

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { migrate } from "drizzle-orm/postgres-js/migrator";
 import { db } from "./db/index.js";
 import { workflowRuns } from "./db/schema.js";
 import { getWindmillClient } from "./lib/windmill-client.js";
-import { JobPoller } from "./lib/job-poller.js";
+import { JobPoller, setJobPoller } from "./lib/job-poller.js";
 import { PeriodicCleanup } from "./lib/periodic-cleanup.js";
 import { requireIdentity } from "./middleware/auth.js";
 import { checkApiRegistryHealth, validateAndUpgradeWorkflows } from "./lib/startup-validator.js";
@@ -117,7 +117,10 @@ async function boot(): Promise<void> {
       process.exit(1);
     }
 
+    // One poll at boot reconciles anything left running across a restart; the
+    // poller then idles itself until a run is dispatched.
     const poller = new JobPoller(db, windmillClient, workflowRuns);
+    setJobPoller(poller);
     poller.start();
 
     // Periodic cleanup: re-runs stale-deprecation + Windmill orphan-flow

--- a/src/lib/execution-admission.ts
+++ b/src/lib/execution-admission.ts
@@ -2,6 +2,7 @@ import { and, eq, inArray, lt, sql } from "drizzle-orm";
 import { workflowRuns, type Workflow, type WorkflowRun } from "../db/schema.js";
 import type { db as DbInstance } from "../db/index.js";
 import type { CampaignAttributionContext } from "./attribution-context.js";
+import { wakeJobPoller } from "./job-poller.js";
 
 type Database = typeof DbInstance;
 
@@ -139,6 +140,12 @@ export async function markExecutionDispatched(
     })
     .where(eq(workflowRuns.id, workflowRunId))
     .returning();
+
+  // This is the only place a run becomes pollable. The poller idles itself when
+  // nothing is queued or running (so an idle Neon compute can actually suspend),
+  // so it has to be woken here or the run is never reconciled.
+  wakeJobPoller();
+
   return updated;
 }
 

--- a/src/lib/job-poller.ts
+++ b/src/lib/job-poller.ts
@@ -6,9 +6,25 @@ import { attributionContextToHeaders } from "./attribution-context.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+/**
+ * Polls Windmill for the outcome of dispatched jobs.
+ *
+ * The poller **stops itself once no run is queued or running**, and is woken by
+ * `wakeJobPoller()` when a run is dispatched. An unconditional `SELECT` every
+ * 10s would hold the Neon compute open forever, which defeats scale-to-zero:
+ * the compute never reaches its idle timeout, so the whole billing period is
+ * charged as active even when nothing has executed.
+ */
 export class JobPoller {
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private isPolling = false;
+  /**
+   * Set by `wake()`. Cleared at the top of `poll()`, i.e. BEFORE the query, so
+   * a run dispatched while a poll is in flight always keeps the poller alive —
+   * without it, a wake landing between the query and the idle check would be
+   * swallowed and the run would never be reconciled.
+   */
+  private wokenDuringPoll = false;
 
   constructor(
     private db: any,
@@ -31,9 +47,23 @@ export class JobPoller {
     }
   }
 
+  isRunning(): boolean {
+    return this.intervalId !== null;
+  }
+
+  /** A run was just dispatched — there is work to reconcile. */
+  wake(): void {
+    this.wokenDuringPoll = true;
+    if (!this.intervalId) {
+      console.log("[workflow-service] JobPoller woken by a dispatched run");
+    }
+    this.start();
+  }
+
   private async poll(): Promise<void> {
     if (this.isPolling) return;
     this.isPolling = true;
+    this.wokenDuringPoll = false;
 
     try {
       const table = this.workflowRunsTable;
@@ -41,6 +71,14 @@ export class JobPoller {
         .select()
         .from(table)
         .where(inArray(table.status, ["queued", "running"]));
+
+      if (activeRuns.length === 0 && !this.wokenDuringPoll) {
+        console.log(
+          "[workflow-service] JobPoller: no queued or running runs — idling until the next dispatch",
+        );
+        this.stop();
+        return;
+      }
 
       for (const run of activeRuns) {
         if (!run.windmillJobId) continue;
@@ -112,4 +150,26 @@ export class JobPoller {
       this.isPolling = false;
     }
   }
+}
+
+/**
+ * The single poller owned by `boot()`. Null when Windmill is not configured —
+ * nothing is dispatched in that case, so there is nothing to wake.
+ */
+let sharedPoller: JobPoller | null = null;
+
+export function setJobPoller(poller: JobPoller | null): void {
+  sharedPoller = poller;
+}
+
+export function getJobPoller(): JobPoller | null {
+  return sharedPoller;
+}
+
+/**
+ * Called when a run is dispatched to Windmill. The poller idles itself once no
+ * run is outstanding, so this is what brings it back.
+ */
+export function wakeJobPoller(): void {
+  sharedPoller?.wake();
 }

--- a/src/lib/spec-watcher.ts
+++ b/src/lib/spec-watcher.ts
@@ -15,10 +15,15 @@ interface SpecWatcherDeps {
   windmillClient: WindmillClient | null;
 }
 
-const INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+// 1 hour. NOT tunable down without re-checking the Neon bill: every tick opens
+// with a `SELECT` over active workflows, so a period shorter than the compute's
+// idle timeout (300s) holds the compute open permanently and scale-to-zero
+// never engages. Spec drift does not need minute-level granularity — boot
+// already validates, and upgrades can be triggered on demand.
+const INTERVAL_MS = 60 * 60 * 1000;
 
 /**
- * Watches for OpenAPI spec changes every 5 minutes.
+ * Watches for OpenAPI spec changes once an hour.
  * The check itself is free (HTTP + CPU hash comparison).
  * Only triggers LLM-powered upgrades when specs actually changed
  * AND the change breaks an active workflow.
@@ -35,7 +40,7 @@ export class SpecWatcher {
 
   start(): void {
     if (this.timer) return;
-    console.log("[workflow-service] SpecWatcher started — checking every 5 minutes");
+    console.log("[workflow-service] SpecWatcher started — checking every 60 minutes");
     this.timer = setInterval(() => void this.check(), INTERVAL_MS);
   }
 
@@ -138,7 +143,7 @@ export class SpecWatcher {
       return;
     }
 
-    // LLM auto-upgrade DISABLED — was burning Gemini credits every 5 minutes.
+    // LLM auto-upgrade DISABLED — was burning Gemini credits on every tick.
     // Just log the issue; do NOT call validateAndUpgradeWorkflows which triggers LLM.
     console.warn(
       "[workflow-service] SpecWatcher: spec change broke workflow(s) — LLM upgrade disabled, skipping",

--- a/tests/unit/job-poller-idle.test.ts
+++ b/tests/unit/job-poller-idle.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col: unknown, val: unknown) => ({ col, val, op: "eq" })),
+  inArray: vi.fn((col: unknown, vals: unknown[]) => ({ col, vals, op: "inArray" })),
+}));
+
+vi.mock("../../src/db/index.js", () => ({
+  db: "mock-db",
+  sql: { end: () => Promise.resolve() },
+}));
+
+vi.mock("../../src/lib/runs-client.js", () => ({
+  closeRun: vi.fn(),
+}));
+
+import {
+  JobPoller,
+  setJobPoller,
+  getJobPoller,
+  wakeJobPoller,
+} from "../../src/lib/job-poller.js";
+
+/**
+ * The poller must not hold the Neon compute open when there is nothing to
+ * reconcile — an unconditional SELECT every 10s means the compute never reaches
+ * its idle timeout and scale-to-zero saves nothing.
+ */
+describe("JobPoller idles when there is no work", () => {
+  let selectCount: number;
+  let activeRuns: Array<Record<string, unknown>>;
+  let onQuery: (() => void) | null;
+
+  function createMockDb() {
+    return {
+      select: () => ({
+        from: () => ({
+          where: () => {
+            selectCount += 1;
+            onQuery?.();
+            return Promise.resolve(activeRuns);
+          },
+        }),
+      }),
+      update: () => ({
+        set: () => ({ where: () => Promise.resolve() }),
+      }),
+    };
+  }
+
+  const windmill = { getJob: vi.fn() } as never;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    selectCount = 0;
+    activeRuns = [];
+    onQuery = null;
+    setJobPoller(null);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    setJobPoller(null);
+  });
+
+  it("stops polling after a tick that finds no queued or running run", async () => {
+    const poller = new JobPoller(createMockDb(), windmill, {}, 10_000);
+    poller.start();
+    expect(poller.isRunning()).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(selectCount).toBe(1);
+    expect(poller.isRunning()).toBe(false);
+
+    // The compute is now free to suspend: no further queries, ever.
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(selectCount).toBe(1);
+  });
+
+  it("keeps polling while runs are outstanding", async () => {
+    activeRuns = [{ id: "r1", status: "running", windmillJobId: null }];
+    const poller = new JobPoller(createMockDb(), windmill, {}, 10_000);
+    poller.start();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(selectCount).toBe(3);
+    expect(poller.isRunning()).toBe(true);
+  });
+
+  it("wake() restarts an idled poller", async () => {
+    const poller = new JobPoller(createMockDb(), windmill, {}, 10_000);
+    poller.start();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(poller.isRunning()).toBe(false);
+
+    activeRuns = [{ id: "r1", status: "queued", windmillJobId: null }];
+    poller.wake();
+    expect(poller.isRunning()).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(selectCount).toBe(2);
+    expect(poller.isRunning()).toBe(true);
+  });
+
+  it("does not swallow a wake that lands mid-poll", async () => {
+    const poller = new JobPoller(createMockDb(), windmill, {}, 10_000);
+    poller.start();
+
+    // A run is dispatched after the SELECT has already returned empty. Without
+    // the woken-during-poll guard the poller would idle and never reconcile it.
+    onQuery = () => {
+      activeRuns = [{ id: "r1", status: "queued", windmillJobId: null }];
+      poller.wake();
+    };
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(poller.isRunning()).toBe(true);
+  });
+
+  it("wake() is idempotent while already polling", () => {
+    const poller = new JobPoller(createMockDb(), windmill, {}, 10_000);
+    poller.start();
+    poller.wake();
+    poller.wake();
+    expect(poller.isRunning()).toBe(true);
+  });
+});
+
+describe("shared poller handle", () => {
+  beforeEach(() => setJobPoller(null));
+  afterEach(() => setJobPoller(null));
+
+  it("wakeJobPoller() is a no-op when Windmill is not configured", () => {
+    expect(getJobPoller()).toBeNull();
+    expect(() => wakeJobPoller()).not.toThrow();
+  });
+
+  it("wakeJobPoller() wakes the registered poller", () => {
+    const wake = vi.fn();
+    setJobPoller({ wake } as unknown as JobPoller);
+
+    wakeJobPoller();
+
+    expect(wake).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Prerequisite for enabling scale-to-zero on the production compute (`ep-still-mud-a1319tcx`, currently `suspend_timeout_seconds: -1`, ~182 CU-hours per billing period in pure idle — the motivation stated in #349).

## Why this is needed before flipping the setting

Flipping scale-to-zero today would have saved **nothing**. Two background loops query the database on a period shorter than the 300s idle timeout, so the compute never suspends and the whole billing period bills as active — the setting reads as enabled and the bill does not move.

| loop | period | opens with |
|---|---|---|
| `JobPoller` | **10s** | `SELECT ... WHERE status IN ('queued','running')`, unconditional |
| `SpecWatcher` | **5 min** | `SELECT ... WHERE status='active'`, before the spec-hash comparison |
| `PeriodicCleanup` | 24h | fine — one wake a day is not a pin |

## Change

- **`JobPoller` stops itself** when that query returns nothing, and `wakeJobPoller()` restarts it from `markExecutionDispatched` — the single place in the codebase where a run becomes pollable. Boot still starts it once, so a restart reconciles anything left running, and then it idles.

  The `wokenDuringPoll` flag is load-bearing and cleared **before** the query: a run dispatched while a poll is in flight keeps the poller alive. Without it, a wake landing between the query and the idle check would be swallowed and that run would never be reconciled. There is a test for exactly that interleaving.

- **`SpecWatcher` moves to hourly.** Spec drift does not need minute-level granularity — boot already validates, upgrades are on demand, and its LLM auto-upgrade is already disabled.

- `CLAUDE.md` gains the invariant so the next `setInterval` does not silently re-pin the compute.

No behaviour change for callers: a dispatched run is polled exactly as before. The only difference is that the poller sleeps between campaigns.

## Tests

671 pass (54 files). New `tests/unit/job-poller-idle.test.ts` covers: idles after an empty tick and issues **no** further queries; keeps polling while runs are outstanding; `wake()` restarts an idled poller; a wake landing mid-poll is not swallowed; `wakeJobPoller()` is a safe no-op when Windmill is unconfigured.