### PR TITLE
fix(startup): recreate a Windmill flow the boot sync finds missing

### DIFF
--- a/src/lib/startup-validator.ts
+++ b/src/lib/startup-validator.ts
@@ -202,7 +202,7 @@ export async function validateAndUpgradeWorkflows(
   }
 }
 
-async function syncFlowToWindmill(
+export async function syncFlowToWindmill(
   wf: Workflow,
   windmillClient: WindmillClient,
 ): Promise<void> {
@@ -212,12 +212,27 @@ async function syncFlowToWindmill(
 
   const dag = wf.dag as DAG;
   const openFlow = dagToOpenFlow(dag, wf.workflowSlug);
-
-  await windmillClient.updateFlow(wf.windmillFlowPath, {
+  const body = {
     summary: wf.workflowSlug,
     description: wf.description ?? "",
     value: openFlow.value,
     schema: openFlow.schema,
-  });
+  };
+
+  try {
+    await windmillClient.updateFlow(wf.windmillFlowPath, body);
+  } catch (err) {
+    // The row says a flow lives at this path and Windmill disagrees. Update
+    // alone can never recover from that: the workflow stays active, every
+    // execute 404s on the missing flow, and the next boot fails the same way.
+    // Recreating at the recorded path is what the row already asserts should
+    // exist, and is a no-op wherever the flow is present.
+    if (!(err instanceof Error) || !err.message.includes("404")) throw err;
+
+    console.warn(
+      `[workflow-service] Flow missing in Windmill for "${wf.workflowSlug}" at ${wf.windmillFlowPath} — recreating`,
+    );
+    await windmillClient.createFlow({ path: wf.windmillFlowPath, ...body });
+  }
 }
 

--- a/tests/unit/sync-flow-recreate.test.ts
+++ b/tests/unit/sync-flow-recreate.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { syncFlowToWindmill } from "../../src/lib/startup-validator.js";
+import { VALID_LINEAR_DAG } from "../helpers/fixtures.js";
+import type { Workflow } from "../../src/db/schema.js";
+import type { WindmillClient } from "../../src/lib/windmill-client.js";
+
+function makeWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    id: "wf-1",
+    workflowSlug: "sales-cold-email-outreach-wisteria",
+    description: "a workflow",
+    dag: VALID_LINEAR_DAG,
+    windmillFlowPath: "f/workflows/org-1/sales_cold_email_outreach_wisteria",
+    ...overrides,
+  } as unknown as Workflow;
+}
+
+function makeClient(updateImpl: () => Promise<void>) {
+  const updateFlow = vi.fn(updateImpl);
+  const createFlow = vi.fn(async () => "path");
+  return {
+    client: { updateFlow, createFlow } as unknown as WindmillClient,
+    updateFlow,
+    createFlow,
+  };
+}
+
+describe("syncFlowToWindmill", () => {
+  it("updates the flow when it already exists", async () => {
+    const { client, updateFlow, createFlow } = makeClient(async () => {});
+
+    await syncFlowToWindmill(makeWorkflow(), client);
+
+    expect(updateFlow).toHaveBeenCalledTimes(1);
+    expect(createFlow).not.toHaveBeenCalled();
+  });
+
+  it("recreates the flow at the recorded path when Windmill 404s", async () => {
+    const { client, updateFlow, createFlow } = makeClient(async () => {
+      throw new Error(
+        "Windmill API error: POST /flows/update/f/workflows/org-1/x → 404 Not Found: Not found: Flow not found",
+      );
+    });
+
+    await syncFlowToWindmill(makeWorkflow(), client);
+
+    expect(updateFlow).toHaveBeenCalledTimes(1);
+    expect(createFlow).toHaveBeenCalledTimes(1);
+    const arg = createFlow.mock.calls[0][0] as unknown as { path: string; summary: string };
+    expect(arg.path).toBe("f/workflows/org-1/sales_cold_email_outreach_wisteria");
+    expect(arg.summary).toBe("sales-cold-email-outreach-wisteria");
+  });
+
+  it("does not swallow a non-404 failure", async () => {
+    const { client, createFlow } = makeClient(async () => {
+      throw new Error("Windmill API error: POST /flows/update/... → 500 Internal Server Error");
+    });
+
+    await expect(syncFlowToWindmill(makeWorkflow(), client)).rejects.toThrow("500");
+    expect(createFlow).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op for a workflow with no flow path", async () => {
+    const { client, updateFlow, createFlow } = makeClient(async () => {});
+
+    await syncFlowToWindmill(makeWorkflow({ windmillFlowPath: null }), client);
+
+    expect(updateFlow).not.toHaveBeenCalled();
+    expect(createFlow).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Surfaced while fixing #353.

## Problem

`syncFlowToWindmill` only ever called `updateFlow`. When a workflow row records a `windmillFlowPath` but Windmill has no flow there, the update 404s, the caller logs a warning and moves on — and **nothing ever repairs it**. The workflow stays active, every execute 404s on the missing flow, and the next boot fails identically:

```
[workflow-service] Failed to sync flow for "sales-cold-email-outreach-wisteria":
  POST /flows/update/f/workflows/<org>/sales_cold_email_outreach_wisteria
  → 404 Not Found: Flow not found

[workflow-service] Failed to run flow in Windmill (not-dispatched):
  POST /jobs/run/f/f/workflows/<org>/sales_cold_email_outreach_legato_v4
  → 404 Not Found: flow not found
```

A sync that can only update is half a sync. There is no path back to a working state short of recreating every workflow by hand.

## Change

On a 404, recreate the flow at the path the row already asserts should exist. It is a no-op wherever the flow is present, so production is unaffected. A non-404 failure still propagates — a Windmill 500 is not something to paper over by blindly creating.

## How it showed up

Staging's Windmill instance had never been provisioned (see #348): its workspace contained no flows at all, so every active workflow hit this. Once the API Registry key landed (#353) the boot sync finally ran, and this is what it found.

Production is not in this state — its flows exist — so this is a resilience fix there, not a bug fix.

## Tests

675 pass (55 files). New `tests/unit/sync-flow-recreate.test.ts`: updates when the flow exists; recreates at the recorded path on 404 (asserting path and summary); rethrows a non-404; no-op when the row has no flow path.