### PR TITLE
fix(job-poller): terminate runs whose Windmill job is permanently unresolvable

### DIFF
--- a/src/lib/job-poller.ts
+++ b/src/lib/job-poller.ts
@@ -1,5 +1,5 @@
 import { eq, inArray } from "drizzle-orm";
-import type { WindmillClient } from "./windmill-client.js";
+import { isUnresolvableWindmillJobError, type WindmillClient } from "./windmill-client.js";
 import { closeRun } from "./runs-client.js";
 import { traceEvent } from "./trace-event.js";
 import { attributionContextToHeaders } from "./attribution-context.js";
@@ -15,6 +15,14 @@ import { attributionContextToHeaders } from "./attribution-context.js";
  * the compute never reaches its idle timeout, so the whole billing period is
  * charged as active even when nothing has executed.
  */
+/**
+ * How many CONSECUTIVE polls must see the same permanently-unresolvable answer
+ * from Windmill before the run is failed. One is enough to be right and not
+ * enough to be safe: the counter is what keeps a freak 404 during a Windmill
+ * restart from killing a live run.
+ */
+export const UNRESOLVABLE_JOB_POLL_ATTEMPTS = 3;
+
 export class JobPoller {
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private isPolling = false;
@@ -25,6 +33,15 @@ export class JobPoller {
    * swallowed and the run would never be reconciled.
    */
   private wokenDuringPoll = false;
+
+  /**
+   * Consecutive polls, per run, that got a permanently-unresolvable answer for
+   * the run's Windmill job. Reset by any poll that resolves the job or fails
+   * transiently, so only an uninterrupted streak terminates a run. In-memory on
+   * purpose: a restart simply re-observes the streak within ~30s, and there is
+   * nothing worth persisting about a counter that only ever counts to three.
+   */
+  private unresolvablePolls = new Map<string, number>();
 
   constructor(
     private db: any,
@@ -58,6 +75,74 @@ export class JobPoller {
       console.log("[workflow-service] JobPoller woken by a dispatched run");
     }
     this.start();
+  }
+
+  /**
+   * Terminate a run whose Windmill job Windmill itself can no longer resolve.
+   *
+   * A run left `queued` holds its `execution_key`, and `conflict_policy:
+   * "use_existing"` then dedups every later execute for that campaign onto the
+   * zombie — so one dead job silently disables a whole campaign forever. The
+   * run is failed (never `completed`: it did not complete) and the error says
+   * exactly what happened, which is what frees the key.
+   */
+  private async failUnresolvableRun(run: any, err: unknown): Promise<void> {
+    const table = this.workflowRunsTable;
+    const detail = err instanceof Error ? err.message : String(err);
+    const message =
+      `Windmill job ${run.windmillJobId} became unresolvable and will never report an outcome ` +
+      `(most often because the workflow was upgraded while the job was in flight, deleting the flow ` +
+      `nodes it referenced). Failing the run after ${UNRESOLVABLE_JOB_POLL_ATTEMPTS} consecutive ` +
+      `unresolvable polls so it stops holding its execution key. Windmill said: ${detail}`;
+
+    console.error(`[workflow-service] JobPoller: FAILING run ${run.id} — ${message}`);
+
+    try {
+      await this.db
+        .update(table)
+        .set({ status: "failed", result: null, error: message, completedAt: new Date() })
+        .where(eq(table.id, run.id));
+    } catch (updateErr) {
+      console.error(
+        `[workflow-service] JobPoller: failed to mark run ${run.id} as failed:`,
+        updateErr,
+      );
+      return;
+    }
+
+    if (run.runId && run.orgId) {
+      try {
+        await closeRun(run.runId, "failed", run.orgId);
+      } catch (closeErr) {
+        console.error(
+          `[workflow-service] JobPoller: failed to close run ${run.runId} in runs-service:`,
+          closeErr,
+        );
+      }
+    }
+
+    if (run.runId) {
+      const pollerHeaders: Record<string, string> = {};
+      if (run.orgId) pollerHeaders["x-org-id"] = run.orgId;
+      if (run.userId) pollerHeaders["x-user-id"] = run.userId;
+      if (run.workflowSlug) pollerHeaders["x-workflow-slug"] = run.workflowSlug;
+      if (run.featureSlug) pollerHeaders["x-feature-slug"] = run.featureSlug;
+      if (run.campaignId) pollerHeaders["x-campaign-id"] = run.campaignId;
+      Object.assign(pollerHeaders, attributionContextToHeaders(run.attributionContext));
+
+      traceEvent(run.runId, {
+        service: "workflow-service",
+        event: "job-unresolvable",
+        detail: message,
+        level: "error",
+        data: {
+          windmillJobId: run.windmillJobId,
+          workflowSlug: run.workflowSlug,
+          status: "failed",
+          reason: "windmill-job-unresolvable",
+        },
+      }, pollerHeaders).catch(() => {});
+    }
   }
 
   private async poll(): Promise<void> {
@@ -137,11 +222,35 @@ export class JobPoller {
               })
               .where(eq(table.id, run.id));
           }
+          this.unresolvablePolls.delete(run.id);
         } catch (err) {
-          console.error(
-            `[workflow-service] Error polling job ${run.windmillJobId}:`,
-            err
-          );
+          if (isUnresolvableWindmillJobError(err)) {
+            const seen = (this.unresolvablePolls.get(run.id) ?? 0) + 1;
+            this.unresolvablePolls.set(run.id, seen);
+            console.error(
+              `[workflow-service] JobPoller: Windmill cannot resolve job ${run.windmillJobId} for run ${run.id} (${seen}/${UNRESOLVABLE_JOB_POLL_ATTEMPTS}):`,
+              err,
+            );
+            if (seen >= UNRESOLVABLE_JOB_POLL_ATTEMPTS) {
+              this.unresolvablePolls.delete(run.id);
+              await this.failUnresolvableRun(run, err);
+            }
+          } else {
+            this.unresolvablePolls.delete(run.id);
+            console.error(
+              `[workflow-service] Error polling job ${run.windmillJobId}:`,
+              err
+            );
+          }
+        }
+      }
+
+      // Drop counters for runs that are no longer active, so the map cannot
+      // grow with ids nothing will ever poll again.
+      if (this.unresolvablePolls.size > 0) {
+        const activeIds = new Set(activeRuns.map((r: any) => r.id));
+        for (const id of [...this.unresolvablePolls.keys()]) {
+          if (!activeIds.has(id)) this.unresolvablePolls.delete(id);
         }
       }
     } catch (err) {

--- a/src/lib/windmill-client.ts
+++ b/src/lib/windmill-client.ts
@@ -83,6 +83,47 @@ export function isAmbiguousWindmillDispatchError(err: unknown): boolean {
   return err instanceof WindmillTransportError && err.dispatchAmbiguous;
 }
 
+/**
+ * A non-2xx answer from the Windmill REST API. Subclasses `Error` and keeps the
+ * exact same `message` shape the plain `Error` used to carry, so existing
+ * `message.includes("404")` callers keep working — the added fields exist so a
+ * caller can classify without parsing prose.
+ */
+export class WindmillApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly method: string,
+    public readonly path: string,
+    public readonly body: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "WindmillApiError";
+  }
+}
+
+/**
+ * True when Windmill can never resolve this job, no matter how long we wait.
+ *
+ * Two shapes, both permanent:
+ *  - 404: the job id is unknown to Windmill (retention purge, wrong workspace).
+ *  - 5xx whose body says something was "not found": a job whose flow definition
+ *    was mutated underneath it. A workflow VERSION UPGRADE deletes the flow
+ *    nodes an in-flight job still references, and Windmill then answers
+ *    `500 Internal: windmill-common/src/cache.rs: Flow node not found` for that
+ *    job forever. Retrying it is retrying a corpse.
+ *
+ * Everything else (connect timeouts, socket resets, a plain 502/503 while
+ * Windmill restarts, a 5xx with no "not found" in it) is transient and must
+ * keep being retried.
+ */
+export function isUnresolvableWindmillJobError(err: unknown): boolean {
+  if (!(err instanceof WindmillApiError)) return false;
+  if (err.status === 404) return true;
+  if (err.status >= 500 && /not found/i.test(err.body)) return true;
+  return false;
+}
+
 export class WindmillClient {
   private baseUrl: string;
   private token: string;
@@ -127,7 +168,11 @@ export class WindmillClient {
 
       if (!res.ok) {
         const text = await res.text().catch(() => "");
-        throw new Error(
+        throw new WindmillApiError(
+          res.status,
+          method,
+          path,
+          text,
           `Windmill API error: ${method} ${path} → ${res.status} ${res.statusText}: ${text}`
         );
       }

--- a/tests/unit/job-poller-unresolvable.test.ts
+++ b/tests/unit/job-poller-unresolvable.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col: unknown, val: unknown) => ({ col, val, op: "eq" })),
+  inArray: vi.fn((col: unknown, vals: unknown[]) => ({ col, vals, op: "inArray" })),
+}));
+
+vi.mock("../../src/db/index.js", () => ({
+  db: "mock-db",
+  sql: { end: () => Promise.resolve() },
+}));
+
+const mockCloseRun = vi.fn();
+vi.mock("../../src/lib/runs-client.js", () => ({
+  closeRun: (...args: unknown[]) => mockCloseRun(...args),
+}));
+
+const mockTraceEvent = vi.fn(() => Promise.resolve());
+vi.mock("../../src/lib/trace-event.js", () => ({
+  traceEvent: (...args: unknown[]) => mockTraceEvent(...args),
+}));
+
+import { JobPoller, UNRESOLVABLE_JOB_POLL_ATTEMPTS } from "../../src/lib/job-poller.js";
+import { WindmillApiError, isUnresolvableWindmillJobError } from "../../src/lib/windmill-client.js";
+
+/**
+ * The production incident this guards: a workflow was upgraded while one of its
+ * jobs was in flight, so Windmill lost the flow node the job referenced and
+ * answered 500 "Flow node not found" for it forever. The poller only logged, so
+ * the run stayed `queued`, kept holding its `execution_key`, and every later
+ * execute for that campaign deduped onto it — the campaign could never run again.
+ */
+describe("JobPoller: permanently unresolvable Windmill jobs", () => {
+  let dbSetCalls: Array<Record<string, unknown>>;
+
+  function createMockDb(runs: Array<Record<string, unknown>>) {
+    dbSetCalls = [];
+    return {
+      select: () => ({ from: () => ({ where: () => Promise.resolve(runs) }) }),
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          dbSetCalls.push(values);
+          return { where: () => Promise.resolve() };
+        },
+      }),
+    };
+  }
+
+  const mockTable = { status: "status", id: "id" };
+
+  const flowNodeNotFound = () =>
+    new WindmillApiError(
+      500,
+      "GET",
+      "/jobs_u/get/01a07173-1d45-d932-d980-5de3073e26e1",
+      "Internal: windmill-common/src/cache.rs: Flow node not found",
+      'Windmill API error: GET /jobs_u/get/01a07173 → 500 Internal Server Error: Internal: windmill-common/src/cache.rs: Flow node not found',
+    );
+
+  beforeEach(() => {
+    mockCloseRun.mockReset();
+    mockCloseRun.mockResolvedValue(undefined);
+    mockTraceEvent.mockClear();
+  });
+
+  it("classifies the incident's error as unresolvable, and a plain 5xx as transient", () => {
+    expect(isUnresolvableWindmillJobError(flowNodeNotFound())).toBe(true);
+    expect(
+      isUnresolvableWindmillJobError(
+        new WindmillApiError(404, "GET", "/jobs_u/get/x", "Not found: job", "404"),
+      ),
+    ).toBe(true);
+    expect(
+      isUnresolvableWindmillJobError(
+        new WindmillApiError(502, "GET", "/jobs_u/get/x", "Bad Gateway", "502"),
+      ),
+    ).toBe(false);
+    expect(isUnresolvableWindmillJobError(new Error("fetch failed"))).toBe(false);
+  });
+
+  it("does not fail the run on the first unresolvable poll", async () => {
+    const runs = [{ id: "run-1", windmillJobId: "job-1", status: "queued", runId: "r1", orgId: "org-1" }];
+    const mockDb = createMockDb(runs);
+    const client = { getJob: vi.fn().mockRejectedValue(flowNodeNotFound()) } as any;
+    const poller = new JobPoller(mockDb, client, mockTable, 60_000);
+    const poll = (poller as any).poll.bind(poller);
+
+    await poll();
+
+    expect(dbSetCalls.length).toBe(0);
+    expect(mockCloseRun).not.toHaveBeenCalled();
+  });
+
+  it("fails the run after consecutive unresolvable polls so it releases its execution key", async () => {
+    const runs = [{
+      id: "6944ae0a-8a8a-419f-b807-bc52e54c0736",
+      windmillJobId: "01a07173-1d45-d932-d980-5de3073e26e1",
+      status: "queued",
+      runId: "runs-svc-1",
+      orgId: "org-1",
+      workflowSlug: "ai-meeting-booking-rhodium",
+      executionKey: "campaign:abc",
+      conflictPolicy: "use_existing",
+    }];
+    const mockDb = createMockDb(runs);
+    const client = { getJob: vi.fn().mockRejectedValue(flowNodeNotFound()) } as any;
+    const poller = new JobPoller(mockDb, client, mockTable, 60_000);
+    const poll = (poller as any).poll.bind(poller);
+
+    for (let i = 0; i < UNRESOLVABLE_JOB_POLL_ATTEMPTS; i++) await poll();
+
+    expect(dbSetCalls.length).toBe(1);
+    expect(dbSetCalls[0].status).toBe("failed");
+    expect(dbSetCalls[0].completedAt).toBeInstanceOf(Date);
+    expect(String(dbSetCalls[0].error)).toContain("unresolvable");
+    expect(String(dbSetCalls[0].error)).toContain("Flow node not found");
+    expect(mockCloseRun).toHaveBeenCalledWith("runs-svc-1", "failed", "org-1");
+    expect(mockTraceEvent).toHaveBeenCalledWith(
+      "runs-svc-1",
+      expect.objectContaining({ event: "job-unresolvable", level: "error" }),
+      expect.any(Object),
+    );
+  });
+
+  it("never marks an unresolvable run completed", async () => {
+    const runs = [{ id: "run-2", windmillJobId: "job-2", status: "running", runId: "r2", orgId: "org-1" }];
+    const mockDb = createMockDb(runs);
+    const client = { getJob: vi.fn().mockRejectedValue(flowNodeNotFound()) } as any;
+    const poller = new JobPoller(mockDb, client, mockTable, 60_000);
+    const poll = (poller as any).poll.bind(poller);
+
+    for (let i = 0; i < UNRESOLVABLE_JOB_POLL_ATTEMPTS + 2; i++) await poll();
+
+    for (const call of dbSetCalls) expect(call.status).not.toBe("completed");
+    expect(mockCloseRun).not.toHaveBeenCalledWith(expect.anything(), "completed", expect.anything());
+  });
+
+  it("keeps retrying a transient failure and still recovers when it clears", async () => {
+    const runs = [{ id: "run-3", windmillJobId: "job-3", status: "running", runId: "r3", orgId: "org-1" }];
+    const mockDb = createMockDb(runs);
+    const getJob = vi.fn()
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockRejectedValueOnce(new WindmillApiError(503, "GET", "/jobs_u/get/job-3", "Service Unavailable", "503"))
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValue({ running: false, success: true, result: { ok: true } });
+    const poller = new JobPoller(mockDb, { getJob } as any, mockTable, 60_000);
+    const poll = (poller as any).poll.bind(poller);
+
+    for (let i = 0; i < 4; i++) await poll();
+
+    expect(dbSetCalls.length).toBe(1);
+    expect(dbSetCalls[0].status).toBe("completed");
+    expect(mockCloseRun).toHaveBeenCalledWith("r3", "completed", "org-1");
+  });
+
+  it("resets the streak when a transient failure interrupts unresolvable polls", async () => {
+    const runs = [{ id: "run-4", windmillJobId: "job-4", status: "running", runId: "r4", orgId: "org-1" }];
+    const mockDb = createMockDb(runs);
+    const getJob = vi.fn()
+      .mockRejectedValueOnce(flowNodeNotFound())
+      .mockRejectedValueOnce(flowNodeNotFound())
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockRejectedValueOnce(flowNodeNotFound())
+      .mockRejectedValueOnce(flowNodeNotFound());
+    const poller = new JobPoller(mockDb, { getJob } as any, mockTable, 60_000);
+    const poll = (poller as any).poll.bind(poller);
+
+    for (let i = 0; i < 5; i++) await poll();
+
+    expect(dbSetCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Production incident

A run dispatched at 12:02:44 UTC was in flight when a deploy shipped a new version of its workflow. Windmill lost the flow node the job referenced and has answered `500 Internal: windmill-common/src/cache.rs: Flow node not found` for it ever since.

`JobPoller.poll` only logged that error, so the run stayed `queued` forever, kept holding its `execution_key`, and `conflict_policy: "use_existing"` deduped every subsequent execute for that campaign onto the zombie. campaign-service re-fired, no run row was ever created, and it re-claimed the campaign as stuck every 15 minutes. One dead job disables its whole campaign, permanently.

Stuck row: `6944ae0a-8a8a-419f-b807-bc52e54c0736`, job `01a07173-1d45-d932-d980-5de3073e26e1`, `ai-meeting-booking-rhodium`.

## Fix

- `WindmillApiError` (`src/lib/windmill-client.ts`) carries the status and body alongside the same `message` string the plain `Error` used to have, so existing `message.includes("404")` callers are untouched.
- `isUnresolvableWindmillJobError` treats a **404** or a **5xx whose body says "not found"** as permanent. Connect timeouts, socket resets and a plain 502/503 while Windmill restarts stay transient.
- The poller counts **consecutive** permanent answers per run and fails the run at 3 (~30s at the 10s interval). Any resolved or transient poll resets the streak, so a blip cannot kill a live run.
- The run is marked `failed` — never `completed`, it did not complete — with an error naming the job and quoting Windmill, closed `failed` in runs-service, and a `job-unresolvable` trace event is emitted at `error`. `failed` is outside the `execution_key` partial unique index, so the key is released and the campaign can dispatch again.

The `use_existing` policy is unchanged; only the zombie holding the key is.

## Tests

`tests/unit/job-poller-unresolvable.test.ts` — classification, no-fail-on-first-error, termination after the streak (asserting the real row's shape), never-completed, transient retry-and-recover, streak reset on an interrupting transient. Full suite: 797 passing.

## Deploy

Hotfix, prod-direct. The stuck row clears on its own within ~30s of the container coming up — no manual database write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)